### PR TITLE
Allow user to specify consistency level with prepared statements

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -681,7 +681,7 @@ class Session(object):
         future.send_request()
         return future
 
-    def prepare(self, query):
+    def prepare(self, query, consistency_level=ConsistencyLevel.ONE):
         """
         Prepares a query string, returing a :class:`~cassandra.query.PreparedStatement`
         instance which can be used as follows::
@@ -702,7 +702,8 @@ class Session(object):
             raise
 
         prepared_statement = PreparedStatement.from_message(
-            query_id, column_metadata, self.cluster.metadata, query, self.keyspace)
+            query_id, column_metadata, self.cluster.metadata, query,
+            self.keyspace, consistency_level)
 
         host = future._current_host
         try:

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -123,17 +123,21 @@ class PreparedStatement(object):
 
     consistency_level = ConsistencyLevel.ONE
 
-    def __init__(self, column_metadata, query_id, routing_key_indexes, query, keyspace):
+    def __init__(self, column_metadata, query_id, routing_key_indexes, query,
+                 keyspace, consistency_level=ConsistencyLevel.ONE):
         self.column_metadata = column_metadata
         self.query_id = query_id
         self.routing_key_indexes = routing_key_indexes
         self.query_string = query
         self.keyspace = keyspace
+        self.consistency_level = consistency_level
 
     @classmethod
-    def from_message(cls, query_id, column_metadata, cluster_metadata, query, keyspace):
+    def from_message(cls, query_id, column_metadata, cluster_metadata, query,
+                     keyspace, consistency_level):
         if not column_metadata:
-            return PreparedStatement(column_metadata, query_id, None, query, keyspace)
+            return PreparedStatement(column_metadata, query_id, None, query,
+                                     keyspace, consistency_level)
 
         partition_key_columns = None
         routing_key_indexes = None
@@ -156,7 +160,8 @@ class PreparedStatement(object):
                     pass  # we're missing a partition key component in the prepared
                           # statement; just leave routing_key_indexes as None
 
-        return PreparedStatement(column_metadata, query_id, routing_key_indexes, query, keyspace)
+        return PreparedStatement(column_metadata, query_id, routing_key_indexes,
+                                 query, keyspace, consistency_level)
 
     def bind(self, values):
         """
@@ -195,11 +200,12 @@ class BoundStatement(Statement):
         `prepared_statement` should be an instance of :class:`PreparedStatement`.
         All other ``*args`` and ``**kwargs`` will be passed to :class:`.Statement`.
         """
+        Statement.__init__(self, *args, **kwargs)
+
         self.consistency_level = prepared_statement.consistency_level
         self.prepared_statement = prepared_statement
         self.values = []
 
-        Statement.__init__(self, *args, **kwargs)
 
     def bind(self, values):
         """


### PR DESCRIPTION
Currently you can't specify a consistency level when using a `PreparedStatement`. I'm not sure if this is by design or it's a bug. Looking at the code makes it seems like it's a bug / an oversight though.

With this pull request user can pass `consistency_level` argument to the `session.bind` method. `PreparedStatament` works slightly different than `SimpleStatement` so I wasn't sure of the best place to put it, but `session.bind` seems like decent place.

There is another thing I don't like that much.

Currently `BoundStatement` inherits from the `Statement` class. When creating a new instance of `BoundStatament`, you need to pass `PreparedStatement` instance and you can also pass all the other arguments which are handled in the parent class (`Statement`). This other arguments include `consistency_level`.

Before my pull request, `BoundStatement` was setting consistency_level to `prepared.consistency_level`, but later overwriting it with `None` with a call to the parent constructor. This meant that `prepared.consistency_level` would be unused if specified (which it wasn't).

In this pull request I've changed it to call parent constructor before the consistency level assignment. This means that `prepared.consistency_level` always takes precedence over `consistency_level` argument passed to the constructor.

I still don't like this approach because it means that `consistency_level` which can get passed to the `BoundStatement` constructor is unused and useless.

We have a couple of options here:
1. Remove _args and *_kwargs and explicitly declare which parent class arguments are supported (exclude `consistency_level` from this list)
2. Remove consistency_level from PreparedStatement and require user to pass it to `BoundStatament` constructor

Note: This is not a finished pull request yet. I will add tests and finish it once we all agree on approach we want to take.

Comments and feedback is welcome.
