### PR TITLE
Needs a MANIFEST.in file so it can actually install from pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include setup.py README.rst MANIFEST.in LICENSE distribute_setup.py
+global-exclude *~


### PR DESCRIPTION
Without this, distribute_setup.py doesn't get packaged up in the sdist tarball, so installing from pypi fails.

```
  Running setup.py egg_info for package cassandra-driver

    Traceback (most recent call last):

      File "<string>", line 16, in <module>

      File "/Users/matt/.virtualenvs/disqus/build/cassandra-driver/setup.py", line 11, in <module>

        from distribute_setup import use_setuptools

    ImportError: No module named distribute_setup

    Complete output from command python setup.py egg_info:

    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/Users/matt/.virtualenvs/disqus/build/cassandra-driver/setup.py", line 11, in <module>

    from distribute_setup import use_setuptools

ImportError: No module named distribute_setup

----------------------------------------

Command python setup.py egg_info failed with error code 1 in /Users/matt/.virtualenvs/disqus/build/cassandra-driver

Exception information:
Traceback (most recent call last):
  File "/Users/matt/.virtualenvs/disqus/lib/python2.7/site-packages/pip-1.2-py2.7.egg/pip/basecommand.py", line 106, in main
    status = self.run(options, args)
  File "/Users/matt/.virtualenvs/disqus/lib/python2.7/site-packages/pip-1.2-py2.7.egg/pip/commands/install.py", line 256, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/Users/matt/.virtualenvs/disqus/lib/python2.7/site-packages/pip-1.2-py2.7.egg/pip/req.py", line 1042, in prepare_files
    req_to_install.run_egg_info()
  File "/Users/matt/.virtualenvs/disqus/lib/python2.7/site-packages/pip-1.2-py2.7.egg/pip/req.py", line 236, in run_egg_info
    command_desc='python setup.py egg_info')
  File "/Users/matt/.virtualenvs/disqus/lib/python2.7/site-packages/pip-1.2-py2.7.egg/pip/util.py", line 612, in call_subprocess
    % (command_desc, proc.returncode, cwd))
InstallationError: Command python setup.py egg_info failed with error code 1 in /Users/matt/.virtualenvs/disqus/build/cassandra-driver
```
