### PR TITLE
PYTHON-190 Updated date/time support

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -75,12 +75,12 @@ def unix_time_from_uuid1(u):
     return (u.time - 0x01B21DD213814000) / 10000000.0
 
 
+DATETIME_EPOC = datetime.datetime(1970, 1, 1)
+
+
 def datetime_from_timestamp(timestamp):
-    if timestamp >= 0:
-        dt = datetime.datetime.utcfromtimestamp(timestamp)
-    else:
-        # PYTHON-119: workaround for Windows
-        dt = datetime.datetime(1970, 1, 1) + datetime.timedelta(seconds=timestamp)
+    # PYTHON-119: workaround for Windows
+    dt = DATETIME_EPOC + datetime.timedelta(seconds=timestamp)
     return dt
 
 
@@ -652,7 +652,7 @@ class SimpleDateType(_CassandraType):
     @staticmethod
     def deserialize(byts, protocol_version):
         timestamp = SimpleDateType.seconds_per_day * (uint32_unpack(byts) - 2 ** 31)
-        dt = datetime.datetime.utcfromtimestamp(timestamp)
+        dt = datetime_from_timestamp(timestamp)
         return datetime.date(dt.year, dt.month, dt.day)
 
 

--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -74,6 +74,7 @@ class Encoder(object):
             UUID: self.cql_encode_object,
             datetime.datetime: self.cql_encode_datetime,
             datetime.date: self.cql_encode_date,
+            datetime.time: self.cql_encode_time,
             dict: self.cql_encode_map_collection,
             OrderedDict: self.cql_encode_map_collection,
             list: self.cql_encode_list_collection,
@@ -146,9 +147,16 @@ class Encoder(object):
     def cql_encode_date(self, val):
         """
         Converts a :class:`datetime.date` object to a string with format
-        ``YYYY-MM-DD-0000``.
+        ``YYYY-MM-DD``.
         """
