### PR TITLE
import from concurrent.futures rather than futures to prevent annoying warning

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3,7 +3,7 @@ This module houses the main classes you will interact with,
 :class:`.Cluster` and :class:`.Session`.
 """
 
-from futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 import logging
 import time
 from threading import RLock, Thread, Event

--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -2,7 +2,7 @@ import unittest
 
 from mock import Mock, ANY
 
-from futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 from cassandra.decoder import ResultMessage
 from cassandra.cluster import ControlConnection, Cluster, _Scheduler


### PR DESCRIPTION
This should prevent the annoying:

``` python
site-packages/futures-2.1.3-py2.6.egg/futures/__init__.py:24: DeprecationWarning: The futures package has been deprecated. Use the concurrent.futures package instead.
  DeprecationWarning)
```

message that gets printed out on every use
