### PR TITLE
When creating a new connection use the same query

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1322,8 +1322,8 @@ class ControlConnection(object):
     _SELECT_COLUMN_FAMILIES = "SELECT * FROM system.schema_columnfamilies"
     _SELECT_COLUMNS = "SELECT * FROM system.schema_columns"
 
-    _SELECT_PEERS = "SELECT peer, data_center, rack, tokens, rpc_address FROM system.peers"
-    _SELECT_LOCAL = "SELECT cluster_name, data_center, rack, tokens, partitioner FROM system.local WHERE key='local'"
+    _SELECT_PEERS = "SELECT peer, data_center, rack, tokens, rpc_address, schema_version FROM system.peers"
+    _SELECT_LOCAL = "SELECT cluster_name, data_center, rack, tokens, partitioner, schema_version FROM system.local WHERE key='local'"
 
     _SELECT_SCHEMA_PEERS = "SELECT rpc_address, schema_version FROM system.peers"
     _SELECT_SCHEMA_LOCAL = "SELECT schema_version FROM system.local WHERE key='local'"
@@ -1406,8 +1406,13 @@ class ControlConnection(object):
                 "SCHEMA_CHANGE": self._handle_schema_change
             })
 
-            self._refresh_node_list_and_token_map(connection)
-            self._refresh_schema(connection)
+            peers_query = QueryMessage(query=self._SELECT_PEERS, consistency_level=ConsistencyLevel.ONE)
+            local_query = QueryMessage(query=self._SELECT_LOCAL, consistency_level=ConsistencyLevel.ONE)
+            shared_results = connection.wait_for_responses(
+                peers_query, local_query, timeout=self._timeout)
+
+            self._refresh_node_list_and_token_map(connection, preloaded_results=shared_results)
+            self._refresh_schema(connection, preloaded_results=shared_results)
         except Exception:
             connection.close()
             raise
@@ -1489,11 +1494,11 @@ class ControlConnection(object):
             log.debug("[control connection] Error refreshing schema", exc_info=True)
             self._signal_error()
 
-    def _refresh_schema(self, connection, keyspace=None, table=None):
+    def _refresh_schema(self, connection, keyspace=None, table=None, preloaded_results=None):
         if self._cluster._is_shutdown:
             return
 
-        self.wait_for_schema_agreement(connection)
+        self.wait_for_schema_agreement(connection, preloaded_results=preloaded_results)
 
         where_clause = ""
         if keyspace:
@@ -1540,13 +1545,19 @@ class ControlConnection(object):
             log.debug("[control connection] Error refreshing node list and token map", exc_info=True)
             self._signal_error()
 
-    def _refresh_node_list_and_token_map(self, connection):
-        log.debug("[control connection] Refreshing node list and token map")
-        cl = ConsistencyLevel.ONE
-        peers_query = QueryMessage(query=self._SELECT_PEERS, consistency_level=cl)
-        local_query = QueryMessage(query=self._SELECT_LOCAL, consistency_level=cl)
-        peers_result, local_result = connection.wait_for_responses(
-            peers_query, local_query, timeout=self._timeout)
+    def _refresh_node_list_and_token_map(self, connection, preloaded_results=None):
+        if preloaded_results:
+            log.debug("[control connection] Refreshing node list and token map using preloaded results")
+            peers_result = preloaded_results[0]
+            local_result = preloaded_results[1]
+        else:
+            log.debug("[control connection] Refreshing node list and token map")
+            cl = ConsistencyLevel.ONE
+            peers_query = QueryMessage(query=self._SELECT_PEERS, consistency_level=cl)
+            local_query = QueryMessage(query=self._SELECT_LOCAL, consistency_level=cl)
+            peers_result, local_result = connection.wait_for_responses(
+                peers_query, local_query, timeout=self._timeout)
+
         peers_result = dict_factory(*peers_result.results)
 
         partitioner = None
@@ -1654,7 +1665,7 @@ class ControlConnection(object):
         elif event['change_type'] == "UPDATED":
             self._submit(self.refresh_schema, keyspace, table)
 
-    def wait_for_schema_agreement(self, connection=None):
+    def wait_for_schema_agreement(self, connection=None, preloaded_results=None):
         # Each schema change typically generates two schema refreshes, one
         # from the response type and one from the pushed notification. Holding
         # a lock is just a simple way to cut down on the number of schema queries
@@ -1663,10 +1674,18 @@ class ControlConnection(object):
             if self._is_shutdown:
                 return
 
