### PR TITLE
Silence exceptions when cluster is shutting down.

### DIFF
--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -145,19 +145,27 @@ class LibevConnection(Connection):
                 return
             self.is_closed = True
 
-        log.debug("Closing connection (%s) to %s", id(self), self.host)
+        try:
+            log.debug("Closing connection (%s) to %s", id(self), self.host)
+        except AttributeError:
+            # this can happen on interpreter shutdown
+            pass
+
         if self._read_watcher:
             self._read_watcher.stop()
         if self._write_watcher:
             self._write_watcher.stop()
         self._socket.close()
-        with _loop_lock:
-            _loop_notifier.send()
+
+        if _loop_lock:
+            with _loop_lock:
+                _loop_notifier.send()
 
         # don't leave in-progress operations hanging
         if not self.is_defunct:
-            self._error_all_callbacks(
-                ConnectionShutdown("Connection to %s was closed" % self.host))
+            if ConnectionShutdown:
+                self._error_all_callbacks(
+                    ConnectionShutdown("Connection to %s was closed" % self.host))
 
     def __del__(self):
         self.close()


### PR DESCRIPTION
I'm not sure if this is the best patch, but I did notice that close() was called elsewhere so I figured just to check for variable existence. Worst case: it showcases where the exceptions on cluster.shutdown() were coming from.

Here are the exceptions that I was getting on a normal program exit:

```
Exception AttributeError: AttributeError("'NoneType' object has no attribute 'debug'",) in <bound method Session.__del__ of <cassandra.cluster.Session object at 0x10e50bc10>> ignored
Exception AttributeError: "'NoneType' object has no attribute 'debug'" in <bound method Cluster.__del__ of <cassandra.cluster.Cluster object at 0x10e4c8ad0>> ignored
```

I realized that log was None, much like:
https://github.com/datastax/python-driver/blob/master/cassandra/cluster.py#L1526

As were _loop_lock and ConnectionShutdown.
