### PR TITLE
resolve "no viable alternative at input" when insert/update with map or list which contains blob as inner types

### DIFF
--- a/cassandra/decoder.py
+++ b/cassandra/decoder.py
@@ -820,14 +820,6 @@ def cql_encode_all_types(val):
     return cql_encoders.get(type(val), cql_encode_object)(val)
 
 
-py_cql_collection_types = frozenset((
-    dict,
-    list, tuple,
-    set, frozenset,
-    types.GeneratorType
-))
-
-
 cql_encoders = {
     float: cql_encode_object,
     bytearray: cql_encode_bytes,


### PR DESCRIPTION
This is same fix with #56.
I just move changes into branch. (still learning about git branch, sorry for making this noise.)

---

My environment is Linux + Cassandra 2.0.3

The table I am working with has column typed as map<uuid, blob>. I received syntax exception when attempting to insert data rows.

```
(here is one of the exception I got: SyntaxException: <ErrorMessage code=2000 [Syntax error in CQL query] message="line 1:129 no viable alternative at input 'is'">)
```

After look into the exception, I noticed that the encoder of python dict object calls cql_quote() which cannot correctly encode python bytearray object into CQL blob literal.

This patch works in my use case. I made a set of test: https://gist.github.com/yinyin/7736711 to verify this patch. This patch also tested with tests/integration/test_types.py with ccm dependency removed. (I have trouble with ccm library ... cannot get all tests running with/without this patch)
