### PR TITLE
Changes the version of sure, so it can be successfully installed.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ deps = nose
 
 [testenv]
 deps = {[base]deps}
+       sure==1.2.3
        blist
-       sure
 setenv = USE_CASS_EXTERNAL=1
 commands = {envpython} setup.py build_ext --inplace
            nosetests --verbosity=2 tests/unit/


### PR DESCRIPTION
For some reason the new version of sure, cannot be installed by tox when specified as a dependency. Poking around I was able to determine this problem seemed to be introduced in 1.2.4, specifying version 1.2.3 seems to solve the problem for us.