### PR TITLE
Fixed deadlock that occurs in an import scenario.

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -44,6 +44,11 @@ try:
 except ImportError:
     from cassandra.io.asyncorereactor import AsyncoreConnection as DefaultConnection  # NOQA
 
+# Forces load of utf8 encoding module to avoid deadlock that occurs
+# if code that is being imported tries to import the module in a seperate
+# thread.
+# See http://bugs.python.org/issue10923
+"".encode('utf8')
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
When user code imports code that initiates a new connection, it could cause a
deadlock when String.encode was called in a seperate thread (e.g. when reading
messages from the cassandra server).
See http://bugs.python.org/issue10923

Reproduce:

connect.py:

```
from cassandra.cluster import Cluster
cluster = Cluster(["127.0.0.1"])
session = cluster.connect()
```

prompt:

```
$ python
Python 2.7.3 (default, Apr 10 2013, 06:20:15)
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import connect
(stuck)
```

Ubuntu 12.04.3 LTS running in a VirtualBox
