### PR TITLE
PYTHON-245 - cqle: introduce 'date' and 'time' column types

### DIFF
--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -29,7 +29,7 @@ from uuid import UUID
 import six
 
 from cassandra.util import (OrderedDict, OrderedMap, OrderedMapSerializedKey,
-                            sortedset, Time)
+                            sortedset, Time, Date)
 
 if six.PY3:
     long = int
@@ -76,6 +76,7 @@ class Encoder(object):
             datetime.datetime: self.cql_encode_datetime,
             datetime.date: self.cql_encode_date,
             datetime.time: self.cql_encode_time,
+            Date: self.cql_encode_date_ext,
             Time: self.cql_encode_time,
             dict: self.cql_encode_map_collection,
             OrderedDict: self.cql_encode_map_collection,
@@ -163,10 +164,17 @@ class Encoder(object):
 
     def cql_encode_time(self, val):
         """
-        Converts a :class:`datetime.date` object to a string with format
+        Converts a :class:`cassandra.util.Time` object to a string with format
         ``HH:MM:SS.mmmuuunnn``.
         """
         return "'%s'" % val
+
+    def cql_encode_date_ext(self, val):
+        """
+        Encodes a :class:`cassandra.util.Date` object as an integer
+        """
+        # using the int form in case the Date exceeds datetime.[MIN|MAX]YEAR
+        return str(val.days_from_epoch + 2 ** 31)
 
     def cql_encode_sequence(self, val):
         """

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -917,7 +917,7 @@ class Time(object):
 
 class Date(object):
     '''
-    Idealized naive date: year, month, day
+    Idealized date: year, month, day
 
     Offers wider year range than datetime.date. For Dates that cannot be represented
     as a datetime.date (because datetime.MINYEAR, datetime.MAXYEAR), this type falls back
@@ -997,5 +997,5 @@ class Date(object):
             dt = datetime_from_timestamp(self.seconds)
             return "%04d-%02d-%02d" % (dt.year, dt.month, dt.day)
         except:
-            # If we overflow datetime.[MIN|M
+            # If we overflow datetime.[MIN|MAX]
             return str(self.days_from_epoch)

--- a/docs/api/cassandra/cqlengine/columns.rst
+++ b/docs/api/cassandra/cqlengine/columns.rst
@@ -52,7 +52,7 @@ Columns of all types are initialized by passing :class:`.Column` attributes to t
 
 .. autoclass:: Counter
 
-.. autoclass:: Date(**kwargs)
+.. autoclass:: Date
 
 .. autoclass:: DateTime(**kwargs)
 
@@ -70,9 +70,15 @@ Columns of all types are initialized by passing :class:`.Column` attributes to t
 
 .. autoclass:: Set
 
+.. autoclass:: SmallInt
+
 .. autoclass:: Text
 
+.. autoclass:: Time
+
 .. autoclass:: TimeUUID(**kwargs)
+
+.. autoclass:: TinyInt
 
 .. autoclass:: UserDefinedType
 

--- a/tests/integration/cqlengine/columns/test_value_io.py
+++ b/tests/integration/cqlengine/columns/test_value_io.py
@@ -17,13 +17,13 @@ from decimal import Decimal
 from uuid import uuid1, uuid4, UUID
 import six
 
-from tests.integration.cqlengine.base import BaseCassEngTestCase
-
+from cassandra.cqlengine import columns
 from cassandra.cqlengine.management import sync_table
 from cassandra.cqlengine.management import drop_table
 from cassandra.cqlengine.models import Model
-from cassandra.cqlengine import columns
-import unittest
+from cassandra import util
+
+from tests.integration.cqlengine.base import BaseCassEngTestCase
 
 
 class BaseColumnIOTest(BaseCassEngTestCase):
@@ -151,9 +151,9 @@ class TestDate(BaseColumnIOTest):
 
     column = columns.Date
 
-    now = datetime.now().date()
+    now = util.Date(datetime.now().date())
     pkey_val = now
-    data_val = now + timedelta(days=1)
+    data_val = util.Date(now.days_from_epoch + 1)
 
 
 class TestUUID(BaseColumnIOTest):

--- a/tests/integration/cqlengine/model/test_model_io.py
+++ b/tests/integration/cqlengine/model/test_model_io.py
@@ -17,14 +17,15 @@ import random
 from datetime import date, datetime
 from decimal import Decimal
 from operator import itemgetter
-from cassandra.cqlengine import CQLEngineException
-from tests.integration.cqlengine.base import BaseCassEngTestCase
 
+from cassandra.cqlengine import columns
+from cassandra.cqlengine import CQLEngineException
 from cassandra.cqlengine.management import sync_table
 from cassandra.cqlengine.management import drop_table
 from cassandra.cqlengine.models import Model
-from cassandra.cqlengine import columns
+from cassandra.util import Date
 
+from tests.integration.cqlengine.base import BaseCassEngTestCase
 
 class TestModel(Model):
 
@@ -161,7 +162,7 @@ class TestModelIO(BaseCassEngTestCase):
 
         sync_table(AllDatatypesModel)
 
-        input = ['ascii', 2 ** 63 - 1, bytearray(b'hello world'), True, date(1970, 1, 1),
+        input = ['ascii', 2 ** 63 - 1, bytearray(b'hello world'), True, Date(date(1970, 1, 1)),
                  datetime.utcfromtimestamp(872835240), Decimal('12.3E+7'), 2.39,
                  3.4028234663852886e+38, '123.123.123.123', 2147483647, 'text',
                  UUID('FE2B4360-28C6-11E2-81C1-0800200C9A66'), UUID('067e6162-3b6f-4ae2-a171-2470b63dff00'),

--- a/tests/integration/cqlengine/model/test_udts.py
+++ b/tests/integration/cqlengine/model/test_udts.py
@@ -21,6 +21,7 @@ from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.usertype import UserType
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.management import sync_table, sync_type, create_keyspace_simple, drop_keyspace
+from cassandra.util import Date
 
 from tests.integration import get_server_versions
 from tests.integration.cqlengine.base import BaseCassEngTestCase
@@ -273,7 +274,7 @@ class UserDefinedTypeTests(BaseCassEngTestCase):
 
         sync_table(AllDatatypesModel)
 
-        input = AllDatatypes(a='ascii', b=2 ** 63 - 1, c=bytearray(b'hello world'), d=True, e=date(1970, 1, 1),
+        input = AllDatatypes(a='ascii', b=2 ** 63 - 1, c=bytearray(b'hello world'), d=True, e=Date(date(1970, 1, 1)),
                              f=datetime.utcfromtimestamp(872835240), g=Decimal('12.3E+7'), h=2.39,
                              i=3.4028234663852886e+38, j='123.123.123.123', k=2147483647, l='text',
                              m=UUID('FE2B4360-28C6-11E2-81C1-0800200C9A66'), n=UUID('067e6162-3b6f-4ae2-a171-2470b63dff00'),


### PR DESCRIPTION
Posting before fixing tests to get reviewer input.