-            log.debug("[control connection] Waiting for schema agreement")
             if not connection:
                 connection = self._connection
 
+            if preloaded_results:
+                log.debug("[control connection] Attempting to use preloaded results for schema agreement")
+
+                peers_result = preloaded_results[0]
+                local_result = preloaded_results[1]
+                if self._do_schemas_match(peers_result, local_result):
+                    return True
+
+            log.debug("[control connection] Waiting for schema agreement")
             start = self._time.time()
             elapsed = 0
             cl = ConsistencyLevel.ONE
@@ -1684,28 +1703,7 @@ class ControlConnection(object):
                     elapsed = self._time.time() - start
                     continue
 
-                peers_result = dict_factory(*peers_result.results)
-
-                versions = set()
-                if local_result.results:
-                    local_row = dict_factory(*local_result.results)[0]
-                    if local_row.get("schema_version"):
-                        versions.add(local_row.get("schema_version"))
-
-                for row in peers_result:
-                    if not row.get("rpc_address") or not row.get("schema_version"):
-                        continue
-
-                    rpc = row.get("rpc_address")
-                    if rpc == "0.0.0.0":  # TODO ipv6 check
-                        rpc = row.get("peer")
-
-                    peer = self._cluster.metadata.get_host(rpc)
-                    if peer and peer.is_up:
-                        versions.add(row.get("schema_version"))
-
-                if len(versions) == 1:
-                    log.debug("[control connection] Schemas match")
+                if self._do_schemas_match(peers_result, local_result):
                     return True
 
                 log.debug("[control connection] Schemas mismatched, trying again")
@@ -1713,6 +1711,34 @@ class ControlConnection(object):
                 elapsed = self._time.time() - start
 
             return False
+
+    def _do_schemas_match(self, peers_result, local_result):
+        peers_result = dict_factory(*peers_result.results)
+
+        versions = set()
+        if local_result.results:
+            local_row = dict_factory(*local_result.results)[0]
+            if local_row.get("schema_version"):
+                versions.add(local_row.get("schema_version"))
+
+        for row in peers_result:
+            if not row.get("rpc_address") or not row.get("schema_version"):
+                continue
+
+            rpc = row.get("rpc_address")
+            if rpc == "0.0.0.0":  # TODO ipv6 check
+                rpc = row.get("peer")
+
+            peer = self._cluster.metadata.get_host(rpc)
+            if peer and peer.is_up:
+                versions.add(row.get("schema_version"))
+
+        if len(versions) == 1:
+            log.debug("[control connection] Schemas match")
+            return True
+
+        return False
+
 
     def _signal_error(self):
         # try just signaling the cluster, as this will trigger a reconnect

--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -90,13 +90,12 @@ class MockConnection(object):
             [["192.168.1.1", "10.0.0.1", "a", "dc1", "rack1", ["1", "101", "201"]],
              ["192.168.1.2", "10.0.0.2", "a", "dc1", "rack1", ["2", "102", "202"]]]
         ]
-
-    def wait_for_responses(self, peer_query, local_query, timeout=None):
         local_response = ResultMessage(
             kind=ResultMessage.KIND_ROWS, results=self.local_results)
         peer_response = ResultMessage(
             kind=ResultMessage.KIND_ROWS, results=self.peer_results)
-        return (peer_response, local_response)
+
+        self.wait_for_responses = Mock(return_value=(peer_response, local_response))
 
 
 class FakeTime(object):
@@ -122,6 +121,38 @@ class ControlConnectionTest(unittest.TestCase):
         self.control_connection._connection = self.connection
         self.control_connection._time = self.time
 
