### PR TITLE
fix prepared statements in batch requests

### DIFF
--- a/cassandra/decoder.py
+++ b/cassandra/decoder.py
@@ -563,13 +563,14 @@ class BatchMessage(_MessageType):
     def send_body(self, f, protocol_version):
         write_byte(f, self.batch_type.value)
         write_short(f, len(self.queries))
-        for string_or_query_id, params in self.queries:
-            if isinstance(string_or_query_id, basestring):
+        for prepared, string_or_query_id, params in self.queries:
+            if not prepared:
                 write_byte(f, 0)
                 write_longstring(f, string_or_query_id)
             else:
                 write_byte(f, 1)
-                write_short(f, string_or_query_id)
+                write_short(f, len(string_or_query_id))
+                f.write(string_or_query_id)
             write_short(f, len(params))
             for param in params:
                 write_value(f, param)

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -362,14 +362,15 @@ class BatchStatement(Statement):
             try:
                 # see if it's a PreparedStatement
                 query_id = statement.query_id
+                bound_statement = statement.bind(parameters)
                 self._statements_and_parameters.append(
-                    (query_id, () if parameters is None else parameters))
+                    (True, query_id, () if parameters is None else bound_statement.values))
             except AttributeError:
                 # it must be a SimpleStatement
                 query_string = statement.query_string
                 if parameters:
                     query_string = bind_params(query_string, parameters)
-                self._statements_and_parameters.append((query_string, ()))
+                self._statements_and_parameters.append((False, query_string, ()))
         return self
 
     def add_all(self, statements, parameters):
@@ -379,7 +380,7 @@ class BatchStatement(Statement):
     def __str__(self):
         consistency = ConsistencyLevel.value_to_name[self.consistency_level]
         return (u'<BatchStatement type=%s, statements=%d, consistency=%s>' %
-                (self.batch_type, len(self._statements_and_values), consistency))
+                (self.batch_type, len(self._statements_and_parameters), consistency))
     __repr__ = __str__
 
 


### PR DESCRIPTION
This patch contains the following:
1. Fix detection of prepared statements in batch requests - both the statement and query_id are instances of `basestring` so detection with `isinstance()` failed. Now `prepared` is explicitly stored when the statement is added.
2. Finish prepared statement serialization
3. Fix `BatchStatement.__str__()`