-        return "'%s'" % val.strftime('%Y-%m-%d-0000')
+        return "'%s'" % val.strftime('%Y-%m-%d')
+
+    def cql_encode_time(self, val):
+        """
+        Converts a :class:`datetime.date` object to a string with format
+        ``HH:MM:SS.mmmuuunnn``.
+        """
+        return "'%s'" % val
 
     def cql_encode_sequence(self, val):
         """

--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -28,7 +28,7 @@ import types
 from uuid import UUID
 import six
 
-from cassandra.util import OrderedDict, OrderedMap, sortedset
+from cassandra.util import OrderedDict, OrderedMap, sortedset, Time
 
 if six.PY3:
     long = int
@@ -75,6 +75,7 @@ class Encoder(object):
             datetime.datetime: self.cql_encode_datetime,
             datetime.date: self.cql_encode_date,
             datetime.time: self.cql_encode_time,
+            Time: self.cql_encode_time,
             dict: self.cql_encode_map_collection,
             OrderedDict: self.cql_encode_map_collection,
             OrderedMap: self.cql_encode_map_collection,

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -33,7 +33,8 @@ from cassandra.cqltypes import (AsciiType, BytesType, BooleanType,
                                 InetAddressType, IntegerType, ListType,
                                 LongType, MapType, SetType, TimeUUIDType,
                                 UTF8Type, UUIDType, UserType,
-                                TupleType, lookup_casstype)
+                                TupleType, lookup_casstype, SimpleDateType,
+                                TimeType)
 from cassandra.policies import WriteType
 
 log = logging.getLogger(__name__)
@@ -530,6 +531,8 @@ class ResultMessage(_MessageType):
         0x000E: IntegerType,
         0x000F: TimeUUIDType,
         0x0010: InetAddressType,
+        0x0011: SimpleDateType,
+        0x0012: TimeType,
         0x0020: ListType,
         0x0021: MapType,
         0x0022: SetType,

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -740,6 +740,9 @@ class Time(object):
         if isinstance(other, Time):
             return self.nanosecond_time == other.nanosecond_time
 
+        if isinstance(other, six.integer_types):
+            return self.nanosecond_time == other
+
         return self.nanosecond_time % Time.MICRO == 0 and \
             datetime.time(hour=self.hour, minute=self.minute, second=self.second,
                           microsecond=self.nanosecond // Time.MICRO) == other

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -563,7 +563,7 @@ from six.moves import cPickle
 
 class OrderedMap(Mapping):
     '''
-    An ordered map that accepts non-hashable types for keys. It also maintains the 
+    An ordered map that accepts non-hashable types for keys. It also maintains the
     insertion order of items, behaving as OrderedDict in that regard. These maps
     are constructed and read just as normal mapping types, exept that they may
     contain arbitrary collections and other non-hashable items as keys::
@@ -653,3 +653,97 @@ class OrderedMap(Mapping):
     @staticmethod
     def _serialize_key(key):
         return cPickle.dumps(key)
+
+
+import datetime
+import time
+
+if six.PY3:
+    long = int
+
+
+class Time(object):
+    '''
+    Idealized time, independent of day.
+
+    Up to nanosecond resolution
+    '''
+
+    MICRO = 1000
+    MILLI = 1000 * MICRO
+    SECOND = 1000 * MILLI
+    MINUTE = 60 * SECOND
+    HOUR = 60 * MINUTE
+    DAY = 24 * HOUR
+
+    nanosecond_time = 0
+
+    def __init__(self, value):
+        if isinstance(value, six.integer_types):
+            self._from_timestamp(value)
+        elif isinstance(value, datetime.time):
+            self._from_time(value)
+        elif isinstance(value, six.string_types):
+            self._from_timestring(value)
+        else:
+            raise TypeError('Time arguments must be a whole number, datetime.time, or string')
+
+    @property
+    def hour(self):
+        return self.nanosecond_time // Time.HOUR
+
+    @property
+    def minute(self):
+        minutes = self.nanosecond_time // Time.MINUTE
+        return minutes % 60
+
+    @property
+    def second(self):
+        seconds = self.nanosecond_time // Time.SECOND
+        return seconds % 60
+
+    @property
+    def nanosecond(self):
+        return self.nanosecond_time % Time.SECOND
+
+    def _from_timestamp(self, t):
+        if t >= Time.DAY:
+            raise ValueError("value must be less than number of nanoseconds in a day (%d)" % Time.DAY)
+        self.nanosecond_time = t
+
+    def _from_timestring(self, s):
+        try:
+            parts = s.split('.')
+            base_time = time.strptime(parts[0], "%H:%M:%S")
+            self.nanosecond_time = (base_time.tm_hour * Time.HOUR +
+                                    base_time.tm_min * Time.MINUTE +
+                                    base_time.tm_sec * Time.SECOND)
+
+            if len(parts) > 1:
+                # right pad to 9 digits
+                nano_time_str = parts[1] + "0" * (9 - len(parts[1]))
+                self.nanosecond_time += int(nano_time_str)
+
+        except ValueError:
+            raise ValueError("can't interpret %r as a time" % (s,))
+
+    def _from_time(self, t):
+        self.nanosecond_time = (t.hour * Time.HOUR +
+                                t.minute * Time.MINUTE +
+                                t.second * Time.SECOND +
+                                t.microsecond * Time.MICRO)
+
+    def __eq__(self, other):
+        if isinstance(other, Time):
+            return self.nanosecond_time == other.nanosecond_time
+
+        return self.nanosecond_time % Time.MICRO == 0 and \
+            datetime.time(hour=self.hour, minute=self.minute, second=self.second,
+                          microsecond=self.nanosecond // Time.MICRO) == other
+
+    def __repr__(self):
+        return "Time(%s)" % self.nanosecond_time
+
+    def __str__(self):
+        return "%02d:%02d:%02d.%09d" % (self.hour, self.minute,
+                                        self.second, self.nanosecond)

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -602,7 +602,7 @@ class OrderedMap(Mapping):
             e = args[0]
             if callable(getattr(e, 'keys', None)):
                 for k in e.keys():
-                    self._items.append((k, e[k]))
+                    self._insert(k, e[k])
             else:
                 for k, v in e:
                     self._insert(k, v)
@@ -620,8 +620,11 @@ class OrderedMap(Mapping):
             self._index[flat_key] = len(self._items) - 1
 
     def __getitem__(self, key):
-        index = self._index[self._serialize_key(key)]
-        return self._items[index][1]
+        try:
+            index = self._index[self._serialize_key(key)]
+            return self._items[index][1]
+        except KeyError:
+            raise KeyError(str(key))
 
     def __iter__(self):
         for i in self._items:

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -22,7 +22,7 @@ import logging
 log = logging.getLogger(__name__)
 
 from decimal import Decimal
-from datetime import datetime
+from datetime import datetime, date, time
 import six
 from uuid import uuid1, uuid4
 
@@ -31,7 +31,6 @@ from cassandra.cluster import Cluster
 from cassandra.cqltypes import Int32Type, EMPTY
 from cassandra.query import dict_factory
 from cassandra.util import OrderedDict, sortedset
-from collections import namedtuple
 
 from tests.integration import get_server_versions, use_singledc, PROTOCOL_VERSION
 
@@ -171,6 +170,8 @@ class TypeTests(unittest.TestCase):
         v1_uuid = uuid1()
         v4_uuid = uuid4()
         mydatetime = datetime(2013, 12, 31, 23, 59, 59, 999000)
+        mydate = date(2015, 1, 15)
+        mytime = time(16, 47, 25, 7)
 
         params = [
             "sometext",
@@ -192,12 +193,9 @@ class TypeTests(unittest.TestCase):
             v1_uuid,  # timeuuid
             u"sometext\u1234",  # varchar
             123456789123456789123456789,  # varint
-            '2014-01-01', # date
-            '01:02:03.456789012' # time
+            mydate,  # date
+            mytime
         ]
-
-        SimpleDate = namedtuple('SimpleDate', 'value')
-        Time = namedtuple('Time', 'value')
 
         expected_vals = (
             "sometext",
@@ -219,8 +217,8 @@ class TypeTests(unittest.TestCase):
             v1_uuid,  # timeuuid
             u"sometext\u1234",  # varchar
             123456789123456789123456789,  # varint
-            SimpleDate(2147499719), # date
-            Time(3723456789012) # time
+            mydate,  # date
+            60445000007000  # time
         )
 
         s.execute("""

