### PR TITLE
PYTHON-298 - Remove race when adding new host during node/token rebuild

### DIFF
--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -112,7 +112,6 @@ class SchemaMetadataTests(unittest.TestCase):
         self.cluster.control_connection.refresh_schema()
 
         meta = self.cluster.metadata
-        self.assertNotEqual(meta.cluster_ref, None)
         self.assertNotEqual(meta.cluster_name, None)
         self.assertTrue(self.ksname in meta.keyspaces)
         ksmeta = meta.keyspaces[self.ksname]

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -316,7 +316,7 @@ class IndexTest(unittest.TestCase):
         column_meta.name = 'column_name_here'
         column_meta.table.name = 'table_name_here'
         column_meta.table.keyspace.name = 'keyspace_name_here'
-        meta_model = Metadata(Mock())
+        meta_model = Metadata()
 
         row = {'index_name': 'index_name_here', 'index_type': 'index_type_here'}
         index_meta = meta_model._build_index_metadata(column_meta, row)


### PR DESCRIPTION
Fixes an issue where a race could cause None return from
Cluster.add_host during node/token list rebuild.

This would cause None to be inserted into the Token map,
and subsequently blow up TokenAware LBP creating a query plan.

PYTHON-298