### PR TITLE
Stop asyncore loop from complaining about a bad socket

### DIFF
--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -26,7 +26,7 @@ def _run_loop():
         try:
             asyncore.loop(timeout=0.001, use_poll=True, count=None)
         except Exception:
-            pass
+            log.debug("Asyncore event loop stopped unexepectedly", exc_info=True)
         _loop_started = False
         if log:
             # this can happen during interpreter shutdown


### PR DESCRIPTION
Stops:

```
Exception in thread event_loop:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 552, in __bootstrap_inner
    self.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 505, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/Users/matt/Dropbox/python-driver/cassandra/io/asyncorereactor.py", line 27, in _run_loop
    asyncore.loop(timeout=0.001, use_poll=True, count=None)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/asyncore.py", line 214, in loop
    poll_fun(timeout, map)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/asyncore.py", line 144, in poll
    r, w, e = select.select(r, w, e, timeout)
error: (9, 'Bad file descriptor')
```
