### PR TITLE
PYTHON-195 - Return connection to pool after set keyspace

### DIFF
--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -355,6 +355,7 @@ class HostConnection(object):
             return
 
         def connection_finished_setting_keyspace(conn, error):
+            self.return_connection(conn)
             errors = [] if not error else [error]
             callback(self, errors)
 
@@ -683,6 +684,7 @@ class HostConnectionPool(object):
             return
 
         def connection_finished_setting_keyspace(conn, error):
+            self.return_connection(conn)
             remaining_callbacks.remove(conn)
             if error:
                 errors.append(error)


### PR DESCRIPTION
PYTHON-195
Fixes a problem where connection.in_flight count leaks when keyspace
changes due to session.set_keyspace or 'USE' statements.