### PR TITLE
Fix trivial typos ; add example of sending concurrency arg

### DIFF
--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -100,7 +100,7 @@ def execute_concurrent(session, statements_and_parameters, concurrency=100, rais
         return results
 
 
-def execute_concurrent_with_args(session, statement, parameters, concurrency=100, raise_on_first_error=True):
+def execute_concurrent_with_args(session, statement, parameters, *args, **kwargs):
     """
     Like :meth:`~cassandra.concurrent.execute_concurrent()`, but takes a single
     statement and a sequence of parameters.  Each item in ``parameters``
@@ -110,9 +110,9 @@ def execute_concurrent_with_args(session, statement, parameters, concurrency=100
 
         statement = session.prepare("INSERT INTO mytable (a, b) VALUES (1, ?)")
         parameters = [(x,) for x in range(1000)]
-        execute_concurrent_with_args(session, statement, parameters)
+        execute_concurrent_with_args(session, statement, parameters, concurrency=50)
     """
-    return execute_concurrent(session, list(zip(cycle((statement,)), parameters)), concurrency=concurrency, raise_on_first_error=True)
+    return execute_concurrent(session, list(zip(cycle((statement,)), parameters)), *args, **kwargs)
 
 
 _sentinel = object()


### PR DESCRIPTION
The first commit wanted to make the concurrency and raise_after_first_error arguments explicit in execute_concurrent_with_args(), due to it being unclear in the api docs that these arguments were supported. In retrospect, they were almost clear and just needed another hint to fix it up.

If, for example, in the future the default value for concurrency became None instead of 100 (so the function could figure out the right default based on the number of hosts and connections per host), we'd have to remember to make this change in both functions instead of one. My first commit proves the point by adding some typos of its own.
