### PR TITLE
Specify "compression = {}" when compression is disabled (PYTHON-187)

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -937,9 +937,8 @@ class TableMetadata(object):
 
         if not options_copy.get('compression'):
             params = json.loads(options_copy.pop('compression_parameters', '{}'))
-            if params:
-                param_strings = ["'%s': '%s'" % (k, v) for k, v in params.items()]
-                ret.append('compression = {%s}' % ', '.join(param_strings))
+            param_strings = ["'%s': '%s'" % (k, v) for k, v in params.items()]
+            ret.append('compression = {%s}' % ', '.join(param_strings))
 
         for name, value in options_copy.items():
             if value is not None:

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -301,6 +301,13 @@ class SchemaMetadataTests(unittest.TestCase):
         self.assertIn('CREATE INDEX d_index', statement)
         self.assertIn('CREATE INDEX e_index', statement)
 
+    def test_compression_disabled(self):
+        create_statement = self.make_create_statement(["a"], ["b"], ["c"])
+        create_statement += " WITH compression = {}"
+        self.session.execute(create_statement)
+        tablemeta = self.get_table_metadata()
+        self.assertIn("compression = {}", tablemeta.export_as_string())
+
 
 class TestCodeCoverage(unittest.TestCase):
 


### PR DESCRIPTION
This was brought up in CASSANDRA-8288.
