### PR TITLE
PYTHON-291 - Deprecate Cluster.refresh_schema and submit_refresh_schema

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1202,7 +1202,7 @@ class Cluster(object):
         if not self.control_connection.refresh_schema(keyspace, table, schema_agreement_wait=max_schema_agreement_wait):
             raise Exception("Table metadata was not refreshed. See log for details.")
 
-    def refresh_type_metadata(self, keyspace, user_type, max_schema_agreement_wait=None):
+    def refresh_user_type_metadata(self, keyspace, user_type, max_schema_agreement_wait=None):
         """
         Synchronously refresh user defined type metadata.
 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1131,6 +1131,9 @@ class Cluster(object):
 
     def refresh_schema(self, keyspace=None, table=None, usertype=None, max_schema_agreement_wait=None):
         """
+        .. deprecated:: 2.6.0
+            Use refresh_*_metadata instead
+
         Synchronously refresh the schema metadata.
 
         By default, the timeout for this operation is governed by :attr:`~.Cluster.max_schema_agreement_wait`
@@ -1142,17 +1145,71 @@ class Cluster(object):
 
         An Exception is raised if schema refresh fails for any reason.
         """
+        msg = "refresh_schema is deprecated. Use Cluster.refresh_*_metadata instead."
+        warnings.warn(msg, DeprecationWarning)
+        log.warning(msg)
         if not self.control_connection.refresh_schema(keyspace, table, usertype, max_schema_agreement_wait):
             raise Exception("Schema was not refreshed. See log for details.")
 
     def submit_schema_refresh(self, keyspace=None, table=None, usertype=None):
         """
+        .. deprecated:: 2.6.0
+            Use refresh_*_metadata instead
+
         Schedule a refresh of the internal representation of the current
         schema for this cluster.  If `keyspace` is specified, only that
         keyspace will be refreshed, and likewise for `table`.
         """
+        msg = "submit_schema_refresh is deprecated. Use Cluster.refresh_*_metadata instead."
+        warnings.warn(msg, DeprecationWarning)
+        log.warning(msg)
         return self.executor.submit(
             self.control_connection.refresh_schema, keyspace, table, usertype)
+
+    def refresh_schema_metadata(self, max_schema_agreement_wait=None):
+        """
+        Synchronously refresh all schema metadata.
+
+        By default, the timeout for this operation is governed by :attr:`~.Cluster.max_schema_agreement_wait`
+        and :attr:`~.Cluster.control_connection_timeout`.
+
+        Passing max_schema_agreement_wait here overrides :attr:`~.Cluster.max_schema_agreement_wait`.
+
+        Setting max_schema_agreement_wait <= 0 will bypass schema agreement and refresh schema immediately.
+
+        An Exception is raised if schema refresh fails for any reason.
+        """
+        if not self.control_connection.refresh_schema(schema_agreement_wait=max_schema_agreement_wait):
+            raise Exception("Schema metadata was not refreshed. See log for details.")
+
+    def refresh_keyspace_metadata(self, keyspace, max_schema_agreement_wait=None):
+        """
+        Synchronously refresh keyspace metadata. This applies to keyspace-level information such as replication
+        and durability settings. It does not refresh tables, types, etc. contained in the keyspace.
+
+        See :meth:`~.Cluster.refresh_schema_metadata` for description of ``max_schema_agreement_wait`` behavior
+        """
+        if not self.control_connection.refresh_schema(keyspace, schema_agreement_wait=max_schema_agreement_wait):
+            raise Exception("Keyspace metadata was not refreshed. See log for details.")
+
+    def refresh_table_metadata(self, keyspace, table, max_schema_agreement_wait=None):
+        """
+        Synchronously refresh table metadata. This applies to a table, and any triggers or indexes attached
+        to the table.
+
+        See :meth:`~.Cluster.refresh_schema_metadata` for description of ``max_schema_agreement_wait`` behavior
+        """
+        if not self.control_connection.refresh_schema(keyspace, table, schema_agreement_wait=max_schema_agreement_wait):
+            raise Exception("Table metadata was not refreshed. See log for details.")
+
+    def refresh_type_metadata(self, keyspace, user_type, max_schema_agreement_wait=None):
+        """
+        Synchronously refresh user defined type metadata.
+
+        See :meth:`~.Cluster.refresh_schema_metadata` for description of ``max_schema_agreement_wait`` behavior
+        """
+        if not self.control_connection.refresh_schema(keyspace, usertype=user_type, schema_agreement_wait=max_schema_agreement_wait):
+            raise Exception("User Type metadata was not refreshed. See log for details.")
 
     def refresh_nodes(self):
         """

--- a/docs/api/cassandra/cluster.rst
+++ b/docs/api/cassandra/cluster.rst
@@ -71,7 +71,7 @@
 
    .. automethod:: refresh_table_metadata
 
-   .. automethod:: refresh_type_metadata
+   .. automethod:: refresh_user_type_metadata
 
    .. automethod:: refresh_schema
 

--- a/docs/api/cassandra/cluster.rst
+++ b/docs/api/cassandra/cluster.rst
@@ -65,6 +65,14 @@
 
    .. automethod:: set_max_connections_per_host
 
+   .. automethod:: refresh_schema_metadata
+
+   .. automethod:: refresh_keyspace_metadata
+
+   .. automethod:: refresh_table_metadata
+
+   .. automethod:: refresh_type_metadata
+
    .. automethod:: refresh_schema
 
    .. automethod:: refresh_nodes


### PR DESCRIPTION
PYTHON-291
Use Cluster.refresh_*_metadata instead