+    def _get_matching_schema_preloaded_results(self):
+        local_results = [
+            ["schema_version", "cluster_name", "data_center", "rack", "partitioner", "tokens"],
+            [["a", "foocluster", "dc1", "rack1", "Murmur3Partitioner", ["0", "100", "200"]]]
+        ]
+        local_response = ResultMessage(kind=ResultMessage.KIND_ROWS, results=local_results)
+
+        peer_results = [
+            ["rpc_address", "peer", "schema_version", "data_center", "rack", "tokens"],
+            [["192.168.1.1", "10.0.0.1", "a", "dc1", "rack1", ["1", "101", "201"]],
+             ["192.168.1.2", "10.0.0.2", "a", "dc1", "rack1", ["2", "102", "202"]]]
+        ]
+        peer_response = ResultMessage(kind=ResultMessage.KIND_ROWS, results=peer_results)
+
+        return (peer_response, local_response)
+
+    def _get_nonmatching_schema_preloaded_results(self):
+        local_results = [
+            ["schema_version", "cluster_name", "data_center", "rack", "partitioner", "tokens"],
+            [["a", "foocluster", "dc1", "rack1", "Murmur3Partitioner", ["0", "100", "200"]]]
+        ]
+        local_response = ResultMessage(kind=ResultMessage.KIND_ROWS, results=local_results)
+
+        peer_results = [
+            ["rpc_address", "peer", "schema_version", "data_center", "rack", "tokens"],
+            [["192.168.1.1", "10.0.0.1", "a", "dc1", "rack1", ["1", "101", "201"]],
+             ["192.168.1.2", "10.0.0.2", "b", "dc1", "rack1", ["2", "102", "202"]]]
+        ]
+        peer_response = ResultMessage(kind=ResultMessage.KIND_ROWS, results=peer_results)
+
+        return (peer_response, local_response)
+
     def test_wait_for_schema_agreement(self):
         """
         Basic test with all schema versions agreeing
@@ -129,6 +160,29 @@ class ControlConnectionTest(unittest.TestCase):
         self.assertTrue(self.control_connection.wait_for_schema_agreement())
         # the control connection should not have slept at all
         self.assertEqual(self.time.clock, 0)
+
+    def test_wait_for_schema_agreement_uses_preloaded_results_if_given(self):
+        """
+        wait_for_schema_agreement uses preloaded results if given for shared table queries
+        """
+        preloaded_results = self._get_matching_schema_preloaded_results()
+
+        self.assertTrue(self.control_connection.wait_for_schema_agreement(preloaded_results=preloaded_results))
+        # the control connection should not have slept at all
+        self.assertEqual(self.time.clock, 0)
+        # the connection should not have made any queries if given preloaded results
+        self.assertEqual(self.connection.wait_for_responses.call_count, 0)
+
+    def test_wait_for_schema_agreement_falls_back_to_querying_if_schemas_dont_match_preloaded_result(self):
+        """
+        wait_for_schema_agreement requery if schema does not match using preloaded results
+        """
+        preloaded_results = self._get_nonmatching_schema_preloaded_results()
+
+        self.assertTrue(self.control_connection.wait_for_schema_agreement(preloaded_results=preloaded_results))
+        # the control connection should not have slept at all
+        self.assertEqual(self.time.clock, 0)
+        self.assertEqual(self.connection.wait_for_responses.call_count, 1)
 
     def test_wait_for_schema_agreement_fails(self):
         """
@@ -196,6 +250,32 @@ class ControlConnectionTest(unittest.TestCase):
         for host in meta.all_hosts():
             self.assertEqual(host.datacenter, "dc1")
             self.assertEqual(host.rack, "rack1")
+
+        self.assertEqual(self.connection.wait_for_responses.call_count, 1)
+
+    def test_refresh_nodes_and_tokens_uses_preloaded_results_if_given(self):
+        """
+        refresh_nodes_and_tokens uses preloaded results if given for shared table queries
+        """
+        preloaded_results = self._get_matching_schema_preloaded_results()
+
+        self.control_connection._refresh_node_list_and_token_map(self.connection, preloaded_results=preloaded_results)
+        meta = self.cluster.metadata
+        self.assertEqual(meta.partitioner, 'Murmur3Partitioner')
+        self.assertEqual(meta.cluster_name, 'foocluster')
+
+        # check token map
+        self.assertEqual(sorted(meta.all_hosts()), sorted(meta.token_map.keys()))
+        for token_list in meta.token_map.values():
+            self.assertEqual(3, len(token_list))
+
+        # check datacenter/rack
+        for host in meta.all_hosts():
+            self.assertEqual(host.datacenter, "dc1")
+            self.assertEqual(host.rack, "rack1")
+
+        # the connection should not have made any queries if given preloaded results
+        self.assertEqual(self.connection.wait_for_responses.call_count, 0)
 
     def test_refresh_nodes_and_tokens_no_partitioner(self):
         """


### PR DESCRIPTION
When a new control connection is made the system.peers table and system.local table are queried multiple times before the control connection is established. This patch combines the queries to each table by using "preloaded" results. This seemed like a minimal way to make the change, but might not necessarily be the best way. Let me know if you feel like a different approach should be used. 
