### PR TITLE
README: adding —pre to pip since package is still beta

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ the instructions in the section below before installing the driver.
 
 Installation through pip is recommended::
 
-    $ pip install cassandra-driver
+    $ pip install cassandra-driver --pre
 
 If you want to install manually, you can instead do::
 


### PR DESCRIPTION
Since the package is still marked as beta, pip complains when running `pip install cassandra-driver`:

``` shell
Downloading/unpacking cassandra-driver
  Could not find a version that satisfies the requirement cassandra-driver (from versions: 1.0.0b5, 1.0.0b6, 1.0.0b7)
Cleaning up...
No distributions matching the version for cassandra-driver
Storing complete log in /home/danielesalatti/.pip/pip.log
```

I added `--pre` to force pip to install the package anyway.
