### PR TITLE
Fast deserialization of results

### DIFF
--- a/ccassandra/buffer.hpp
+++ b/ccassandra/buffer.hpp
@@ -1,0 +1,78 @@
+#ifndef __PYCCASSANDRA_BUFFER
+#define __PYCCASSANDRA_BUFFER
+#include <cstddef>
+
+
+namespace pyccassandra
+{
+    /// Buffer.
+
+    /// Internal buffer structure for accessing raw data safely. The data
+    /// passed to the buffer must remain available for the entire life time of
+    /// the buffer.
+    class Buffer
+    {
+    public:
+        /// Initialize a buffer.
+
+        /// @param data Data.
+        /// @param size Data size in octets.
+        Buffer(const unsigned char* data, std::size_t size)
+            :   _position(data),
+                _residual(size)
+        {
+
+        }
+
+
+        /// Current data position.
+        inline const unsigned char* Position() const
+        {
+            return _position;
+        }
+
+
+        /// Residual data left in the buffer.
+        inline const std::size_t& Residual() const
+        {
+            return _residual;
+        }
+
+
+        /// Advance the current data position.
+        inline void Advance(const std::size_t& amount)
+        {
+            _position += amount;
+            _residual -= amount;
+        }
+
+
+        /// Consume an amount of data from the buffer.
+
+        /// @param amount Amount.
+        /// @returns a pointer to start of the consumed data if sufficient data
+        /// is available, otherwise NULL.
+        inline const unsigned char* Consume(const std::size_t& amount)
+        {
+            if (_residual < amount)
+                return NULL;
+
+            const unsigned char* pos = _position;
+            _position += amount;
+            _residual -= amount;
+            return pos;
+        }
+    private:
+        Buffer(Buffer&);
+        Buffer& operator =(Buffer&);
+
+
+        /// Data position.
+        const unsigned char* _position;
+
+
+        /// Residual data size including the current data position.
+        std::size_t _residual;
+    };
+}
+#endif

