### PR TITLE
Stabilize Jenkins on Cassandra 1.2 - 2.0

### DIFF
--- a/tests/integration/standard/test_authentication.py
+++ b/tests/integration/standard/test_authentication.py
@@ -40,7 +40,7 @@ def setup_module():
     ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
     # there seems to be some race, with some versions of C* taking longer to 
     # get the auth (and default user) setup. Sleep here to give it a chance
-    time.sleep(2)
+    time.sleep(10)
 
 
 def teardown_module():

--- a/tests/integration/standard/test_metrics.py
+++ b/tests/integration/standard/test_metrics.py
@@ -86,7 +86,7 @@ class MetricsTests(unittest.TestCase):
             # Test write
             query = SimpleStatement("INSERT INTO test (k, v) VALUES (2, 2)", consistency_level=ConsistencyLevel.ALL)
             with self.assertRaises(WriteTimeout):
-                session.execute(query)
+                session.execute(query, timeout=None)
             self.assertEqual(1, cluster.metrics.stats.write_timeouts)
 
         finally:


### PR DESCRIPTION
Some extra fixes to stabilize older C* versions.