--- a/tests/unit/test_marshalling.py
+++ b/tests/unit/test_marshalling.py
@@ -19,7 +19,7 @@ except ImportError:
     import unittest  # noqa
 
 import platform
-from datetime import datetime
+from datetime import datetime, date
 from decimal import Decimal
 from uuid import UUID
 
@@ -79,8 +79,9 @@ marshalled_value_pairs = (
     (b'\x00\x00', 'ListType(FloatType)', []),
     (b'\x00\x00', 'SetType(IntegerType)', sortedset()),
     (b'\x00\x01\x00\x10\xafYC\xa3\xea<\x11\xe1\xabc\xc4,\x03"y\xf0', 'ListType(TimeUUIDType)', [UUID(bytes=b'\xafYC\xa3\xea<\x11\xe1\xabc\xc4,\x03"y\xf0')]),
-    (b'\x00\x00>\xc7', 'SimpleDateType', '2014-01-01'),
-    (b'\x00\x00\x00\x00\x00\x00\x00\x01', 'TimeType', '00:00:00.000000001')
+    (b'\x80\x00\x00\x01', 'SimpleDateType', date(1970,1,2)),
+    (b'\x7f\xff\xff\xff', 'SimpleDateType', date(1969,12,31)),
+    (b'\x00\x00\x00\x00\x00\x00\x00\x01', 'TimeType', 1)
 )
 
 ordered_dict_value = OrderedDict()

--- a/tests/unit/test_marshalling.py
+++ b/tests/unit/test_marshalling.py
@@ -24,7 +24,7 @@ from decimal import Decimal
 from uuid import UUID
 
 from cassandra.cqltypes import lookup_casstype