--- a/ccassandra/ccassandra.cpp
+++ b/ccassandra/ccassandra.cpp
@@ -1,0 +1,146 @@
+#include <map>
+
+#include "python.hpp"
+#include "marshal.hpp"
+#include "cql_types.hpp"
+
+
+typedef std::map<PyObject*, pyccassandra::CqlType*> PyCqlTypeMap;
+
+
+/// Mapping of pure-Python Cassandra driver CQL types to internal types.
+static PyCqlTypeMap pyCassandraCqlTypeMapping;
+
+
+static PyObject* ccassandra_deserialize_cqltype(PyObject*,
+                                                PyObject* args,
+                                                PyObject* kwargs)
+{
+    Py_ssize_t dataLength;
+    const unsigned char* data;
+    PyObject* pyCqlType;
+    const char* keywords[] =
+    {
+        "data",
+        "cql_type",
+        NULL,
+    };
+
+    if (!PyArg_ParseTupleAndKeywords(args,
+                                     kwargs,
+                                     "s#O",
+                                     const_cast<char**>(keywords),
+                                     &data,
+                                     &dataLength,
+                                     &pyCqlType))
+        return NULL;
+
+    // Find the corresponding CQL type implementation.
+    const PyCqlTypeMap::iterator it =
+        pyCassandraCqlTypeMapping.find(pyCqlType);
+
+    if (it == pyCassandraCqlTypeMapping.end())
+    {
+        PyErr_SetString(PyExc_ValueError, "unsupported CQL type");
+        return NULL;
+    }
+
+    // Deserialize.
+    pyccassandra::Buffer buffer(data, Py_ssize_t(dataLength));
+    return it->second->Deserialize(buffer);
+}
+
+
+static PyMethodDef CcassandraMethods[] =
+{
+    {
+        "deserialize_cqltype",
+        (PyCFunction)ccassandra_deserialize_cqltype,
+        METH_VARARGS | METH_KEYWORDS,
+        "Deserialize a CQL type"
+    },
+    {
+        NULL,
+        NULL,
+        0,
+        NULL
+    }
+};
+
+
+PyMODINIT_FUNC initccassandra(void)
+{
+    // Import the types on which we depend.
+#define IMPORT_PYTHON_MODULE(_to, _name)            \
+    PyObject* _to = PyImport_ImportModule(_name);   \
+    if (!_to)                                       \
+        return
+#define STORE_ATTR(_to, _from, _name)                       \
+    PyObject* _to = PyObject_GetAttrString(_from, _name);   \
+    if (!_to) \
+        return
+
+    IMPORT_PYTHON_MODULE(pyUuid, "uuid");
+    STORE_ATTR(pyUuidUuid, pyUuid, "UUID");
+
+    IMPORT_PYTHON_MODULE(pyDatetime, "datetime");
+    STORE_ATTR(pyDatetimeDatetime, pyDatetime, "datetime");
+
+    IMPORT_PYTHON_MODULE(pyDecimal, "decimal");
+    STORE_ATTR(pyDecimalDecimal, pyDecimal, "Decimal");
+    
+    // Import the pure Python Cassandra driver from Datastax and set up the
+    // mapping.
+    IMPORT_PYTHON_MODULE(pyCassandraCqltypes, "cassandra.cqltypes");
+
+#define MAP_SIMPLE_CQL_TYPE(_py, _cpp)                                  \
+    {                                                                   \
+        STORE_ATTR(pyCqlType, pyCassandraCqltypes, _py);                \
+        pyCassandraCqlTypeMapping[pyCqlType] = new pyccassandra::_cpp(); \
+    }
+
+    MAP_SIMPLE_CQL_TYPE("Int32Type", CqlInt32Type);
+    MAP_SIMPLE_CQL_TYPE("LongType", CqlLongType);
+    MAP_SIMPLE_CQL_TYPE("FloatType", CqlFloatType);
+    MAP_SIMPLE_CQL_TYPE("DoubleType", CqlDoubleType);
+    MAP_SIMPLE_CQL_TYPE("BooleanType", CqlBooleanType);
+    MAP_SIMPLE_CQL_TYPE("BytesType", CqlBytesType);
+    MAP_SIMPLE_CQL_TYPE("AsciiType", CqlAsciiType);
+    MAP_SIMPLE_CQL_TYPE("UTF8Type", CqlUtf8Type);
+    MAP_SIMPLE_CQL_TYPE("VarcharType", CqlVarcharType);
+    MAP_SIMPLE_CQL_TYPE("CounterColumnType", CqlCounterColumnType);
+    MAP_SIMPLE_CQL_TYPE("InetAddressType", CqlInetAddressType);
+    MAP_SIMPLE_CQL_TYPE("IntegerType", CqlIntegerType);
+
+#undef MAP_SIMPLE_CQL_TYPE
+
+    {
+        STORE_ATTR(pyUuidCqlType, pyCassandraCqltypes, "UUIDType");
+        STORE_ATTR(pyTimeUuidCqlType, pyCassandraCqltypes, "TimeUUIDType");
+        pyccassandra::CqlUuidType* type =
+            new pyccassandra::CqlUuidType(pyUuidUuid);
+        pyCassandraCqlTypeMapping[pyUuidCqlType] = type;
+        pyCassandraCqlTypeMapping[pyTimeUuidCqlType] = type;
+    }
+
+    {
+        STORE_ATTR(pyDateCqlType, pyCassandraCqltypes, "DateType");
+        STORE_ATTR(pyTimestampCqlType, pyCassandraCqltypes, "TimestampType");
+        pyccassandra::CqlType* type =
+            new pyccassandra::CqlDateType(pyDatetimeDatetime);
+        pyCassandraCqlTypeMapping[pyDateCqlType] = type;
+        pyCassandraCqlTypeMapping[pyTimestampCqlType] = type;
+    }
+
+    {
+        STORE_ATTR(pyCqlType, pyCassandraCqltypes, "DecimalType");
+        pyCassandraCqlTypeMapping[pyCqlType] =
+            new pyccassandra::CqlDecimalType(pyDecimalDecimal);
+    }
+
+    // Initialize the module.
+    PyObject* module;
+
+    if (!(module = Py_InitModule("ccassandra", CcassandraMethods)))
+        return;
+}

