### PR TITLE
Include User Defined Types in KeyspaceMetadata.export_as_string()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Bug Fixes
 * Raise ValueError when tuple query parameters for prepared statements
   have extra items (PYTHON-98)
 * Correctly encode nested tuples and UDTs for non-prepared statements (PYTHON-100)
+* Include User Defined Types in KeyspaceMetadata.export_as_string() (PYTHON-96)
 
 Other
 -----


### PR DESCRIPTION
Adds CREATE TYPE statements to keyspace meta, ordered by resolved inter-dependencies.
