### PR TITLE
Fix dict iteration in CredentialsMessage::send_body

### DIFF
--- a/cassandra/decoder.py
+++ b/cassandra/decoder.py
@@ -383,7 +383,7 @@ class CredentialsMessage(_MessageType):
 
     def send_body(self, f):
         write_short(f, len(self.creds))
-        for credkey, credval in self.creds:
+        for credkey, credval in self.creds.items():
             write_string(f, credkey)
             write_string(f, credval)
 


### PR DESCRIPTION
I know Authentication is TBD according to the README. After seeing the message already implemented, we decided to try it out. This diff is a small tweak we made to get auth working here.
