### PR TITLE
Add documentation on using libev with MacOS and Homebrew

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -79,6 +79,18 @@ through `Homebrew <http://brew.sh/>`_. For example, on Mac OS X::
 
     $ brew install libev
 
+In addition on Mac OS X, be sure to include libev in the lib and include paths or
+libev support will NOT be included. For example::
+
+    $ brew list libev
+    /usr/local/Cellar/libev/4.15/include/ (2 files)
+    /usr/local/Cellar/libev/4.15/lib/libev.4.dylib
+    /usr/local/Cellar/libev/4.15/lib/ (2 other files)
+    /usr/local/Cellar/libev/4.15/share/man/man3/ev.3
+
+    $ export CPPFLAGS=-I/usr/local/Cellar/libev/4.15/include
+    $ export LDFLAGS=-L/usr/local/Cellar/libev/4.15/lib
+
 If successful, you should be able to build and install the extension
 (just using ``setup.py build`` or ``setup.py install``) and then use
 the libev event loop by doing the following:

--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,18 @@ On OSX, via homebrew:
 
     $ brew install libev
 
+    In addition on OSX, you'll need to add libev's lib and include paths to your
+    build variables or libev support will NOT be compiled. For example:
+
+    $ brew list libev
+    /usr/local/Cellar/libev/4.15/include/ (2 files)
+    /usr/local/Cellar/libev/4.15/lib/libev.4.dylib
+    /usr/local/Cellar/libev/4.15/lib/ (2 other files)
+    /usr/local/Cellar/libev/4.15/share/man/man3/ev.3
+
+    $ export CPPFLAGS=-I/usr/local/Cellar/libev/4.15/include
+    $ export LDFLAGS=-L/usr/local/Cellar/libev/4.15/lib
+
 ===============================================================================
     """
 


### PR DESCRIPTION
I was doing some tests on MacOS and was baffled why my performance tests were so slow on MacOS compared to Linux. Turns out that libev support was quietly not being compiled because the lib and include paths were not set properly.
