### PR TITLE
PYTHON-213 - CQL export refinement for legacy tables

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -291,11 +291,7 @@ class _CassandraType(object):
             cname = apache_cassandra_type_prefix + cname
         if not subtypes:
             return cname
-        fieldnames = getattr(cls, 'fieldnames', None)
-        if fieldnames and any(fieldnames):
-            sublist = ', '.join('%s=>%s' % (field_name, subtype.cass_parameterized_type(full=full)) for (field_name, subtype) in zip(fieldnames, subtypes))
-        else:
-            sublist = ', '.join(styp.cass_parameterized_type(full=full) for styp in subtypes)
+        sublist = ', '.join(styp.cass_parameterized_type(full=full) for styp in subtypes)
         return '%s(%s)' % (cname, sublist)
 
     @classmethod
@@ -1032,6 +1028,18 @@ class CompositeType(_CompositeType):
 
 class DynamicCompositeType(_CompositeType):
     typename = "'org.apache.cassandra.db.marshal.DynamicCompositeType'"
+
+    @classmethod
+    def cass_parameterized_type_with(cls, subtypes, full=False):
+        fieldnames = getattr(cls, 'fieldnames', None)
+        if fieldnames and any(fieldnames):
+            cname = cls.cassname
+            if full and '.' not in cname:
+                cname = apache_cassandra_type_prefix + cname
+            sublist = ', '.join('%s=>%s' % (field_name, subtype.cass_parameterized_type(full=full)) for (field_name, subtype) in zip(cls.fieldnames, subtypes))
+            return '%s(%s)' % (cname, sublist)
+        else:
+            return super(DynamicCompositeType, cls).cass_parameterized_type_with(subtypes, full)
 
 
 class ColumnToCollectionType(_ParameterizedType):

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -291,7 +291,11 @@ class _CassandraType(object):
             cname = apache_cassandra_type_prefix + cname
         if not subtypes:
             return cname
-        sublist = ', '.join(styp.cass_parameterized_type(full=full) for styp in subtypes)
+        fieldnames = getattr(cls, 'fieldnames', None)
+        if fieldnames and any(fieldnames):
+            sublist = ', '.join('%s=>%s' % (field_name, subtype.cass_parameterized_type(full=full)) for (field_name, subtype) in zip(fieldnames, subtypes))
+        else:
+            sublist = ', '.join(styp.cass_parameterized_type(full=full) for styp in subtypes)
         return '%s(%s)' % (cname, sublist)
 
     @classmethod
@@ -996,15 +1000,11 @@ class UserType(TupleType):
         return nt
 
 
-class CompositeType(_ParameterizedType):
-    typename = "'org.apache.cassandra.db.marshal.CompositeType'"
+class _CompositeType(_ParameterizedType):
     num_subtypes = 'UNKNOWN'
 
     @classmethod
     def cql_parameterized_type(cls):
-        """
-        There is no CQL notation for Composites, so we override this.
-        """
         typestring = cls.cass_parameterized_type(full=True)
         return "'%s'" % (typestring,)
 
@@ -1026,7 +1026,11 @@ class CompositeType(_ParameterizedType):
         return tuple(result)
 
 
-class DynamicCompositeType(CompositeType):
+class CompositeType(_CompositeType):
+    typename = "'org.apache.cassandra.db.marshal.CompositeType'"
+
+
+class DynamicCompositeType(_CompositeType):
     typename = "'org.apache.cassandra.db.marshal.DynamicCompositeType'"
 
 

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -336,15 +336,16 @@ class Metadata(object):
                 is_compact = True
                 has_value = column_aliases or not cf_col_rows
                 clustering_size = num_column_name_components
-
-                # Some thrift tables define names in composite types (see PYTHON-192)
-                if not column_aliases and hasattr(comparator, 'fieldnames'):
-                    column_aliases = comparator.fieldnames
         else:
             is_compact = True
-            if column_aliases or not cf_col_rows:
+
+            # Unrecognized comparator types are used verbatim as the clustering column.
+            # Need to test directly in case the thrift CF also defines static index columns
+            # (which are not expressible in CQL as of C* 2.1.3).
+            # See PYTHON-213 for more background.
+            if column_aliases or not cf_col_rows or issubclass(comparator, (types._UnrecognizedType, types.DynamicCompositeType)):
                 has_value = True
-                clustering_size = num_column_name_components
+                clustering_size = 1
             else:
                 has_value = False
                 clustering_size = 0
