### PR TITLE
add the include path where ev.h is installed by libev-devel on Centos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,8 +133,10 @@ libev_support = Feature(
     "Libev event loop support",
     standard=True,
     ext_modules=[Extension('cassandra.io.libevwrapper',
-                           libraries=['ev'],
-                           sources=['cassandra/io/libevwrapper.c'])])
+                           sources=['cassandra/io/libevwrapper.c'],
+                           include_dirs=['/usr/include/libev'],
+                           libraries=['ev']
+                           )])
 
 features = {
     "murmur3": murmur3_ext,


### PR DESCRIPTION
The README should probably also be updated with the yum install instructions:
sudo yum install libev libev-devel

The yum install places the header files needed by the new libev wrapper in /usr/include/libev (instead of just /usr/include as done by some other package systems):

repoquery -lq libev-devel
/usr/include/libev
/usr/include/libev/ev++.h
/usr/include/libev/ev.h
/usr/include/libev/event.h
/usr/lib/libev.so
/usr/lib/pkgconfig/libev.pc
/usr/include/libev
/usr/include/libev/ev++.h
/usr/include/libev/ev.h
/usr/include/libev/event.h
/usr/lib64/libev.so
/usr/lib64/pkgconfig/libev.pc

This pull request just adds this as an include path so the build will include the libev wrapper on systems with yum as a package manager (e.g. Centos)
