### PR TITLE
String formatting when logging should be lazy

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -519,7 +519,7 @@ class Cluster(object):
         if not self._prepared_statements:
             return
 
-        log.debug("Preparing all known prepared statements against host %s" % (host,))
+        log.debug("Preparing all known prepared statements against host %s", host)
         try:
             connection = self.connection_factory(host.address)
             try:
@@ -542,14 +542,14 @@ class Cluster(object):
                         if (not isinstance(response, ResultMessage) or
                             response.kind != ResultMessage.KIND_PREPARED):
                             log.debug("Got unexpected response when preparing "
-                                      "statement on host %s: %r" % (host, response))
+                                      "statement on host %s: %r", host, response)
                     except Exception:
                         log.exception("Error trying to prepare statement on "
-                                      "host %s" % (host,))
+                                      "host %s", host)
 
         except Exception:
             # log and ignore
-            log.exception("Error trying to prepare all statements on host %s" % (host,))
+            log.exception("Error trying to prepare all statements on host %s", host)
 
     def prepare_on_all_sessions(self, query_id, prepared_statement, excluded_host):
         self._prepared_statements[query_id] = prepared_statement
@@ -755,18 +755,18 @@ class Session(object):
                 try:
                     request_id = future._query(host)
                 except Exception:
-                    log.exception("Error preparing query for host %s:" % (host,))
+                    log.exception("Error preparing query for host %s:", host)
                     continue
 
                 if request_id is None:
                     # the error has already been logged by ResponsFuture
-                    log.debug("Failed to prepare query for host %s" % (host,))
+                    log.debug("Failed to prepare query for host %s", host)
                     continue
 
                 try:
                     future.result()
                 except Exception:
