### PR TITLE
resolve "no viable alternative at input" when insert/update with map or list which contains blob as inner types

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -854,7 +854,7 @@ class Session(object):
 
     Setting this to :const:`None` will cause no timeouts to be set by default.
 
-    *Note*: This timeout currently has no effect on callbacks registered
+    *Important*: This timeout currently has no effect on callbacks registered
     on a :class:`~.ResponseFuture` through :meth:`~.ResponseFuture.add_callback` or
     :meth:`~.ResponseFuture.add_errback`; even if a query exceeds this default
     timeout, neither the registered callback or errback will be called.


### PR DESCRIPTION
My environment is Linux + Cassandra 2.0.3

The table I am working with has column typed as map<uuid, blob>. I received syntax exception when attempting to insert data rows.

```
(here is one of the exception I got: SyntaxException: <ErrorMessage code=2000 [Syntax error in CQL query] message="line 1:129 no viable alternative at input 'is'">)
```

After look into the exception, I noticed that the encoder of python dict object calls cql_quote() which cannot correctly encode python bytearray object into CQL blob literal.

This patch works in my use case. I made a set of test: https://gist.github.com/yinyin/7736711 to verify this patch. This patch also tested with tests/integration/test_types.py with ccm dependency removed. (I have trouble with ccm library ... cannot get all tests running with/without this patch)
