### PR TITLE
Fix UTF8Type serialization for already-encoded utf8

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -528,15 +528,11 @@ class UTF8Type(_CassandraType):
 
     @staticmethod
     def serialize(ustr):
-        # ustr.encode('utf8') fails when the string is already encoded
-        # this is common if your data comes through other database drivers (e.g. odbc, psycopg2, etc.)
-        if isinstance(ustr, unicode): # check type explicitly. Unicode will encode successfuly.
-            return ustr.encode('utf8')
-        # otherwise, our input string is either already encoded or not unicode to begin with.
-        # since all cassandra strings are utf-8, we can validate that the ustr is already encoded utf-8 by decoding it
-        else:
-            ustr.decode('utf-8') # will raise UnicodeDecodeError if not utf8 encoded byte string.
-            return ustr # definitely valid :)
+        try:
+            return ustr.encode('utf-8')
+        except UnicodeDecodeError:
+            # already utf-8
+            return ustr
 
 
 class VarcharType(UTF8Type):


### PR DESCRIPTION
If your data is already utf-8 encoded by the time it reaches the UTF8Type.serialize() method, the encode() will fail, raising a UnicodeDecodeError.
Explicitly testing the type for Unicode before the .encode() should guarantee it doesn't fail, and in cases where it isn't Unicode, we simply test whether it's already a valid byte-encoded unicode string by attempting to decode it. 
This shouldn't add any significant overhead for strings passed in as Unicode, will prevent unnecessary failures with already-encoded Unicode strings, and raise a UnicodeDecodeError otherwise.
