### PR TITLE
Add nested tuple tests

### DIFF
--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -503,9 +503,9 @@ class TypeTests(unittest.TestCase):
         s = c.connect()
         s.encoders[tuple] = cql_encode_tuple
 
-        s.execute("""CREATE KEYSPACE test_tuple_types
+        s.execute("""CREATE KEYSPACE test_tuple_subtypes
             WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}""")
-        s.set_keyspace("test_tuple_types")
+        s.set_keyspace("test_tuple_subtypes")
 
         s.execute("CREATE TABLE mytable ("
                   "k int PRIMARY KEY, "
@@ -522,6 +522,69 @@ class TypeTests(unittest.TestCase):
 
             result = s.execute("SELECT v FROM mytable WHERE k=%s", (i,))[0]
             self.assertEqual(response_tuple, result.v)
+
+    def nested_tuples_schema_helper(self, depth):
+        """
+        Helper method for creating nested tuple schema
+        """
+
+        if depth == 0:
+            return 'int'
+        else:
+            return 'tuple<%s>' % self.nested_tuples_schema_helper(depth - 1)
+
+    def nested_tuples_creator_helper(self, depth):
+        """
+        Helper method for creating nested tuples
+        """
+
+        if depth == 0:
+            return 303
+        else:
+            return tuple((self.nested_tuples_creator_helper(depth - 1),))
+
+    def test_nested_tuples(self):
+        """
+        Ensure nested are appropriately handled.
+        """
+
+        if self._cass_version < (2, 1, 0):
+            raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
+
+        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        s = c.connect()
+
+        # set the row_factory to dict_factory for programmatic access
+        # set the encoder for tuples for the ability to write tuples
+        s.row_factory = dict_factory
+        s.encoders[tuple] = cql_encode_tuple
+
+        s.execute("""CREATE KEYSPACE test_nested_tuples
+            WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}""")
+        s.set_keyspace("test_nested_tuples")
+
+        # create a table with multiple sizes of nested tuples
+        s.execute("CREATE TABLE mytable ("
+                  "k int PRIMARY KEY, "
+                  "v_1 %s,"
+                  "v_2 %s,"
+                  "v_3 %s,"
+                  "v_128 %s"
+                  ")" % (self.nested_tuples_schema_helper(1),
+                        self.nested_tuples_schema_helper(2),
+                        self.nested_tuples_schema_helper(3),
+                        self.nested_tuples_schema_helper(128)))
+
+        for i in (1, 2, 3, 128):
+            # create tuple
+            created_tuple = self.nested_tuples_creator_helper(i)
+
+            # write tuple
+            s.execute("INSERT INTO mytable (k, v_%s) VALUES (%s, %s)", (i, i, created_tuple))
+
+            # verify tuple was written and read correctly
+            result = s.execute("SELECT v_%s FROM mytable WHERE k=%s", (i, i))[0]
+            self.assertEqual(created_tuple, result['v_%s' % i])
 
     def test_unicode_query_string(self):
         c = Cluster(protocol_version=PROTOCOL_VERSION)


### PR DESCRIPTION
This code creates this table:

```
CREATE TABLE mytable (k int PRIMARY KEY, v_1 tuple<int>,v_2 tuple<tuple<int>>,v_3 tuple<tuple<tuple<int>>>,v_128 tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<tuple<int>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>)
```

The first insert of `(303,)` is fine. The second insert of `((303,),)` produces this error:

```
Traceback (most recent call last):
  File "/Users/joaquin/repos/python-driver/tests/integration/standard/test_types.py", line 583, in test_nested_tuples
    s.execute("INSERT INTO mytable (k, v_%s) VALUES (%s, %s)", (i, i, created_tuple))
  File "/Users/joaquin/repos/python-driver/cassandra/cluster.py", line 1233, in execute
    result = future.result(timeout)
  File "/Users/joaquin/repos/python-driver/cassandra/cluster.py", line 2674, in result
    raise self._final_exception
InvalidRequest: code=2200 [Invalid query] message="Invalid tuple literal for v_2: component 0 is not of type tuple<int>"
```