-from cassandra.util import OrderedMap, sortedset
+from cassandra.util import OrderedMap, sortedset, Time
 
 marshalled_value_pairs = (
     # binary form, type, python native type
@@ -81,7 +81,7 @@ marshalled_value_pairs = (
     (b'\x00\x01\x00\x10\xafYC\xa3\xea<\x11\xe1\xabc\xc4,\x03"y\xf0', 'ListType(TimeUUIDType)', [UUID(bytes=b'\xafYC\xa3\xea<\x11\xe1\xabc\xc4,\x03"y\xf0')]),
     (b'\x80\x00\x00\x01', 'SimpleDateType', date(1970,1,2)),
     (b'\x7f\xff\xff\xff', 'SimpleDateType', date(1969,12,31)),
-    (b'\x00\x00\x00\x00\x00\x00\x00\x01', 'TimeType', 1)
+    (b'\x00\x00\x00\x00\x00\x00\x00\x01', 'TimeType', Time(1))
 )
 
 ordered_map_value = OrderedMap([(u'\u307fbob', 199),

--- a/tests/unit/test_marshalling.py
+++ b/tests/unit/test_marshalling.py
@@ -79,6 +79,8 @@ marshalled_value_pairs = (
     (b'\x00\x00', 'ListType(FloatType)', []),
     (b'\x00\x00', 'SetType(IntegerType)', sortedset()),
     (b'\x00\x01\x00\x10\xafYC\xa3\xea<\x11\xe1\xabc\xc4,\x03"y\xf0', 'ListType(TimeUUIDType)', [UUID(bytes=b'\xafYC\xa3\xea<\x11\xe1\xabc\xc4,\x03"y\xf0')]),
+    (b'\x00\x00>\xc7', 'SimpleDateType', '2014-01-01'),
+    (b'\x00\x00\x00\x00\x00\x00\x00\x01', 'TimeType', '00:00:00.000000001')
 )
 
 ordered_dict_value = OrderedDict()

--- a/tests/unit/test_orderedmap.py
+++ b/tests/unit/test_orderedmap.py
@@ -32,6 +32,11 @@ class OrderedMapTest(unittest.TestCase):
         self.assertEqual(a, builtin)
         self.assertEqual(OrderedMap([(1, 1), (1, 2)]), {1: 2})
 
+        d = OrderedMap({'': 3}, key1='v1', key2='v2')
+        self.assertEqual(d[''], 3)
+        self.assertEqual(d['key1'], 'v1')
+        self.assertEqual(d['key2'], 'v2')
+
     def test_contains(self):
         keys = ['first', 'middle', 'last']
 

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -128,56 +128,77 @@ class TypeTests(unittest.TestCase):
         """
         Test cassandra.cqltypes.SimpleDateType() construction
         """
+        # from string
+        expected_date = datetime.date(1492, 10, 12)
+        sd = SimpleDateType('1492-10-12')
+        self.assertEqual(sd.val, expected_date)
 
-        nd = SimpleDateType.interpret_simpledate_string('2014-01-01')
-        tval = time.strptime('2014-01-01', SimpleDateType.date_format)
-        manual = calendar.timegm(tval) / SimpleDateType.seconds_per_day
-        self.assertEqual(nd, manual)
+        # date
+        sd = SimpleDateType(expected_date)
+        self.assertEqual(sd.val, expected_date)
 
-        nd = SimpleDateType.interpret_simpledate_string('1970-01-01')
-        self.assertEqual(nd, 0)
+        # int
+        expected_timestamp = calendar.timegm(expected_date.timetuple())
+        sd = SimpleDateType(expected_timestamp)
+        self.assertEqual(sd.val, expected_timestamp)
+
+        # no contruct
+        self.assertRaises(ValueError, SimpleDateType, '1999-10-10-bad-time')
+        self.assertRaises(TypeError, SimpleDateType, 1.234)
 
     def test_time(self):
         """
         Test cassandra.cqltypes.TimeType() construction
         """
-
         one_micro = 1000
-        one_milli = 1000L*one_micro
-        one_second = 1000L*one_milli
-        one_minute = 60L*one_second
-        one_hour = 60L*one_minute
+        one_milli = 1000 * one_micro
+        one_second = 1000 * one_milli
+        one_minute = 60 * one_second
+        one_hour = 60 * one_minute
 
-        nd = TimeType.interpret_timestring('00:00:00.000000001')
-        self.assertEqual(nd, 1)
-        nd = TimeType.interpret_timestring('00:00:00.000001')
-        self.assertEqual(nd, one_micro)
-        nd = TimeType.interpret_timestring('00:00:00.001')
-        self.assertEqual(nd, one_milli)
-        nd = TimeType.interpret_timestring('00:00:01')
-        self.assertEqual(nd, one_second)
-        nd = TimeType.interpret_timestring('00:01:00')
-        self.assertEqual(nd, one_minute)
-        nd = TimeType.interpret_timestring('01:00:00')
-        self.assertEqual(nd, one_hour)
+        # from strings
+        tt = TimeType('00:00:00.000000001')
+        self.assertEqual(tt.val, 1)
+        tt = TimeType('00:00:00.000001')
+        self.assertEqual(tt.val, one_micro)
+        tt = TimeType('00:00:00.001')
+        self.assertEqual(tt.val, one_milli)
+        tt = TimeType('00:00:01')
+        self.assertEqual(tt.val, one_second)
+        tt = TimeType('00:01:00')
+        self.assertEqual(tt.val, one_minute)
+        tt = TimeType('01:00:00')
+        self.assertEqual(tt.val, one_hour)
+        tt = TimeType('01:00:00.')
+        self.assertEqual(tt.val, one_hour)
 
-        nd = TimeType('23:59:59.1')
-        nd = TimeType('23:59:59.12')
-        nd = TimeType('23:59:59.123')
-        nd = TimeType('23:59:59.1234')
-        nd = TimeType('23:59:59.12345')
+        tt = TimeType('23:59:59.1')
+        tt = TimeType('23:59:59.12')
+        tt = TimeType('23:59:59.123')
+        tt = TimeType('23:59:59.1234')
+        tt = TimeType('23:59:59.12345')
 
-        nd = TimeType.interpret_timestring('23:59:59.123456')
-        self.assertEquals(nd, 23*one_hour + 59*one_minute + 59*one_second + 123*one_milli + 456*one_micro)
+        tt = TimeType('23:59:59.123456')
+        self.assertEqual(tt.val, 23*one_hour + 59*one_minute + 59*one_second + 123*one_milli + 456*one_micro)
 
-        nd = TimeType.interpret_timestring('23:59:59.1234567')
-        self.assertEquals(nd, 23*one_hour + 59*one_minute + 59*one_second + 123*one_milli + 456*one_micro + 700)
+        tt = TimeType('23:59:59.1234567')
+        self.assertEqual(tt.val, 23*one_hour + 59*one_minute + 59*one_second + 123*one_milli + 456*one_micro + 700)
 
-        nd = TimeType.interpret_timestring('23:59:59.12345678')
-        self.assertEquals(nd, 23*one_hour + 59*one_minute + 59*one_second + 123*one_milli + 456*one_micro + 780)
+        tt = TimeType('23:59:59.12345678')
+        self.assertEqual(tt.val, 23*one_hour + 59*one_minute + 59*one_second + 123*one_milli + 456*one_micro + 780)
 
-        nd = TimeType.interpret_timestring('23:59:59.123456789')
-        self.assertEquals(nd, 23*one_hour + 59*one_minute + 59*one_second + 123*one_milli + 456*one_micro + 789)
+        tt = TimeType('23:59:59.123456789')
+        self.assertEqual(tt.val, 23*one_hour + 59*one_minute + 59*one_second + 123*one_milli + 456*one_micro + 789)
+
+        # from int
+        tt = TimeType(12345678)
+        self.assertEqual(tt.val, 12345678)
+
+        # no construct
+        self.assertRaises(ValueError, TimeType, '1999-10-10 11:11:11.1234')
+        self.assertRaises(TypeError, TimeType, 1.234)
+        self.assertRaises(TypeError, TimeType, datetime.datetime(2004, 12, 23, 11, 11, 1))
+
 
     def test_cql_typename(self):
         """

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -11,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import tempfile
-
 try:
     import unittest2 as unittest
 except ImportError:
@@ -21,18 +19,20 @@ except ImportError:
 from binascii import unhexlify
 import calendar
 import datetime
+import tempfile
 import time
+
 import cassandra
 from cassandra.cqltypes import (BooleanType, lookup_casstype_simple, lookup_casstype,
                                 LongType, DecimalType, SetType, cql_typename,
                                 CassandraType, UTF8Type, parse_casstype_args,
                                 SimpleDateType, TimeType,
                                 EmptyValue, _CassandraType, DateType, int64_pack)
-from cassandra.query import named_tuple_factory
+from cassandra.encoder import cql_quote
 from cassandra.protocol import (write_string, read_longstring, write_stringmap,
                                 read_stringmap, read_inet, write_inet,
                                 read_string, write_longstring)
-from cassandra.encoder import cql_quote
+from cassandra.query import named_tuple_factory
 
 
 class TypeTests(unittest.TestCase):


### PR DESCRIPTION
Superset of https://github.com/datastax/python-driver/pull/241

Updated to map native types to cql types.

The integration test will probably not be merged until we find out what versions of C* will have these types to test against.

I had some general difficulty testing against this branch due to some apparently unrelated server-side errors.
https://github.com/josh-mckenzie/cassandra/compare/7523_squashed