--- a/ccassandra/config.hpp
+++ b/ccassandra/config.hpp
@@ -1,0 +1,24 @@
+#ifndef __PYCASSANDRA_CONFIG
+#define __PYCASSANDRA_CONFIG
+
+// Endianness test.
+//
+// Currently expects either Clang or GCC, which both set __LITTLE_ENDIAN__ or
+// __BIG_ENDIAN__ to 1 depending on the endianness (we don't give a crap about
+// PGP byte ordering):
+//
+// gcc -E -dM - < /dev/null |grep ENDIAN
+#if __LITTLE_ENDIAN__
+    #define IS_LITTLE_ENDIAN 1
+#elif __BIG_ENDIAN__
+    #define IS_LITTLE_ENDIAN 0
+#else
+    #error Unsupported compiler or endianness.
+#endif
+
+// Type assertions.
+#if CHAR_BIT != 8
+    #error Only octets are supported.
+#endif
+
+#endif

--- a/ccassandra/cql_types.cpp
+++ b/ccassandra/cql_types.cpp
@@ -1,0 +1,235 @@
+#include <arpa/inet.h>
+#include <iostream>
+
+#include "cql_types.hpp"
+#include "marshal.hpp"
+
+
+using namespace pyccassandra;
+
+
+CqlType::~CqlType()
+{
+
+}
+
+
+#define IMPLEMENT_SIMPLE_CQL_TYPE_DESERIALIZE(_cls, _desc, _size, _unmarshal) \
+    PyObject* _cls::Deserialize(Buffer& buffer)                         \
+    {                                                                   \
+        const unsigned char* data = buffer.Consume(_size);              \
+        if (!data)                                                      \
+        {                                                               \
+            PyErr_SetString(PyExc_EOFError,                             \
+                            "unexpected end of buffer deserializing "   \
+                            _desc);                                     \
+            return NULL;                                                \
+        }                                                               \
+                                                                        \
+        return _unmarshal(data);                                        \
+    }
+
+
+IMPLEMENT_SIMPLE_CQL_TYPE_DESERIALIZE(CqlInt32Type,
+                                      "signed 32-bit integer",
+                                      4,
+                                      UnmarshalInt32)
+IMPLEMENT_SIMPLE_CQL_TYPE_DESERIALIZE(CqlLongType,
+                                      "signed 64-bit integer",
+                                      8,
+                                      UnmarshalInt64)
+IMPLEMENT_SIMPLE_CQL_TYPE_DESERIALIZE(CqlFloatType,
+                                      "32-bit floating point number",
+                                      4,
+                                      UnmarshalFloat32)
+IMPLEMENT_SIMPLE_CQL_TYPE_DESERIALIZE(CqlDoubleType,
+                                      "64-bit floating point number",
+                                      8,
+                                      UnmarshalFloat64)
+IMPLEMENT_SIMPLE_CQL_TYPE_DESERIALIZE(CqlBooleanType,
+                                      "boolean",
+                                      1,
+                                      UnmarshalBoolean)
+
+
+#undef IMPLEMENT_SIMPLE_CQL_TYPE_DESERIALIZE
+
+
+PyObject* CqlBytesType::Deserialize(Buffer& buffer)
+{
+    const std::size_t size = buffer.Residual();
+    if (size == 0)
+        return PyString_FromStringAndSize("", 0);
+
+    return PyString_FromStringAndSize((const char*)(buffer.Consume(size)),
+                                      Py_ssize_t(size));
+}
+
+
+PyObject* CqlUtf8Type::Deserialize(Buffer& buffer)
+{
+    const std::size_t size = buffer.Residual();
+    const char* data = (size ?
+                        (const char*)(buffer.Consume(size)) :
+                        "");
+
+    PyObject* str = PyString_FromStringAndSize(data, Py_ssize_t(size));
+    if (!str)
+        return NULL;
+
+    PyObject* dec = PyString_AsDecodedObject(str, "utf-8", "strict");
+
+    Py_DECREF(str);
+
+    return dec;
+}
+
+
+PyObject* CqlUuidType::Deserialize(Buffer& buffer)
+{
+    const std::size_t size = buffer.Residual();
+    const char* data = (size ?
+                        (const char*)(buffer.Consume(size)) :
+                        "");
+
+    PyObject* str = PyString_FromStringAndSize(data, Py_ssize_t(size));
+    if (!str)
+        return NULL;
+
+    PyObject* uuid = NULL;
+    PyObject* args = PyTuple_Pack(2, Py_None, str);
+    if (args)
+    {
+        uuid = PyObject_CallObject(_pythonUuidType, args);
+        Py_DECREF(args);
+    }
+
+    Py_DECREF(str);
+
+    return uuid;
+}
+
+
+PyObject* CqlInetAddressType::Deserialize(Buffer& buffer)
+{
+    const std::size_t size = buffer.Residual();
+
+    if ((size != 4) && (size != 16))
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "expected buffer to either represent a 4 or 16 octet "
+                        "network address");
+        return NULL;
+    }
+
+    const char* data = (size ? (const char*)(buffer.Consume(size)) : NULL);
+    char presentation[INET6_ADDRSTRLEN];
+
+    if (!inet_ntop(size == 4 ? AF_INET : AF_INET6,
+                   data,
+                   presentation,
+                   INET6_ADDRSTRLEN))
+    {
+        PyErr_SetString(PyExc_OSError, "error converting Internet address");
+        return NULL;
+    }
+
+    return PyString_FromString(presentation);
+}
+
+
+PyObject* CqlDateType::Deserialize(Buffer& buffer)
+{
+    const unsigned char* data = buffer.Consume(8);
+    if (!data)
+    {
+        PyErr_SetString(PyExc_EOFError,
+                        "unexpected end of buffer deserializing date");
+        return NULL;
+    }
+
+    int64_t timestampMs = UnpackInt64(data);
+
+    PyObject* pyTimestamp = PyFloat_FromDouble(double(timestampMs) / 1000.0);
+    if (!pyTimestamp)
+        return NULL;
+
+    PyObject* date = NULL;
+    PyObject* args = PyTuple_Pack(1, pyTimestamp);
+    if (args)
+    {
+        date = PyObject_CallObject(_pythonDatetimeUtcFromTimestamp, args);
+        Py_DECREF(args);
+    }
+
+    Py_DECREF(pyTimestamp);
+
+    return date;
+}
+
+
+PyObject* CqlIntegerType::Deserialize(Buffer& buffer)
+{
+    const std::size_t size = buffer.Residual();
+    return UnmarshalVarint(buffer.Consume(size), size);
+}
+
+
+PyObject* CqlDecimalType::Deserialize(Buffer& buffer)
+{
+    PyObject* result = NULL;
+    
+    // Deserialize the scale.
+    const unsigned char* scaleData = buffer.Consume(4);
+    if (!scaleData)
+    {
+        PyErr_SetString(PyExc_EOFError,
+                        "unexpected end of buffer deserializing "
+                        "decimal number");
+        return NULL;
+    }
+    int32_t negativeScale = UnpackInt32(scaleData);
+
+    PyObject* scale = PyInt_FromLong(-negativeScale);
+    if (scale)
+    {
+        // Deserialize the unscaled value.
+        const std::size_t size = buffer.Residual();
+        PyObject* unscaled = UnmarshalVarint(buffer.Consume(size), size);
+        if (unscaled)
+        {
+            // Format the string representation of the decimal number.
+            PyObject* format = PyString_FromString("%de%d");
+            if (format)
+            {
+                PyObject* formatArgs = PyTuple_Pack(2, unscaled, scale);
+                if (formatArgs)
+                {
+                    PyObject* stringRepr = PyString_Format(format, formatArgs);
+                    if (stringRepr)
+                    {
+                        PyObject* args = PyTuple_Pack(1, stringRepr);
+                        if (args)
+                        {
+                            result = PyObject_CallObject(_pythonDecimalType,
+                                                         args);
+                            Py_DECREF(args);
+                        }
+
+                        Py_DECREF(stringRepr);
+                    }
+
+                    Py_DECREF(formatArgs);
+                }
+                
+                Py_DECREF(format);
+            }
+
+            Py_DECREF(unscaled);
+        }
+
+        Py_DECREF(scale);
+    }
+
+    return result;
+}