-                    log.exception("Error preparing query for host %s:" % (host,))
+                    log.exception("Error preparing query for host %s:", host)
 
     def shutdown(self):
         """
@@ -888,7 +888,7 @@ class _ControlReconnectionHandler(_ReconnectionHandler):
         if isinstance(exc, AuthenticationFailed):
             return False
         else:
-            log.debug("Error trying to reconnect control connection: %r" % (exc,))
+            log.debug("Error trying to reconnect control connection: %r", exc)
             return True
 
 
@@ -1134,7 +1134,7 @@ class ControlConnection(object):
 
             host = self._cluster.metadata.get_host(addr)
             if host is None:
-                log.debug("[control connection] Found new host to connect to: %s" % (addr,))
+                log.debug("[control connection] Found new host to connect to: %s", addr)
                 host = self._cluster.add_host(addr, signal=True)
             host.set_location_info(row.get("data_center"), row.get("rack"))
 
@@ -1255,11 +1255,11 @@ class ControlConnection(object):
         return bool(conn and conn.is_open)
 
     def on_up(self, host):
-        log.debug("[control connection] Host %s is considered up" % (host,))
+        log.debug("[control connection] Host %s is considered up", host)
         self._balancing_policy.on_up(host)
 
     def on_down(self, host):
-        log.debug("[control connection] Host %s is considered down" % (host,))
+        log.debug("[control connection] Host %s is considered down", host)
         self._balancing_policy.on_down(host)
 
         conn = self._connection
@@ -1268,12 +1268,12 @@ class ControlConnection(object):
             self.reconnect()
 
     def on_add(self, host):
-        log.debug("[control connection] Adding host %r and refreshing topology" % (host,))
+        log.debug("[control connection] Adding host %r and refreshing topology", host)
         self._balancing_policy.on_add(host)
         self.refresh_node_list_and_token_map()
 
     def on_remove(self, host):
-        log.debug("[control connection] Removing host %r and refreshing topology" % (host,))
+        log.debug("[control connection] Removing host %r and refreshing topology", host)
         self._balancing_policy.on_remove(host)
         self.refresh_node_list_and_token_map()
 
@@ -1305,7 +1305,7 @@ class _Scheduler(object):
             run_at = time.time() + delay
             self._scheduled.put_nowait((run_at, (fn, args, kwargs)))
         else:
-            log.debug("Ignoring scheduled function after shutdown: %r" % fn)
+            log.debug("Ignoring scheduled function after shutdown: %r", fn)
 
     def run(self):
         while True:
@@ -1500,7 +1500,7 @@ class ResponseFuture(object):
                     try:
                         prepared_statement = self.session.cluster._prepared_statements[query_id]
                     except KeyError:
-                        log.error("Tried to execute unknown prepared statement %s" % (query_id.encode('hex'),))
+                        log.error("Tried to execute unknown prepared statement %s", query_id.encode('hex'))
                         self._set_final_exception(response)
                         return
 

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -196,7 +196,7 @@ class Connection(object):
             response = decode_response(stream_id, flags, opcode, body, self.decompressor)
         except Exception as exc:
             log.exception("Error decoding response from Cassandra. "
-                          "opcode: %04x; message contents: %r" % (opcode, body))
+                          "opcode: %04x; message contents: %r", opcode, body)
             if callback is not None:
                 callback(exc)
             self.defunct(exc)
@@ -244,11 +244,11 @@ class Connection(object):
                        set(self.remote_supported_compressions))
             if len(overlap) == 0:
                 log.debug("No available compression types supported on both ends."
-                          " locally supported: %r. remotely supported: %r"
-                          % (locally_supported_compressions.keys(),
-                             self.remote_supported_compressions))
+                          " locally supported: %r. remotely supported: %r",
+                          locally_supported_compressions.keys(),
+                          self.remote_supported_compressions)
             else:
-                compression_type = iter(overlap).next() # choose any
+                compression_type = iter(overlap).next()  # choose any
                 opts['COMPRESSION'] = compression_type
                 # set the decompressor here, but set the compressor only after
                 # a successful Ready message
@@ -263,12 +263,12 @@ class Connection(object):
         if self.is_defunct:
             return
         if isinstance(startup_response, ReadyMessage):
-            log.debug("Got ReadyMessage on new Connection from %s" % self.host)
+            log.debug("Got ReadyMessage on new Connection from %s", self.host)
             if self._compressor:
                 self.compressor = self._compressor
             self.connected_event.set()
         elif isinstance(startup_response, AuthenticateMessage):
-            log.debug("Got AuthenticateMessage on new Connection from %s" % self.host)
+            log.debug("Got AuthenticateMessage on new Connection from %s", self.host)
 
             if self.credentials is None:
                 raise AuthenticationFailed('Remote end requires authentication.')
@@ -278,8 +278,8 @@ class Connection(object):
             callback = partial(self._handle_startup_response, did_authenticate=True)
             self.send_msg(cm, cb=callback)
         elif isinstance(startup_response, ErrorMessage):
-            log.debug("Received ErrorMessage on new Connection from %s: %s"
-                      % (self.host, startup_response.summary_msg()))
+            log.debug("Received ErrorMessage on new Connection from %s: %s",
+                      self.host, startup_response.summary_msg())
             if did_authenticate:
                 raise AuthenticationFailed(
                     "Failed to authenticate to %s: %s" %
@@ -289,9 +289,9 @@ class Connection(object):
                     "Failed to initialize new connection to %s: %s"
                     % (self.host, startup_response.summary_msg()))
         else:
-            msg = "Unexpected response during Connection setup: %r" % (startup_response,)
-            log.error(msg)
-            raise ProtocolError(msg)
+            msg = "Unexpected response during Connection setup: %r"
+            log.error(msg, startup_response)
+            raise ProtocolError(msg % (startup_response,))
 
     def set_keyspace(self, keyspace):
         if not keyspace or keyspace == self.keyspace:

--- a/cassandra/decoder.py
+++ b/cassandra/decoder.py
@@ -156,7 +156,7 @@ def decode_response(stream_id, flags, opcode, body, decompressor=None):
         trace_id = None
 
     if flags:
-        log.warn("Unknown protocol flags set: %02x. May cause problems." % flags)
+        log.warn("Unknown protocol flags set: %02x. May cause problems.", flags)
 
     msg_class = _message_types_by_opcode[opcode]
     msg = msg_class.recv_body(body)
@@ -166,6 +166,7 @@ def decode_response(stream_id, flags, opcode, body, decompressor=None):
 
 
 error_classes = {}
+
 
 class ErrorMessage(_MessageType, Exception):
     opcode = 0x00

--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -19,7 +19,7 @@ except ImportError:
 try:
     import ssl
 except ImportError:
-    ssl = None # NOQA
+    ssl = None  # NOQA
 
 from cassandra.connection import (Connection, ResponseWaiter, ConnectionShutdown,
                                   ConnectionBusy, ConnectionException, NONBLOCKING)
@@ -33,6 +33,7 @@ _loop_lock = Lock()
 
 _starting_conns = set()
 _starting_conns_lock = Lock()
+
 
 def _run_loop():
     global _loop_started
@@ -155,11 +156,11 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
                 return
             self.is_closed = True
 
-        log.debug("Closing connection to %s" % (self.host,))
+        log.debug("Closing connection to %s", self.host)
         self._writable = False
         self._readable = False
         asyncore.dispatcher.close(self)
-        log.debug("Closed socket to %s" % (self.host,))
+        log.debug("Closed socket to %s", self.host)
 
         with _starting_conns_lock:
             _starting_conns.discard(self)

--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -141,7 +141,7 @@ class LibevConnection(Connection):
                 return
             self.is_closed = True
 
-        log.debug("Closing connection to %s" % (self.host,))
+        log.debug("Closing connection to %s", self.host)
         if self._read_watcher:
             self._read_watcher.stop()
         if self._write_watcher:

--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -297,7 +297,7 @@ class HostConnectionPool(object):
         conns = self._connections
         if not conns:
             # handled specially just for simpler code
-            log.debug("Detected empty pool, opening core conns to %s" % (self.host,))
+            log.debug("Detected empty pool, opening core conns to %s", self.host)
             core_conns = self._session.cluster.get_core_connections_per_host(self.host_distance)
             with self._lock:
                 # we check the length of self._connections again
@@ -352,7 +352,7 @@ class HostConnectionPool(object):
                 return
             self._scheduled_for_creation += 1
 
-        log.debug("Submitting task for creation of new Connection to %s" % (self.host,))
+        log.debug("Submitting task for creation of new Connection to %s", self.host)
         self._session.submit(self._create_new_connection)
 
     def _create_new_connection(self):
@@ -383,7 +383,7 @@ class HostConnectionPool(object):
             self._signal_available_conn()
             return True
         except ConnectionException as exc:
-            log.exception("Failed to add new connection to pool for host %s" % (self.host,))
+            log.exception("Failed to add new connection to pool for host %s", self.host)
             with self._lock:
                 self.open_count -= 1
             if self.host.monitor.signal_connection_failure(exc):
@@ -485,7 +485,7 @@ class HostConnectionPool(object):
                 self._trash.add(connection)
 
         if did_trash:
-            log.debug("Trashed connection to %s" % (self.host,))
+            log.debug("Trashed connection to %s", self.host)
 
     def _replace(self, connection):
         should_replace = False
@@ -498,7 +498,7 @@ class HostConnectionPool(object):
                 should_replace = True
 
         if should_replace:
-            log.debug("Replacing connection to %s" % (self.host,))
+            log.debug("Replacing connection to %s", self.host)
 
             def close_and_replace():
                 connection.close()
@@ -507,7 +507,7 @@ class HostConnectionPool(object):
             self._session.submit(close_and_replace)
         else:
             # just close it
-            log.debug("Closing connection to %s" % (self.host,))
+            log.debug("Closing connection to %s", self.host)
             connection.close()
 
     def shutdown(self):


### PR DESCRIPTION
String formatting is not free by any means, so we should let the logger evaluate when/if needed. Also, this helps with error grouping and whatnot in something like Sentry.
