### PR TITLE
PYTHON-166 - Select and use peer address for schema agreement

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2215,7 +2215,7 @@ class ControlConnection(object):
 
             peer = self._cluster.metadata.get_host(addr)
             if peer and peer.is_up:
-                versions[row.get("schema_version")].add(addr)
+                versions[schema_ver].add(addr)
 
         if len(versions) == 1:
             log.debug("[control connection] Schemas match")


### PR DESCRIPTION
Fixes a problem with schema agreement which manifests when rpc_address =
0.0.0.0
