### PR TITLE
Correct import in example for `tuple_factory`.

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -57,7 +57,7 @@ def tuple_factory(colnames, rows):
 
     Example::
 
-        >>> from cassandra.query import named_tuple_factory
+        >>> from cassandra.query import tuple_factory
         >>> session = cluster.connect('mykeyspace')
         >>> session.row_factory = tuple_factory
         >>> rows = session.execute("SELECT name, age FROM users LIMIT 1")


### PR DESCRIPTION
The docstring for `tuple_factory` has a small typo where it imports `named_tuple_factory` and not `tuple_factory`, which is imported into the datastax.io auto-docs for the class. 

Just for a sanity, a REPL session to show the error:

``` python
>>> from cassandra.cluster import Cluster 
>>> cluster = Cluster() 
>>> from cassandra.query import named_tuple_factory
>>> session = cluster.connect('nhanes_ks')
>>> session.row_factory = tuple_factory
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'tuple_factory' is not defined
```

Mimicking the docstring change, with prerequisite initialization:

``` python
>>> from cassandra.cluster import Cluster
>>> cluster = Cluster()
>>> from cassandra.query import tuple_factory
>>> session = cluster.connect('nhanes_ks')
>>> session.row_factory = tuple_factory
>>> rows = session.execute("SELECT name, age FROM nhanes LIMIT 1;")
>>> rows = session.execute("SELECT age, gender, goiter FROM nhanes LIMIT 1;")
>>> rows
[(50, u'Male', None)]
```
