### PR TITLE
Fix token ring wrapping

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -891,9 +891,7 @@ class TokenMap(object):
                 return []
 
         point = bisect_left(self.ring, token)
-        if point == 0 and token != self.ring[0]:
-            return tokens_to_hosts[self.ring[-1]]
-        elif point == len(self.ring):
+        if point == len(self.ring):
             return tokens_to_hosts[self.ring[0]]
         else:
             return tokens_to_hosts[self.ring[point]]

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -385,7 +385,7 @@ class TokenMetadataTest(unittest.TestCase):
         cluster.shutdown()
 
     def test_getting_replicas(self):
-        tokens = [MD5Token(str(i)) for i in range(0, (2 ** 127 - 1), 2 ** 125)]
+        tokens = [MD5Token(str(i)) for i in range(1, (2 ** 127 - 1), 2 ** 125)]
         hosts = [Host("ip%d" % i, SimpleConvictionPolicy) for i in range(len(tokens))]
         token_to_primary_replica = dict(zip(tokens, hosts))
         keyspace = KeyspaceMetadata("ks", True, "SimpleStrategy", {"replication_factor": "1"})
@@ -398,7 +398,7 @@ class TokenMetadataTest(unittest.TestCase):
             self.assertEqual(set(replicas), set([expected_host]))
 
         # shift the tokens back by one
-        for token, expected_host in zip(tokens[1:], hosts[1:]):
+        for token, expected_host in zip(tokens, hosts):
             replicas = token_map.get_replicas("ks", MD5Token(str(token.value - 1)))
             self.assertEqual(set(replicas), set([expected_host]))
 


### PR DESCRIPTION
TokenMap#get_replicas is slightly wrong.
If a compared token is "smaller" than a token for the first host in the token map, then the last host would be selected, but it should the be the first one.