--- a/ccassandra/cql_types.hpp
+++ b/ccassandra/cql_types.hpp
@@ -1,0 +1,148 @@
+#ifndef __PYCCASSANDRA_CQLTYPES
+#define __PYCCASSANDRA_CQLTYPES
+#include "buffer.hpp"
+#include "python.hpp"
+
+
+namespace pyccassandra
+{
+    /// CQL type.
+    class CqlType
+    {
+    public:
+        CqlType() {}
+        virtual ~CqlType();
+
+
+        /// Deserialize the data type from a buffer.
+
+        /// @param buffer Buffer.
+        /// @returns a pointer to the deserialized Python object representation
+        /// of the value if successful, otherwise NULL, in which case the
+        /// proper Python exception has been set.
+        virtual PyObject* Deserialize(Buffer& buffer) = 0;
+    private:
+        CqlType(CqlType&);
+        CqlType& operator =(CqlType&);
+    };
+
+
+#define DECLARE_SIMPLE_CQL_TYPE_CLASS(_cls)                 \
+    class _cls                                              \
+        :   public CqlType                                  \
+    {                                                       \
+    public:                                                 \
+        _cls()                                              \
+            :   CqlType()                                   \
+        {}                                                  \
+        virtual ~_cls() {}                                  \
+        virtual PyObject* Deserialize(Buffer& buffer);      \
+    }
+
+
+    /// 32-bit signed integer CQL type.
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlInt32Type);
+
+
+    /// 64-bit signed integer CQL type.
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlLongType);
+
+
+    /// Counter column CQL type.
+    typedef CqlLongType CqlCounterColumnType;
+
+
+    /// 32-bit floating point CQL type.
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlFloatType);
+
+
+    /// 64-bit floating point CQL type.
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlDoubleType);
+
+
+    /// Boolean CQL type.
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlBooleanType);
+
+
+    /// Bytes CQL type.
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlBytesType);
+
+
+    /// ASCII CQL type.
+    typedef CqlBytesType CqlAsciiType;
+
+
+    /// UTF-8 CQL type.
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlUtf8Type);
+
+
+    /// Varchar CQL type.
+    typedef CqlUtf8Type CqlVarcharType;
+
+
+    /// Inet address CQL type.
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlInetAddressType);
+
+
+    /// Integer CQL type (varint.)
+    DECLARE_SIMPLE_CQL_TYPE_CLASS(CqlIntegerType);
+
+
+    /// UUID CQL type.
+    class CqlUuidType
+        :   public CqlType
+    {
+    public:
+        CqlUuidType(PyObject* pythonUuidType)
+            :   CqlType(),
+                _pythonUuidType(pythonUuidType)
+        {}
+        virtual ~CqlUuidType() {}
+        virtual PyObject* Deserialize(Buffer& buffer);
+    private:
+        PyObject* _pythonUuidType;
+    };
+
+
+    /// Date CQL type.
+    class CqlDateType
+        :   public CqlType
+    {
+    public:
+        CqlDateType(PyObject* pythonDatetimeType)
+            :   CqlType(),
+                _pythonDatetimeUtcFromTimestamp(
+                    PyObject_GetAttrString(pythonDatetimeType,
+                                           "utcfromtimestamp")
+                )
+        {}
+        virtual ~CqlDateType() {}
+        virtual PyObject* Deserialize(Buffer& buffer);
+    private:
+        PyObject* _pythonDatetimeUtcFromTimestamp;
+    };
+
+    
+    /// Timestamp CQL type.
+    typedef CqlDateType CqlTimestampType;
+
+
+    /// Decimal CQL type.
+    class CqlDecimalType
+        :   public CqlType
+    {
+    public:
+        CqlDecimalType(PyObject* pythonDecimalType)
+            :   CqlType(),
+                _pythonDecimalType(pythonDecimalType)
+        {}
+        virtual ~CqlDecimalType() {}
+        virtual PyObject* Deserialize(Buffer& buffer);
+    private:
+        PyObject* _pythonDecimalType;
+    };
+
+
+#undef DECLARE_SIMPLE_CQL_TYPE_CLASS
+}
+#endif

