### PR TITLE
Test nested registered udts

### DIFF
--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -239,7 +239,6 @@ class TypeTests(unittest.TestCase):
         else:
             return udts[i](self.nested_udt_helper(udts, i - 1))
 
-
     def test_nested_registered_udts(self):
         """
         Test for ensuring nested udts are handled correctly.
@@ -308,7 +307,16 @@ class TypeTests(unittest.TestCase):
         Test for ensuring nested unregistered udts are handled correctly.
         """
 
-        # is this even possible?
+        # close copy to test_nested_registered_udts
+        pass
+
+    def test_nested_registered_udts_with_different_namedtuples(self):
+        """
+        Test for ensuring nested udts are handled correctly when the
+        created namedtuples are use names that are different the cql type.
+        """
+
+        # close copy to test_nested_registered_udts
         pass
 
     def test_non_existing_types(self):


### PR DESCRIPTION
Here are the datatypes that are created:

```
CREATE TYPE depth_0 (age int, name text)
CREATE TYPE depth_1 (value depth_0)
CREATE TYPE depth_2 (value depth_1)
CREATE TYPE depth_3 (value depth_2)
CREATE TYPE depth_4 (value depth_3)
```

The first line gets written, the second line is result[0]:

```
depth_0(age=42, name='Bob')
{u'v_0': depth_0(age=42, name=u'Bob')}
```

This is the value that throws the exception:

```
depth_1(value=depth_0(age=42, name='Bob'))
```

```
Traceback (most recent call last):
  File "/Users/joaquin/repos/python-driver/tests/integration/standard/test_udts.py", line 303, in test_nested_registered_udts
    s.execute("INSERT INTO mytable (k, v_%s) VALUES (0, %s)", (i, udt))
  File "/Users/joaquin/repos/python-driver/cassandra/cluster.py", line 1255, in execute
    result = future.result(timeout)
  File "/Users/joaquin/repos/python-driver/cassandra/cluster.py", line 2714, in result
    raise self._final_exception
SyntaxException: <ErrorMessage code=2000 [Syntax error in CQL query] message="line 1:70 no viable alternative at input '='">
```
