### PR TITLE
Add tox and Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.swo
 *.so
 *.egg-info
+.tox
 build
 MANIFEST
 dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python: 2.7
+env:
+  - TOX_ENV=py26
+  - TOX_ENV=py27
+  - TOX_ENV=pypy
+
+before_install:
+  - sudo apt-get update -y
+  - sudo apt-get install -y build-essential python-dev
+  - sudo apt-get install -y libev4 libev-dev
+install:
+  - pip install tox
+
+script:
+  - tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py26,py27,pypy
+
+[testenv]
+deps = nose
+       mock
+       ccm
+commands = {envpython} setup.py build_ext --inplace
+           nosetests tests/unit/


### PR DESCRIPTION
This pull requests adds tox (http://tox.readthedocs.org/en/latest/) and TravisCI config.

Tox is a Python library which makes running tasks such as tests under different Python versions easier. Travis CI config just runs (atm) unit tests on every commit.

Ideally this pull request would get merged and TravisCI hook enabled for this repository.

Running tests under Python 2.6 also discovered a couple of issue which I will fix in a separate pull request.