--- a/ccassandra/marshal.hpp
+++ b/ccassandra/marshal.hpp
@@ -1,0 +1,264 @@
+#ifndef __PYCASSANDRA_MARSHAL
+#define __PYCASSANDRA_MARSHAL
+#include <stdint.h>
+#include <iostream>
+
+#include "python.hpp"
+#include "config.hpp"
+
+
+namespace pyccassandra
+{
+    /// Unpack a 64-bit unsigned integer.
+    inline uint64_t UnpackUint64(const unsigned char* data)
+    {
+        uint64_t val = *((uint64_t*)data);
+
+#if IS_LITTLE_ENDIAN
+        val = (((val << 8) & 0xff00ff00ff00ff00ull) |
+               ((val >> 8) & 0x00ff00ff00ff00ffull));
+        val = (((val << 16) & 0xffff0000ffff0000ull) |
+               ((val >> 16) & 0x0000ffff0000ffffull));
+        return (val << 32) | (val >> 32);
+#else
+        return val;
+#endif
+    }
+
+
+    /// Unpack a 64-bit signed integer.
+    inline int64_t UnpackInt64(const unsigned char* data)
+    {
+        int64_t val = *((int64_t*)data);
+
+#if IS_LITTLE_ENDIAN
+        val = (((val << 8) & 0xff00ff00ff00ff00ull) |
+               ((val >> 8) & 0x00ff00ff00ff00ffull));
+        val = (((val << 16) & 0xffff0000ffff0000ull) |
+               ((val >> 16) & 0x0000ffff0000ffffull));
+        return (val << 32) | ((val >> 32) & 0xffffffffull);
+#else
+        return val;
+#endif
+    }
+
+
+    /// Unpack a 32-bit unsigned integer.
+    inline uint32_t UnpackUint32(const unsigned char* data)
+    {
+        uint32_t val = *((uint32_t*)data);
+
+#if IS_LITTLE_ENDIAN
+        val = ((val << 8) & 0xff00ff00) | ((val >> 8) & 0xff00ff); 
+        return (val << 16) | (val >> 16);
+#else
+        return val;
+#endif
+    }
+
+
+    /// Unpack a 32-bit signed integer.
+    inline int32_t UnpackInt32(const unsigned char* data)
+    {
+        int32_t val = *((int32_t*)data);
+
+#if IS_LITTLE_ENDIAN
+        val = ((val << 8) & 0xff00ff00) | ((val >> 8) & 0xff00ff);
+        return (val << 16) | ((val >> 16) & 0xffff);
+#else
+        return val;
+#endif
+    }
+
+
+    /// Unpack a 16-bit unsigned integer.
+    inline uint16_t UnpackUint16(const unsigned char* data)
+    {
+        uint16_t val = *((uint16_t*)data);
+
+#if IS_LITTLE_ENDIAN
+        return (val << 8) | (val >> 8);
+#else
+        return val;
+#endif
+    }
+
+    
+    /// Unpack a 16-bit signed integer.
+    inline int16_t UnpackInt16(const unsigned char* data)
+    {
+        int16_t val = *((uint16_t*)data);
+
+#if IS_LITTLE_ENDIAN
+        return (val << 8) | ((val >> 8) & 0xff);
+#else
+        return val;
+#endif
+    }
+
+
+    /// Unpack an 8-bit unsigned integer.
+    inline uint8_t UnpackUint8(const unsigned char* data)
+    {
+        return *data;
+    }
+
+
+    /// Unpack an 8-bit signed integer.
+    inline int8_t UnpackInt8(const unsigned char* data)
+    {
+        return *((int8_t*)(data));
+    }
+
+
+    /// Unpack a 64-bit floating point number.
+    inline double UnpackFloat64(const unsigned char* data)
+    {
+        const uint64_t representation = UnpackUint64(data);
+        return *((const double*)(&representation));
+    }
+
+
+    /// Unpack a 32-bit floating point number.
+    inline float UnpackFloat32(const unsigned char* data)
+    {
+        const uint32_t representation = UnpackUint32(data);
+        return *((const float*)(&representation));
+    }
+
+
+    /// Unmarshal a 64-bit unsigned integer to a Python object.
+    inline PyObject* UnmarshalUint64(const unsigned char* data)
+    {
+        return PyLong_FromUnsignedLongLong(UnpackUint64(data));
+    }
+
+
+    /// Unmarshal a 64-bit signed integer to a Python object.
+    inline PyObject* UnmarshalInt64(const unsigned char* data)
+    {
+        return PyLong_FromLongLong(UnpackInt64(data));
+    }
+
+
+    /// Unmarshal a 32-bit unsigned integer to a Python object.
+    inline PyObject* UnmarshalUint32(const unsigned char* data)
+    {
+        return PyInt_FromSize_t(UnpackUint32(data));
+    }
+
+
+    /// Unmarshal a 32-bit signed integer to a Python object.
+    inline PyObject* UnmarshalInt32(const unsigned char* data)
+    {
+        return PyInt_FromLong(UnpackInt32(data));
+    }
+
+
+    /// Unmarshal a 16-bit unsigned integer to a Python object.
+    inline PyObject* UnmarshalUint16(const unsigned char* data)
+    {
+        return PyInt_FromLong(UnpackUint16(data));
+    }
+
+
+    /// Unmarshal a 16-bit signed integer to a Python object.
+    inline PyObject* UnmarshalInt16(const unsigned char* data)
+    {
+        return PyInt_FromLong(UnpackInt16(data));
+    }
+
+
+    /// Unmarshal an 8-bit unsigned integer to a Python object.
+    inline PyObject* UnmarshalUint8(const unsigned char* data)
+    {
+        return PyInt_FromLong(UnpackUint8(data));
+    }
+
+
+    /// Unmarshal an 8-bit signed integer to a Python object.
+    inline PyObject* UnmarshalInt8(const unsigned char* data)
+    {
+        return PyInt_FromLong(UnpackInt8(data));
+    }
+
+
+    /// Unmarshal a 64-bit floating point number to a Python object.
+    inline PyObject* UnmarshalFloat64(const unsigned char* data)
+    {
+        return PyFloat_FromDouble(UnpackFloat64(data));
+    }
+    
+
+    /// Unmarshal a 32-bit floating point number to a Python object.
+    inline PyObject* UnmarshalFloat32(const unsigned char* data)
+    {
+        return PyFloat_FromDouble(UnpackFloat32(data));
+    }
+
+
+    /// Unmarshal a boolean value to a Python object.
+    inline PyObject* UnmarshalBoolean(const unsigned char* data)
+    {
+        return (*data ? Py_True : Py_False);
+    }
+
+
+    /// Unmarshal a variable length integer value to a Python object.
+    inline PyObject* UnmarshalVarint(const unsigned char* data,
+                                     std::size_t size)
+    {
+        if (size == 0)
+            return PyLong_FromLong(0);
+
+        // Allocate a buffer big enough to hold the hex encoded varint. This,
+        // sadly, seems to be the only reliable way of getting Python to eat a
+        // variable length integer.
+        char hexData[size * 2 + 2];
+
+        // Write out the hex data as best as we can.
+        std::size_t dataResidual = size;
+        const unsigned char* dataPosition = data;
+        char* hexPosition = hexData + 1;
+        while (dataResidual--)
+        {
+            const unsigned char in = *dataPosition++;
+            const uint8_t high = in >> 4;
+            const uint8_t low = in & 0xf;
+
+            *hexPosition++ = (high > 9 ? 87 + high : 48 + high);
+            *hexPosition++ = (low > 9 ? 87 + low : 48 + low);
+        }
+
+        *hexPosition = 0;
+
+        // Create the naive Python representation.
+        PyObject* repr = PyInt_FromString(hexData + 1, NULL, 16);
+        if (!repr)
+            return NULL;
+
+        // If this is a negative number, we need to do some work here.
+        if (data[0] & 128)
+        {
+            // Let's construct the subtractor to get the resulting negative
+            // number.
+            hexData[0] = '1';
+            memset(hexData + 1, '0', size * 2);
+
+            PyObject* result = NULL;
+            PyObject* subt = PyInt_FromString(hexData, NULL, 16);
+            if (subt)
+            {
+                result = PyNumber_Subtract(repr, subt);
+                Py_DECREF(subt);
+            }
+
+            Py_DECREF(repr);
+
+            return result;
+        }
+        else
+            return repr;
+    }
+}
+#endif

