### PR TITLE
Add support for upper case uuid

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -15,7 +15,6 @@
 from copy import deepcopy, copy
 from datetime import date, datetime
 import logging
-import re
 import six
 import warnings
 
@@ -518,8 +517,6 @@ class UUID(Column):
     """
     db_type = 'uuid'
 
-    re_uuid = re.compile(r'[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}')
-
     def validate(self, value):
         val = super(UUID, self).validate(value)
         if val is None:
@@ -527,9 +524,12 @@ class UUID(Column):
         from uuid import UUID as _UUID
         if isinstance(val, _UUID):
             return val
-        if isinstance(val, six.string_types) and self.re_uuid.match(val):
-            return _UUID(val)
-        raise ValidationError("{} {} is not a valid uuid".format(self.column_name, value))
+        if isinstance(val, six.string_types):
+            try:
+                return _UUID(val)
+            except ValueError:
+                raise ValidationError("{} {} is not a valid uuid".format(
+                    self.column_name, value))
 
     def to_python(self, value):
         return self.validate(value)

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -240,6 +240,13 @@ class TestUUID(BaseCassEngTestCase):
         t1 = self.UUIDTest.get(test_id=1)
         assert a_uuid == t1.a_uuid
 
+    def test_uuid_with_upcase(self):
+        a_uuid = uuid4()
+        val = str(a_uuid).upper()
+        t0 = self.UUIDTest.create(test_id=0, a_uuid=val)
+        t1 = self.UUIDTest.get(test_id=0)
+        assert a_uuid == t1.a_uuid
+
 class TestTimeUUID(BaseCassEngTestCase):
     class TimeUUIDTest(Model):
 


### PR DESCRIPTION
Systems like iOS creates uuid in uppercase, while storing to
cassandra one has to convert to lowercase before storing in cassandra.
This is quite difficult for developer to remember, it is better
handle at driver level.