### PR TITLE
Not checking None result

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -847,7 +847,9 @@ class Session(object):
         # create connection pools in parallel
         futures = []
         for host in hosts:
-            futures.append(self.add_or_renew_pool(host, is_host_addition=False))
+            future = self.add_or_renew_pool(host, is_host_addition=False);
+            if future is not None:
+                futures.append(future)
 
         for future in futures:
             future.result()


### PR DESCRIPTION
None is returned from `Session.add_or_renew_pool()`  when the load balancer policy returns `HostDistance.IGNORED`. This is appended to the futures list without a None check. These None values eventually get a method call and bomb.
