### PR TITLE
Fix Token's __hash__ method so that BytesToken instances to be added to ...

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -924,7 +924,7 @@ class Token(object):
         return self.value == other.value
 
     def __hash__(self):
-        return self.value
+        return hash(self.value)
 
     def __repr__(self):
         return "<%s: %r>" % (self.__class__.__name__, self.value)


### PR DESCRIPTION
...token_to_host_owner (currently the driver is broken on ByteOrderedPartitioner)
