### PR TITLE
enable collections inside UDTs via freezing Tuple

### DIFF
--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -580,7 +580,6 @@ class TypeTests(unittest.TestCase):
         """
         Test for inserting various types of DATA_TYPE_NON_PRIMITIVE into UDT's
         """
-        raise unittest.SkipTest("Collections are not allowed in UDTs")
         c = Cluster(protocol_version=PROTOCOL_VERSION)
         s = c.connect()
 
@@ -599,6 +598,9 @@ class TypeTests(unittest.TestCase):
                 if nonprim_datatype == "map":
                     type_string = "{0}_{1} {2}<{3}, {3}>".format(chr(start_index + i), chr(start_index + j),
                                                                  nonprim_datatype, datatype)
+                elif nonprim_datatype == "tuple":
+                    type_string = "{0}_{1} frozen<{2}<{3}>>".format(chr(start_index + i), chr(start_index + j),
+                                                            nonprim_datatype, datatype)
                 else:
                     type_string = "{0}_{1} {2}<{3}>".format(chr(start_index + i), chr(start_index + j),
                                                             nonprim_datatype, datatype)


### PR DESCRIPTION
Collection datatypes are allowed inside UDT's as the UDT itself is frozen, which freezes the collections inside. This is true for all collection types except for Tuple, which must be declared as frozen<> explicitly.