### PR TITLE
Suggestions for PYTHON-295

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -377,9 +377,23 @@ class Integer(Column):
         return self.validate(value)
 
 
+class TinyInt(Integer):
+    """
+    Stores an 8-bit signed integer value
+    """
+    db_type = 'tinyint'
+
+
+class SmallInt(Integer):
+    """
+    Stores a 16-bit signed integer value
+    """
+    db_type = 'smallint'
+
+
 class BigInt(Integer):
     """
-    Stores a 64-bit signed long value
+    Stores a 64-bit signed integer value
     """
     db_type = 'bigint'
 

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -424,7 +424,7 @@ class BooleanType(_CassandraType):
     def serialize(truth, protocol_version):
         return int8_pack(truth)
 
-class TinyIntType(_CassandraType):
+class ByteType(_CassandraType):
     typename = 'tinyint'
 
     @staticmethod
@@ -661,7 +661,7 @@ class SimpleDateType(_CassandraType):
         return util.Date(days)
 
 
-class SmallIntType(_CassandraType):
+class ShortType(_CassandraType):
     typename = 'smallint'
 
     @staticmethod

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -36,7 +36,7 @@ from cassandra.cqltypes import (AsciiType, BytesType, BooleanType,
                                 LongType, MapType, SetType, TimeUUIDType,
                                 UTF8Type, UUIDType, UserType,
                                 TupleType, lookup_casstype, SimpleDateType,
-                                TimeType, TinyIntType, SmallIntType)
+                                TimeType, ByteType, ShortType)
 from cassandra.policies import WriteType
 
 log = logging.getLogger(__name__)
@@ -623,8 +623,8 @@ class ResultMessage(_MessageType):
         0x0010: InetAddressType,
         0x0011: SimpleDateType,
         0x0012: TimeType,
-        0x0013: SmallIntType,
-        0x0014: TinyIntType,
+        0x0013: ShortType,
+        0x0014: ByteType,
         0x0020: ListType,
         0x0021: MapType,
         0x0022: SetType,


### PR DESCRIPTION
Whilst adding small and tiny ints to cqlsh I noticed that the DESCRIBE command was wrong, the column name was 'org.apache.cassandra.db.marshal.ByteType' instead of 'tinyint' and  'org.apache.cassandra.db.marshal.ShortType' instead of 'smallint'. I think the names of the types in cqltypes.py must match the names in org.apache.cassandra.db.marshal, see lookup_casstype_simple(). Therefore I changed them accordingly.

I also added the columns, but I did not test them.