### PR TITLE
type checking for contact_points in Cluster constructor

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -380,7 +380,12 @@ class Cluster(object):
         Any of the mutable Cluster attributes may be set as keyword arguments
         to the constructor.
         """
-        self.contact_points = contact_points
+        if contact_points is not None:
+            if isinstance(contact_points, six.string_types):
+                raise TypeError("contact_points should not be a string, it should be a sequence (e.g. list) of strings")
+
+            self.contact_points = contact_points
+
         self.port = port
         self.compression = compression
         self.protocol_version = protocol_version


### PR DESCRIPTION
I recently fell prey to passing in a string as the contact_points variable, which led to an error only after calling cluster.connect(), which happens in a for loop that incorrectly attempts connect to each character of the contact_points string. contact_points is expected to be a list or a tuple. I think it would be useful to catch this sort of simple error inside the Cluster constructor, as opposed to delaying the error or hoping that it gets caught when connecting.

P.S. This is my first attempt at contributing to any real open source project. :) Let me know if I am doing something wrong, and I will try to fix it.
