### PR TITLE
support lz4 compression if it is available

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -26,6 +26,12 @@ else:
             return ''
         return snappy.decompress(byts)
     locally_supported_compressions['snappy'] = (snappy.compress, decompress)
+try:
+    import lz4
+except ImportError:
+    pass
+else:
+    locally_supported_compressions['lz4'] = (lz4.compress, lz4.decompress)
 
 
 MAX_STREAM_PER_CONNECTION = 128


### PR DESCRIPTION
Use https://github.com/steeve/python-lz4 to provide lz4 compression support.
I couldn't verify that OptionsMessage() will actually return 'lz4' as a supported COMPRESSION option...

UPDATE: should have checked the source more closely, lz4 is not currently supported as a native client protocol compression option, so this fix will need: https://issues.apache.org/jira/browse/CASSANDRA-5765 in order to be usable.