@@ -408,6 +409,9 @@ class Metadata(object):
                 if value_alias is None and value_alias_rows:  # CASSANDRA-8487
                     # In 2.0+, we can use the 'type' column. In 3.0+, we have to use it.
                     value_alias = value_alias_rows[0].get('column_name')
+            # Sometimes a value is required, even though no alias is specified. If
+            # we 'has_value', use the default alias. PYTHON-213 for background.
+            value_alias = value_alias or "value"
 
             default_validator = row.get("default_validator")
             if default_validator:
@@ -416,8 +420,8 @@ class Metadata(object):
                 if value_alias_rows:  # CASSANDRA-8487
                     validator = types.lookup_casstype(value_alias_rows[0].get('validator'))
 
-            col = ColumnMetadata(table_meta, value_alias, validator)
-            if value_alias:  # CASSANDRA-8487
+            if value_alias and validator:  # CASSANDRA-8487
+                col = ColumnMetadata(table_meta, value_alias, validator)
                 table_meta.columns[value_alias] = col
 
         # other normal columns
@@ -1225,14 +1229,11 @@ class TableMetadata(object):
         """
         A boolean indicating if this table can be represented as CQL in export
         """
-        # no such thing as DCT in CQL
-        incompatible = issubclass(self.comparator, types.DynamicCompositeType)
-
-        # no compact storage with more than one column beyond PK if there
-        # are clustering columns
-        incompatible |= (self.is_compact_storage and
-                         len(self.columns) > len(self.primary_key) + 1 and
-                         len(self.clustering_key) >= 1)
+        # no compact storage with more than one column beyond PK
+        composite_primary = bool(self.clustering_key)
+        incompatible = (self.is_compact_storage and 
+                        composite_primary and
+                        len(self.columns) > len(self.primary_key) + 1)
 
         return not incompatible
 
@@ -1465,9 +1466,14 @@ class ColumnMetadata(object):
         or "map<string, int>".
         """
         if issubclass(self.data_type, types.ReversedType):
-            return self.data_type.subtypes[0].cql_parameterized_type()
+            typ = self.data_type.subtypes[0]
         else:
-            return self.data_type.cql_parameterized_type()
+            typ = self.data_type
+
+        if issubclass(typ, types._UnrecognizedType):
+            return "'%s'" % typ.cass_parameterized_type()
+        else:
+            return typ.cql_parameterized_type()
 
     def __str__(self):
         return "%s %s" % (self.name, self.data_type)

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -413,6 +413,7 @@ class Metadata(object):
             # we 'has_value', use the default alias. PYTHON-213 for background.
             value_alias = value_alias or "value"
 
+            validator = None
             default_validator = row.get("default_validator")
             if default_validator:
                 validator = types.lookup_casstype(default_validator)
@@ -1231,7 +1232,7 @@ class TableMetadata(object):
         """
         # no compact storage with more than one column beyond PK
         composite_primary = bool(self.clustering_key)
-        incompatible = (self.is_compact_storage and 
+        incompatible = (self.is_compact_storage and
                         composite_primary and
                         len(self.columns) > len(self.primary_key) + 1)
 

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -662,7 +662,7 @@ class TestCodeCoverage(unittest.TestCase):
                 "Protocol 3.0+ is required for UDT change events, currently testing against %r"
                 % (PROTOCOL_VERSION,))
 
-        if sys.version_info[0:2] != (2, 7):
+        if sys.version_info[:2] != (2, 7):
             raise unittest.SkipTest('This test compares static strings generated from dict items, which may change orders. Test with 2.7.')
 
         cluster = Cluster(protocol_version=PROTOCOL_VERSION)
