### PR TITLE
Limit the amount of iterations we take over rows

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2366,9 +2366,11 @@ class ControlConnection(object):
 
         versions = defaultdict(set)
         if local_result.results:
-            local_row = dict_factory(*local_result.results)[0]
-            if local_row.get("schema_version"):
-                versions[local_row.get("schema_version")].add(local_address)
+            local_row = dict_factory(*local_result.results)
+            if local_row:
+                local_row = local_row[0]
+                if local_row.get("schema_version"):
+                    versions[local_row.get("schema_version")].add(local_address)
 
         for row in peers_result:
             schema_ver = row.get('schema_version')

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -568,16 +568,33 @@ class ResultMessage(_MessageType):
         return cls(kind, results, paging_state)
 
     @classmethod
+    def _get_parsed_rows(cls, column_metadata, coltypes, f, protocol_version):
+        rowcount = read_int(f)
+        column_length = len(column_metadata)
+        for i in range(rowcount):
+            row = cls.recv_row(f, column_length)
+            yield tuple(
+                ctype.from_binary(val, protocol_version)
+                for ctype, val in zip(coltypes, row)
+            )
+
+    @classmethod
     def recv_results_rows(cls, f, protocol_version, user_type_map):
         paging_state, column_metadata = cls.recv_results_metadata(f, user_type_map)
-        rowcount = read_int(f)
-        rows = [cls.recv_row(f, len(column_metadata)) for _ in range(rowcount)]
-        colnames = [c[2] for c in column_metadata]
-        coltypes = [c[3] for c in column_metadata]
-        parsed_rows = [
-            tuple(ctype.from_binary(val, protocol_version)
-                  for ctype, val in zip(coltypes, row))
-            for row in rows]
+        colnames = []
+        coltypes = []
+
+        for c in column_metadata:
+            colnames.append(c[2])
+            coltypes.append(c[3])
+
+        parsed_rows = cls._get_parsed_rows(
+            column_metadata,
+            coltypes,
+            f,
+            protocol_version
+        )
+
         return (paging_state, (colnames, parsed_rows))
 
     @classmethod


### PR DESCRIPTION
This reduces the amount of times we iterate over rows and hopefully speeds up the deserialization process.

This was the before and after profiler with this change:

```
time python single.py 
102326

real	0m4.778s
user	0m2.045s
sys	0m0.049s
```

![before](https://cloud.githubusercontent.com/assets/151924/7463476/b2413b8e-f26e-11e4-8278-d963008d83e3.png)

and after:

```
time python single.py 
102326

real	0m4.302s
user	0m1.881s
sys	0m0.050s
```

![after](https://cloud.githubusercontent.com/assets/151924/7463495/d09d22a0-f26e-11e4-9204-4335fcfd776f.png)
