### PR TITLE
Suggestions for PYTHON-315

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -167,6 +167,12 @@ class Statement(object):
     this will be set to a :class:`.QueryTrace` instance.
     """
 
+    warnings = None
+    """
+    If :meth:`.Session.execute()` is run with `warnings` set to :const:`True`,
+    this will be set to a list of warnings, if any were returned by the server.
+    """
+
     trace_id = None
     """
     If :meth:`.Session.execute()` is run with `trace` set to :const:`True`,


### PR DESCRIPTION
We don't have access to the future in cqlsh because we call the synchronous Session.execute() method.

I've added the warnings to the statement to keep it in line with what's already done for tracing but feel free to propose an alternative, i.e. returning the warning directly from execute() or other.