--- a/ccassandra/python.hpp
+++ b/ccassandra/python.hpp
@@ -1,0 +1,2 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>

--- a/setup.py
+++ b/setup.py
@@ -123,6 +123,11 @@ libev_ext = Extension('cassandra.io.libevwrapper',
                       libraries=['ev'],
                       library_dirs=['/usr/local/lib', '/opt/local/lib'])
 
+ccassandra_ext = Extension('ccassandra',
+                           sources=[
+                               'ccassandra/ccassandra.cpp',
+                               'ccassandra/cql_types.cpp',
+                           ])
 
 class build_extensions(build_ext):
 
@@ -226,7 +231,7 @@ def run_setup(extensions):
         ],
         **kw)
 
-extensions = [murmur3_ext, libev_ext]
+extensions = [murmur3_ext, libev_ext, ccassandra_ext]
 if "--no-extensions" in sys.argv:
     sys.argv = [a for a in sys.argv if a != "--no-extensions"]
     extensions = []
@@ -236,6 +241,9 @@ elif "--no-murmur3" in sys.argv:
 elif "--no-libev" in sys.argv:
     sys.argv = [a for a in sys.argv if a != "--no-libev"]
     extensions.remove(libev_ext)
+elif "--no-ccassandra" in sys.argv:
+    sys.argv = [a for a in sys.argv if a != "--no-ccassandra"]
+    extensions.remove(ccassandra_ext)
 
 
 platform_unsupported_msg = \


### PR DESCRIPTION
## Step 1: implement fast deserializers for CQL types

- [X] AsciiType
- [X] BooleanType
- [X] BytesType
- [ ] ColumnToCollectionType
- [ ] CompositeType
- [X] CounterColumnType
- [X] DateType
- [X] DecimalType
- [X] DoubleType
- [ ] DynamicCompositeType
- [X] FloatType
- [ ] FrozenType
- [X] InetAddressType
- [X] Int32Type
- [X] IntegerType
- [ ] ListType
- [X] LongType
- [ ] MapType
- [ ] ReversedType
- [ ] SetType
- [X] TimeUUIDType
- [X] TimestampType
- [ ] TupleType
- [X] UTF8Type
- [X] UUIDType
- [ ] UserType
- [X] VarcharType