@@ -863,7 +863,7 @@ CREATE TABLE export_udts.users (
         if cass_ver >= (2, 2, 0):
             raise unittest.SkipTest('Cannot test cli script on Cassandra 2.2.0+')
 
-        if sys.version_info[0:2] != (2, 7):
+        if sys.version_info[:2] != (2, 7):
             raise unittest.SkipTest('This test compares static strings generated from dict items, which may change orders. Test with 2.7.')
 
         cli_script = """CREATE KEYSPACE legacy
@@ -908,7 +908,7 @@ CREATE COLUMN FAMILY nested_composite_key
 
 create column family composite_comp_no_col
   with column_type = 'Standard'
-  and comparator = 'DynamicCompositeType(t=>org.apache.cassandra.db.marshal.TimeUUIDType,s=>org.apache.cassandra.db.marshal.UTF8Type,b=>org.apache.cassandra.db.marshal.BytesType)'
+  and comparator = 'DynamicCompositeType(t=>TimeUUIDType,s=>UTF8Type,b=>BytesType)'
   and default_validation_class = 'BytesType'
   and key_validation_class = 'BytesType'
   and read_repair_chance = 0.0
@@ -925,7 +925,7 @@ create column family composite_comp_no_col
 
 create column family composite_comp_with_col
   with column_type = 'Standard'
-  and comparator = 'DynamicCompositeType(t=>org.apache.cassandra.db.marshal.TimeUUIDType,s=>org.apache.cassandra.db.marshal.UTF8Type,b=>org.apache.cassandra.db.marshal.BytesType)'
+  and comparator = 'DynamicCompositeType(t=>TimeUUIDType,s=>UTF8Type,b=>BytesType)'
   and default_validation_class = 'BytesType'
   and key_validation_class = 'BytesType'
   and read_repair_chance = 0.0
@@ -963,14 +963,13 @@ Approximate structure, for reference:
 
 CREATE TABLE legacy.composite_comp_with_col (
     key blob,
-    t timeuuid,
-    b blob,
-    s text,
+    column0 'org.apache.cassandra.db.marshal.DynamicCompositeType(b=>org.apache.cassandra.db.marshal.BytesType, s=>org.apache.cassandra.db.marshal.UTF8Type, t=>org.apache.cassandra.db.marshal.TimeUUIDType)',
+    value blob,
     "b@6869746d65776974686d75736963" blob,
     "b@6d616d6d616a616d6d61" blob,
-    PRIMARY KEY (key, t, b, s)
+    PRIMARY KEY (key, column0)
 ) WITH COMPACT STORAGE
-    AND CLUSTERING ORDER BY (t ASC, b ASC, s ASC)
+    AND CLUSTERING ORDER BY (column0 ASC)
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = 'Stores file meta data'
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
@@ -1083,20 +1082,13 @@ CREATE TABLE legacy.simple_no_col (
     AND read_repair_chance = 0.0
     AND speculative_retry = 'NONE';
 
-/*
-Warning: Table legacy.composite_comp_no_col omitted because it has constructs not compatible with CQL (was created via legacy API).
-
-Approximate structure, for reference:
-(this should not be used to reproduce this schema)
-
 CREATE TABLE legacy.composite_comp_no_col (
     key blob,
-    column1 'org.apache.cassandra.db.marshal.DynamicCompositeType(org.apache.cassandra.db.marshal.TimeUUIDType, org.apache.cassandra.db.marshal.BytesType, org.apache.cassandra.db.marshal.UTF8Type)',
-    column2 text,
+    column1 'org.apache.cassandra.db.marshal.DynamicCompositeType(b=>org.apache.cassandra.db.marshal.BytesType, s=>org.apache.cassandra.db.marshal.UTF8Type, t=>org.apache.cassandra.db.marshal.TimeUUIDType)',
     value blob,
-    PRIMARY KEY (key, column1, column1, column2)
+    PRIMARY KEY (key, column1)
 ) WITH COMPACT STORAGE
-    AND CLUSTERING ORDER BY (column1 ASC, column1 ASC, column2 ASC)
+    AND CLUSTERING ORDER BY (column1 ASC)
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = 'Stores file meta data'
     AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
@@ -1108,8 +1100,7 @@ CREATE TABLE legacy.composite_comp_no_col (
     AND memtable_flush_period_in_ms = 0
     AND min_index_interval = 128
     AND read_repair_chance = 0.0
-    AND speculative_retry = 'NONE';
-*/"""
+    AND speculative_retry = 'NONE';"""
 
         ccm = get_cluster()
         ccm.run_cli(cli_script)

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -914,8 +914,6 @@ create column family composite_comp_no_col
   and read_repair_chance = 0.0
   and dclocal_read_repair_chance = 0.1
   and gc_grace = 864000
-  and min_compaction_threshold = 4
-  and max_compaction_threshold = 32
   and compaction_strategy = 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'
   and caching = 'KEYS_ONLY'
   and cells_per_row_to_cache = '0'
@@ -931,8 +929,6 @@ create column family composite_comp_with_col
   and read_repair_chance = 0.0
   and dclocal_read_repair_chance = 0.1
   and gc_grace = 864000
-  and min_compaction_threshold = 4
-  and max_compaction_threshold = 32
   and compaction_strategy = 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'
   and caching = 'KEYS_ONLY'
   and cells_per_row_to_cache = '0'


### PR DESCRIPTION
Treat DCT like other unrecognized types
Improve CQL export for DCT tables
Do not print columns with invalid names
PYTHON-213