### PR TITLE
catch OperationTimedOut in consistency tests

### DIFF
--- a/tests/integration/long/utils.py
+++ b/tests/integration/long/utils.py
@@ -133,21 +133,21 @@ def ring(node):
 def wait_for_up(cluster, node, wait=True):
     while True:
         host = cluster.metadata.get_host(IP_FORMAT % node)
-        time.sleep(0.1)
         if host and host.is_up:
             log.debug("Done waiting for node %s to be up", node)
             return
         else:
             log.debug("Host is still marked down, waiting")
+            time.sleep(1)
 
 
 def wait_for_down(cluster, node, wait=True):
     log.debug("Waiting for node %s to be down", node)
     while True:
         host = cluster.metadata.get_host(IP_FORMAT % node)
-        time.sleep(0.1)
         if not host or not host.is_up:
             log.debug("Done waiting for node %s to be down", node)
             return
         else:
             log.debug("Host is still marked up, waiting")
+            time.sleep(1)


### PR DESCRIPTION
Catch OperationTimedOut in consistency tests, sleep 1 second in while loops to save CPU cycles.