### PR TITLE
Added an entry to the scheduled queue to prevent thread leak on shutdown

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1593,6 +1593,7 @@ class _Scheduler(object):
             # this can happen on interpreter shutdown
             pass
         self.is_shutdown = True
+        self._scheduled.put_nowait((None, None))
 
     def schedule(self, delay, fn, *args, **kwargs):
         if not self.is_shutdown:


### PR DESCRIPTION
`cluster.Cluster` is leaking threads even with a proper call to `cluster.shutdown()`. 

The `cluster._Scheduler` class waits infinitely for a task to be push into the priority queue. This prevents the scheduler thread from ever dying, even when the shutdown method is called. Adding an entry to the queue kicks the scheduler out of this wait so that it can see the `is_shutdown` flag.
