### PR TITLE
add encoder mapping for OrderedDict

### DIFF
--- a/cassandra/decoder.py
+++ b/cassandra/decoder.py
@@ -825,6 +825,7 @@ cql_encoders = {
     datetime.datetime: cql_encode_datetime,
     datetime.date: cql_encode_date,
     dict: cql_encode_map_collection,
+    OrderedDict: cql_encode_map_collection,
     list: cql_encode_list_collection,
     tuple: cql_encode_list_collection,
     set: cql_encode_set_collection,


### PR DESCRIPTION
OrderedDict is the resulted object type when SELECT-ing map data object.

I got the following exception when use fetched map object (ie: will be a python OrderedDict object) as query arguments.

```
SyntaxException: <ErrorMessage code=2000 [Syntax error in CQL query] message="line 1:73 
no viable alternative at input 'beta-2'">
```

This patch fixes this issue by add a entry in `cql_encoders` for OrderedDict

---

I tested this patch by the following code -

``` python
    s.execute("CREATE TABLE test_map_table(t_id timeuuid, t_val map<varchar, varchar>, PRIMARY KEY(t_id))")

    t_id = uuid.uuid1()
    t_val_1 = {'a': 'alpha-1', 'b': 'beta-2', }
    s.execute("INSERT INTO test_map_table(t_id, t_val) VALUES(%s, %s)", (t_id, t_val_1,))

    result = s.execute("SELECT t_id, t_val FROM test_map_table")
    t_val_2 = result[0].t_val

    s.execute("UPDATE test_map_table SET t_val=%s WHERE (t_id = %s)", (t_val_2, t_id,))

    result = s.execute("SELECT t_id, t_val FROM test_map_table")
    self.assertEqual(t_id, result[0].t_id)
    self.assertEqual(t_val_2, result[0].t_val)
```
