### PR TITLE
Fixes #97, error following 'DROP TABLE'.

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -159,7 +159,8 @@ class Metadata(object):
 
         if not cf_results:
             # the table was removed
-            del keyspace_meta.tables[table]
+            if table in keyspace_meta.tables: 
+                del keyspace_meta.tables[table]
         else:
             assert len(cf_results) == 1
             keyspace_meta.tables[table] = self._build_table_metadata(


### PR DESCRIPTION
Following 'DROP TABLE', metadata.py was raising KeyError in line 162,
which resulted in cluster conn being terminated. Resolved this with
checking if the key (the name of the dropped table) exists.

Gist: https://gist.github.com/mkocikowski/9778989
