### PR TITLE
Check if max_attempts is None for ConstantReconnectionPolicy

### DIFF
--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -509,14 +509,16 @@ class ConstantReconnectionPolicy(ReconnectionPolicy):
         """
         if delay < 0:
             raise ValueError("delay must not be negative")
-        if max_attempts < 0:
+        if max_attempts is not None and max_attempts < 0:
             raise ValueError("max_attempts must not be negative")
 
         self.delay = delay
         self.max_attempts = max_attempts
 
     def new_schedule(self):
-        return repeat(self.delay, self.max_attempts)
+        if self.max_attempts:
+            return repeat(self.delay, self.max_attempts)
+        return repeat(self.delay)
 
 
 class ExponentialReconnectionPolicy(ReconnectionPolicy):


### PR DESCRIPTION
Found some issues with this reconnect policy:
```
class ConstantReconnectionPolicy(ReconnectionPolicy):
    """
    A :class:`.ReconnectionPolicy` subclass which sleeps for a fixed delay
    inbetween each reconnection attempt.
    """

    def __init__(self, delay, max_attempts=64):
        """
        `delay` should be a floating point number of seconds to wait inbetween
        each attempt.

        `max_attempts` should be a total number of attempts to be made before
        giving up, or :const:`None` to continue reconnection attempts forever.
        The default is 64.
        """
        if delay < 0:
            raise ValueError("delay must not be negative")
        if max_attempts < 0:
            raise ValueError("max_attempts must not be negative")

        self.delay = delay
        self.max_attempts = max_attempts

    def new_schedule(self):
        return repeat(self.delay, self.max_attempts)
```
If passing max_attempts=None to ConstantReconnectionPolicy would raise a value error, since None is smaller than 0:

```
In [1]: from cassandra.policies import ConstantReconnectionPolicy

In [2]: policy = ConstantReconnectionPolicy(10, max_attempts=None)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)


<ipython-input-2-763f0e978a2e> in <module>()
----> 1 policy = ConstantReconnectionPolicy(10, max_attempts=None)

/home/tom/Workspace/polaris-storage/.venv-storage/local/lib/python2.7/site-packages/cassandra/policies.py in __init__(self, delay, max_attempts)
    511             raise ValueError("delay must not be negative")
    512         if max_attempts < 0:
--> 513             raise ValueError("max_attempts must not be negative")
    514 
    515         self.delay = delay

ValueError: max_attempts must not be negative
```

And repeat doesn't take None as an argument:
```
In [3]: from itertools import repeat

In [4]: repeat(10, None)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-78a54565c583> in <module>()
----> 1 repeat(10, None)

TypeError: an integer is required
```
