### PR TITLE
Removes warnings of schema disagreements when there aren't any.

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2175,8 +2175,9 @@ class ControlConnection(object):
                 self._time.sleep(0.2)
                 elapsed = self._time.time() - start
 
-            log.warn("Node %s is reporting a schema disagreement: %s",
-                     connection.host, schema_mismatches)
+            if schema_mismatches is not None:
+                log.warn("Node %s is reporting a schema disagreement: %s",
+                         connection.host, schema_mismatches)
             return False
 
     def _get_schema_mismatches(self, peers_result, local_result, local_address):


### PR DESCRIPTION
I was getting a lot of these warning messages in my app:

```
WARNING:cassandra.cluster:Node 127.0.0.1 is reporting a schema disagreement: None
```

But this seems innocuous since there is no actual disagreement (and I'm running with a single C\* node regardless.)
