### PR TITLE
Fixes select schema peers query

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1713,7 +1713,7 @@ class ControlConnection(object):
     _SELECT_PEERS = "SELECT peer, data_center, rack, tokens, rpc_address, schema_version FROM system.peers"
     _SELECT_LOCAL = "SELECT cluster_name, data_center, rack, tokens, partitioner, schema_version FROM system.local WHERE key='local'"
 
-    _SELECT_SCHEMA_PEERS = "SELECT rpc_address, schema_version FROM system.peers"
+    _SELECT_SCHEMA_PEERS = "SELECT rpc_address, peer, schema_version FROM system.peers"
     _SELECT_SCHEMA_LOCAL = "SELECT schema_version FROM system.local WHERE key='local'"
 
     _is_shutdown = False


### PR DESCRIPTION
Extends select schema peers query so it selects 'peer' field
and it can be used if rpc_address='0.0.0.0'
