### PR TITLE
Set 60 sec timeout for  SELECT and CREATE TYPE queries (PYTHON-118)

### DIFF
--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -275,7 +275,7 @@ class TypeTests(unittest.TestCase):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
         MAX_TEST_LENGTH = 16384
-        timeout = 60
+        EXTENDED_QUERY_TIMEOUT = 60
 
         c = Cluster(protocol_version=PROTOCOL_VERSION)
         s = c.connect()
@@ -285,8 +285,9 @@ class TypeTests(unittest.TestCase):
         s.set_keyspace("test_udt_sizes")
 
         # create the seed udt, increase timeout to avoid the query failure on slow systems
-        s.execute("CREATE TYPE lengthy_udt ({})".format(', '.join(['v_{} int'.format(i)
-                                                                   for i in range(MAX_TEST_LENGTH)])), timeout=timeout)
+        s.execute("CREATE TYPE lengthy_udt ({})"
+                  .format(', '.join(['v_{} int'.format(i)
+                                    for i in range(MAX_TEST_LENGTH)])), timeout=EXTENDED_QUERY_TIMEOUT)
 
         # create a table with multiple sizes of nested udts
         # no need for all nested types, only a spot checked few and the largest one
@@ -308,7 +309,7 @@ class TypeTests(unittest.TestCase):
             s.execute("INSERT INTO mytable (k, v) VALUES (0, %s)", (created_udt,))
 
             # verify udt was written and read correctly, increase timeout to avoid the query failure on slow systems
-            result = s.execute("SELECT v FROM mytable WHERE k=0", timeout=timeout)[0]
+            result = s.execute("SELECT v FROM mytable WHERE k=0", timeout=EXTENDED_QUERY_TIMEOUT)[0]
             self.assertEqual(created_udt, result.v)
 
     def nested_udt_helper(self, udts, i):


### PR DESCRIPTION
...oid test failure on slow systems.
