### PR TITLE
Add blist.sortedset to cql encoders

### DIFF
--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -135,3 +135,12 @@ else:
         bytes: cql_encode_bytes,
         type(None): cql_encode_none,
     })
+
+# sortedset is optional
+try:
+    from blist import sortedset
+    cql_encoders.update({
+        sortedset: cql_encode_set_collection
+    })
+except ImportError:
+    pass


### PR DESCRIPTION
This fixes a bug that happens when one tries to encode data that was decoded into sortedset (ie, when the blist package is available).
