### PR TITLE
missing connection check before returning it

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1402,7 +1402,7 @@ class ResponseFuture(object):
 
     def _set_result(self, response):
         try:
-            if self._current_pool:
+            if self._current_pool and self._connection:
                 self._current_pool.return_connection(self._connection)
 
             trace_id = getattr(response, 'trace_id', None)


### PR DESCRIPTION
checking if the connection still exists solved lots of random AttributeError exceptions 'NoneType' object has no attribute 'lock'

looking few lines up seems like this check is necessary
