### PR TITLE
PYTHON-288  cqlengine 2.6 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ a
 
 The driver supports Python 2.6, 2.7, 3.3, and 3.4*.
 
-\* cqlengine component presently supports Python 2.7+
+\* cqlengine component presently supports Python 2.6+
 
 Feedback Requested
 ------------------

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -21,6 +21,7 @@ import warnings
 from cassandra import util
 from cassandra.cqltypes import DateType, SimpleDateType
 from cassandra.cqlengine import ValidationError
+from cassandra.cqlengine.functions import get_total_seconds
 
 log = logging.getLogger(__name__)
 
@@ -186,7 +187,7 @@ class Column(object):
         """
         if value is None:
             if self.required:
-                raise ValidationError('{} - None values are not allowed'.format(self.column_name or self.db_field))
+                raise ValidationError('{0} - None values are not allowed'.format(self.column_name or self.db_field))
         return value
 
     def to_python(self, value):
@@ -228,7 +229,7 @@ class Column(object):
         Returns a column definition for CQL table definition
         """
         static = "static" if self.static else ""
-        return '{} {} {}'.format(self.cql, self.db_type, static)
+        return '{0} {1} {2}'.format(self.cql, self.db_type, static)
 
     # TODO: make columns use cqltypes under the hood
     # until then, this bridges the gap in using types along with cassandra.metadata for CQL generation
@@ -250,14 +251,14 @@ class Column(object):
     @property
     def db_index_name(self):
         """ Returns the name of the cql index """
-        return 'index_{}'.format(self.db_field_name)
+        return 'index_{0}'.format(self.db_field_name)
 
     @property
     def cql(self):
         return self.get_cql()
 
     def get_cql(self):
-        return '"{}"'.format(self.db_field_name)
+        return '"{0}"'.format(self.db_field_name)
 
     def _val_is_null(self, val):
         """ determines if the given value equates to a null value for the given column type """
@@ -323,13 +324,13 @@ class Text(Column):
         if value is None:
             return
         if not isinstance(value, (six.string_types, bytearray)) and value is not None:
-            raise ValidationError('{} {} is not a string'.format(self.column_name, type(value)))
+            raise ValidationError('{0} {1} is not a string'.format(self.column_name, type(value)))
         if self.max_length:
             if len(value) > self.max_length:
-                raise ValidationError('{} is longer than {} characters'.format(self.column_name, self.max_length))
+                raise ValidationError('{0} is longer than {1} characters'.format(self.column_name, self.max_length))
         if self.min_length:
             if len(value) < self.min_length:
-                raise ValidationError('{} is shorter than {} characters'.format(self.column_name, self.min_length))
+                raise ValidationError('{0} is shorter than {1} characters'.format(self.column_name, self.min_length))
         return value
 
 
@@ -347,7 +348,7 @@ class Integer(Column):
         try:
             return int(val)
         except (TypeError, ValueError):
-            raise ValidationError("{} {} can't be converted to integral value".format(self.column_name, value))
+            raise ValidationError("{0} {1} can't be converted to integral value".format(self.column_name, value))
 
     def to_python(self, value):
         return self.validate(value)
@@ -399,7 +400,7 @@ class VarInt(Column):
             return int(val)
         except (TypeError, ValueError):
             raise ValidationError(
-                "{} {} can't be converted to integral value".format(self.column_name, value))
+                "{0} {1} can't be converted to integral value".format(self.column_name, value))
 
     def to_python(self, value):
         return self.validate(value)
@@ -463,11 +464,11 @@ class DateTime(Column):
             if isinstance(value, date):
                 value = datetime(value.year, value.month, value.day)
             else:
-                raise ValidationError("{} '{}' is not a datetime object".format(self.column_name, value))
+                raise ValidationError("{0} '{1}' is not a datetime object".format(self.column_name, value))
         epoch = datetime(1970, 1, 1, tzinfo=value.tzinfo)
-        offset = epoch.tzinfo.utcoffset(epoch).total_seconds() if epoch.tzinfo else 0
+        offset = get_total_seconds(epoch.tzinfo.utcoffset(epoch)) if epoch.tzinfo else 0
 
-        return int(((value - epoch).total_seconds() - offset) * 1000)
+        return int((get_total_seconds(value - epoch) - offset) * 1000)
 
 
 class Date(Column):
@@ -530,7 +531,7 @@ class UUID(Column):
             except ValueError:
                 # fall-through to error
                 pass
-        raise ValidationError("{} {} is not a valid uuid".format(
+        raise ValidationError("{0} {1} is not a valid uuid".format(
             self.column_name, value))
 
     def to_python(self, value):
@@ -561,8 +562,8 @@ class TimeUUID(UUID):
         global _last_timestamp
 
         epoch = datetime(1970, 1, 1, tzinfo=dt.tzinfo)
-        offset = epoch.tzinfo.utcoffset(epoch).total_seconds() if epoch.tzinfo else 0
-        timestamp = (dt - epoch).total_seconds() - offset
+        offset = get_total_seconds(epoch.tzinfo.utcoffset(epoch)) if epoch.tzinfo else 0
+        timestamp = get_total_seconds(dt  - epoch) - offset
 
         node = None
         clock_seq = None
@@ -611,7 +612,7 @@ class BaseFloat(Column):
         try:
             return float(value)
         except (TypeError, ValueError):
-            raise ValidationError("{} {} is not a valid float".format(self.column_name, value))
+            raise ValidationError("{0} {1} is not a valid float".format(self.column_name, value))
 
     def to_python(self, value):
         return self.validate(value)
@@ -660,7 +661,7 @@ class Decimal(Column):
         try:
             return _Decimal(val)
         except InvalidOperation:
-            raise ValidationError("{} '{}' can't be coerced to decimal".format(self.column_name, val))
+            raise ValidationError("{0} '{1}' can't be coerced to decimal".format(self.column_name, val))
 
     def to_python(self, value):
         return self.validate(value)
@@ -702,7 +703,7 @@ class BaseContainerColumn(Column):
         # It is dangerous to let collections have more than 65535.
         # See: https://issues.apache.org/jira/browse/CASSANDRA-5428
         if value is not None and len(value) > 65535:
-            raise ValidationError("{} Collection can't have more than 65535 elements.".format(self.column_name))
+            raise ValidationError("{0} Collection can't have more than 65535 elements.".format(self.column_name))
         return value
 
     def _val_is_null(self, val):
@@ -726,7 +727,7 @@ class Set(BaseContainerColumn):
             type on validation, or raise a validation error, defaults to True
         """
         self.strict = strict
-        self.db_type = 'set<{}>'.format(value_type.db_type)
+        self.db_type = 'set<{0}>'.format(value_type.db_type)
         super(Set, self).__init__(value_type, default=default, **kwargs)
 
     def validate(self, value):
@@ -736,24 +737,24 @@ class Set(BaseContainerColumn):
         types = (set,) if self.strict else (set, list, tuple)
         if not isinstance(val, types):
             if self.strict:
-                raise ValidationError('{} {} is not a set object'.format(self.column_name, val))
+                raise ValidationError('{0} {1} is not a set object'.format(self.column_name, val))
             else:
-                raise ValidationError('{} {} cannot be coerced to a set object'.format(self.column_name, val))
+                raise ValidationError('{0} {1} cannot be coerced to a set object'.format(self.column_name, val))
 
         if None in val:
-            raise ValidationError("{} None not allowed in a set".format(self.column_name))
+            raise ValidationError("{0} None not allowed in a set".format(self.column_name))
 
-        return {self.value_col.validate(v) for v in val}
+        return set(self.value_col.validate(v) for v in val)
 
     def to_python(self, value):
         if value is None:
             return set()
-        return {self.value_col.to_python(v) for v in value}
+        return set(self.value_col.to_python(v) for v in value)
 
     def to_database(self, value):
         if value is None:
             return None
-        return {self.value_col.to_database(v) for v in value}
+        return set(self.value_col.to_database(v) for v in value)
 
 
 class List(BaseContainerColumn):
@@ -766,7 +767,7 @@ class List(BaseContainerColumn):
         """
         :param value_type: a column class indicating the types of the value
         """
-        self.db_type = 'list<{}>'.format(value_type.db_type)
+        self.db_type = 'list<{0}>'.format(value_type.db_type)
         return super(List, self).__init__(value_type=value_type, default=default, **kwargs)
 
     def validate(self, value):
@@ -774,9 +775,9 @@ class List(BaseContainerColumn):
         if val is None:
             return
         if not isinstance(val, (set, list, tuple)):
-            raise ValidationError('{} {} is not a list object'.format(self.column_name, val))
+            raise ValidationError('{0} {1} is not a list object'.format(self.column_name, val))
         if None in val:
-            raise ValidationError("{} None is not allowed in a list".format(self.column_name))
+            raise ValidationError("{0} None is not allowed in a list".format(self.column_name))
         return [self.value_col.validate(v) for v in val]
 
     def to_python(self, value):
@@ -802,7 +803,7 @@ class Map(BaseContainerColumn):
         :param value_type: a column class indicating the types of the value
         """
 
-        self.db_type = 'map<{}, {}>'.format(key_type.db_type, value_type.db_type)
+        self.db_type = 'map<{0}, {1}>'.format(key_type.db_type, value_type.db_type)
 
         inheritance_comparator = issubclass if isinstance(key_type, type) else isinstance
         if not inheritance_comparator(key_type, Column):
@@ -825,21 +826,21 @@ class Map(BaseContainerColumn):
         if val is None:
             return
         if not isinstance(val, dict):
-            raise ValidationError('{} {} is not a dict object'.format(self.column_name, val))
+            raise ValidationError('{0} {1} is not a dict object'.format(self.column_name, val))
         if None in val:
             raise ValidationError("{} None is not allowed in a map".format(self.column_name))
-        return {self.key_col.validate(k): self.value_col.validate(v) for k, v in val.items()}
+        return dict((self.key_col.validate(k), self.value_col.validate(v)) for k, v in val.items())
 
     def to_python(self, value):
         if value is None:
             return {}
         if value is not None:
-            return {self.key_col.to_python(k): self.value_col.to_python(v) for k, v in value.items()}
+            return dict((self.key_col.to_python(k), self.value_col.to_python(v)) for k, v in value.items())
 
     def to_database(self, value):
         if value is None:
             return None
-        return {self.key_col.to_database(k): self.value_col.to_database(v) for k, v in value.items()}
+        return dict((self.key_col.to_database(k), self.value_col.to_database(v)) for k, v in value.items())
 
     @property
     def sub_columns(self):
@@ -901,7 +902,7 @@ class _PartitionKeysToken(Column):
 
     @property
     def db_field_name(self):
-        return 'token({})'.format(', '.join(['"{}"'.format(c.db_field_name) for c in self.partition_columns]))
+        return 'token({0})'.format(', '.join(['"{0}"'.format(c.db_field_name) for c in self.partition_columns]))
 
     def to_database(self, value):
         from cqlengine.functions import Token
@@ -910,4 +911,4 @@ class _PartitionKeysToken(Column):
         return value
 
     def get_cql(self):
-        return "token({})".format(", ".join(c.cql for c in self.partition_columns))
+        return "token({0})".format(", ".join(c.cql for c in self.partition_columns))

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -563,7 +563,7 @@ class TimeUUID(UUID):
 
         epoch = datetime(1970, 1, 1, tzinfo=dt.tzinfo)
         offset = get_total_seconds(epoch.tzinfo.utcoffset(epoch)) if epoch.tzinfo else 0
-        timestamp = get_total_seconds(dt  - epoch) - offset
+        timestamp = get_total_seconds(dt - epoch) - offset
 
         node = None
         clock_seq = None

--- a/cassandra/cqlengine/functions.py
+++ b/cassandra/cqlengine/functions.py
@@ -16,6 +16,14 @@ from datetime import datetime
 
 from cassandra.cqlengine import UnicodeMixin, ValidationError
 
+import sys
+
+if sys.version_info >= (2, 7):
+    def get_total_seconds(td):
+        return td.total_seconds()
+else:
+    def get_total_seconds(td):
+        return 86400*td.days + td.seconds + td.microseconds/1e6
 
 class QueryValue(UnicodeMixin):
     """
@@ -23,7 +31,7 @@ class QueryValue(UnicodeMixin):
     be passed into .filter() keyword args
     """
 
-    format_string = '%({})s'
+    format_string = '%({0})s'
 
     def __init__(self, value):
         self.value = value
@@ -58,7 +66,7 @@ class MinTimeUUID(BaseQueryFunction):
     http://cassandra.apache.org/doc/cql3/CQL.html#timeuuidFun
     """
 
-    format_string = 'MinTimeUUID(%({})s)'
+    format_string = 'MinTimeUUID(%({0})s)'
 
     def __init__(self, value):
         """
@@ -71,8 +79,8 @@ class MinTimeUUID(BaseQueryFunction):
 
     def to_database(self, val):
         epoch = datetime(1970, 1, 1, tzinfo=val.tzinfo)
-        offset = epoch.tzinfo.utcoffset(epoch).total_seconds() if epoch.tzinfo else 0
-        return int(((val - epoch).total_seconds() - offset) * 1000)
+        offset = get_total_seconds(epoch.tzinfo.utcoffset(epoch)) if epoch.tzinfo else 0
+        return int((get_total_seconds(val - epoch) - offset) * 1000)
 
     def update_context(self, ctx):
         ctx[str(self.context_id)] = self.to_database(self.value)
@@ -85,7 +93,7 @@ class MaxTimeUUID(BaseQueryFunction):
     http://cassandra.apache.org/doc/cql3/CQL.html#timeuuidFun
     """
 
-    format_string = 'MaxTimeUUID(%({})s)'
+    format_string = 'MaxTimeUUID(%({0})s)'
 
     def __init__(self, value):
         """
@@ -125,8 +133,8 @@ class Token(BaseQueryFunction):
         return len(self.value)
 
     def __unicode__(self):
-        token_args = ', '.join('%({})s'.format(self.context_id + i) for i in range(self.get_context_size()))
-        return "token({})".format(token_args)
+        token_args = ', '.join('%({0})s'.format(self.context_id + i) for i in range(self.get_context_size()))
+        return "token({0})".format(token_args)
 
     def update_context(self, ctx):
         for i, (col, val) in enumerate(zip(self._columns, self.value)):

--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -433,12 +433,12 @@ class BaseModel(object):
                 poly_base._discover_polymorphic_submodels()
                 klass = poly_base._get_model_by_discriminator_value(disc_key)
                 if klass is None:
-                    raise PolyMorphicModelException(
-                        'unrecognized discriminator column {0} for class {1}'.format(poly_key, poly_base.__name__)
+                    raise PolymorphicModelException(
+                        'unrecognized discriminator column {0} for class {1}'.format(disc_key, poly_base.__name__)
                     )
 
             if not issubclass(klass, cls):
-                raise PolyMorphicModelException(
+                raise PolymorphicModelException(
                     '{0} is not a subclass of {1}'.format(klass.__name__, cls.__name__)
                 )
 

--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -280,7 +280,7 @@ class ColumnDescriptor(object):
             if self.column.can_delete:
                 instance._values[self.column.column_name].delval()
             else:
-                raise AttributeError('cannot delete {} columns'.format(self.column.column_name))
+                raise AttributeError('cannot delete {0} columns'.format(self.column.column_name))
 
 
 class BaseModel(object):
@@ -378,8 +378,8 @@ class BaseModel(object):
         self._timeout = connection.NOT_SET
 
     def __repr__(self):
-        return '{}({})'.format(self.__class__.__name__,
-                               ', '.join('{}={!r}'.format(k, getattr(self, k))
+        return '{0}({1})'.format(self.__class__.__name__,
+                               ', '.join('{0}={1!r}'.format(k, getattr(self, k))
                                          for k in self._defined_columns.keys()
                                          if k != self._discriminator_column_name))
 
@@ -387,8 +387,8 @@ class BaseModel(object):
         """
         Pretty printing of models by their primary key
         """
-        return '{} <{}>'.format(self.__class__.__name__,
-                                ', '.join('{}={}'.format(k, getattr(self, k)) for k in self._primary_keys.keys()))
+        return '{0} <{1}>'.format(self.__class__.__name__,
+                                ', '.join('{0}={1}'.format(k, getattr(self, k)) for k in self._primary_keys.keys()))
 
     @classmethod
     def _discover_polymorphic_submodels(cls):
@@ -433,16 +433,16 @@ class BaseModel(object):
                 poly_base._discover_polymorphic_submodels()
                 klass = poly_base._get_model_by_discriminator_value(disc_key)
                 if klass is None:
-                    raise PolymorphicModelException(
-                        'unrecognized discriminator column {} for class {}'.format(disc_key, poly_base.__name__)
+                    raise PolyMorphicModelException(
+                        'unrecognized polymorphic key {0} for class {1}'.format(poly_key, poly_base.__name__)
                     )
 
             if not issubclass(klass, cls):
-                raise PolymorphicModelException(
-                    '{} is not a subclass of {}'.format(klass.__name__, cls.__name__)
+                raise PolyMorphicModelException(
+                    '{0} is not a subclass of {1}'.format(klass.__name__, cls.__name__)
                 )
 
-            field_dict = {k: v for k, v in field_dict.items() if k in klass._columns.keys()}
+            field_dict = dict((k, v) for (k, v) in field_dict.items() if k in klass._columns.keys())
 
         else:
             klass = cls
@@ -509,7 +509,7 @@ class BaseModel(object):
         """
         cf_name = protect_name(cls._raw_column_family_name())
         if include_keyspace:
-            return '{}.{}'.format(protect_name(cls._get_keyspace()), cf_name)
+            return '{0}.{1}'.format(protect_name(cls._get_keyspace()), cf_name)
 
         return cf_name
 
@@ -524,7 +524,7 @@ class BaseModel(object):
                     cls._table_name = cls._polymorphic_base._raw_column_family_name()
                 else:
                     camelcase = re.compile(r'([a-z])([A-Z])')
-                    ccase = lambda s: camelcase.sub(lambda v: '{}_{}'.format(v.group(1), v.group(2).lower()), s)
+                    ccase = lambda s: camelcase.sub(lambda v: '{0}_{1}'.format(v.group(1), v.group(2).lower()), s)
 
                     cf_name = ccase(cls.__name__)
                     # trim to less than 48 characters or cassandra will complain
@@ -608,7 +608,7 @@ class BaseModel(object):
         """
         extra_columns = set(kwargs.keys()) - set(cls._columns.keys())
         if extra_columns:
-            raise ValidationError("Incorrect columns passed: {}".format(extra_columns))
+            raise ValidationError("Incorrect columns passed: {0}".format(extra_columns))
         return cls.objects.create(**kwargs)
 
     @classmethod
@@ -701,11 +701,11 @@ class BaseModel(object):
 
             # check for nonexistant columns
             if col is None:
-                raise ValidationError("{}.{} has no column named: {}".format(self.__module__, self.__class__.__name__, k))
+                raise ValidationError("{0}.{1} has no column named: {2}".format(self.__module__, self.__class__.__name__, k))
 
             # check for primary key update attempts
             if col.is_primary_key:
-                raise ValidationError("Cannot apply update to primary key '{}' for {}.{}".format(k, self.__module__, self.__class__.__name__))
+                raise ValidationError("Cannot apply update to primary key '{0}' for {1}.{2}".format(k, self.__module__, self.__class__.__name__))
 
             setattr(self, k, v)
 
@@ -808,7 +808,7 @@ class ModelMetaClass(type):
         discriminator_columns = [c for c in column_definitions if c[1].discriminator_column]
         is_polymorphic = len(discriminator_columns) > 0
         if len(discriminator_columns) > 1:
-            raise ModelDefinitionException('only one discriminator_column (polymorphic_key (deprecated)) can be defined in a model, {} found'.format(len(discriminator_columns)))
+            raise ModelDefinitionException('only one discriminator_column (polymorphic_key (deprecated)) can be defined in a model, {0} found'.format(len(discriminator_columns)))
 
         if attrs['__discriminator_value__'] and not is_polymorphic:
             raise ModelDefinitionException('__discriminator_value__ specified, but no base columns defined with discriminator_column=True')
@@ -847,7 +847,7 @@ class ModelMetaClass(type):
         for k, v in column_definitions:
             # don't allow a column with the same name as a built-in attribute or method
             if k in BaseModel.__dict__:
-                raise ModelDefinitionException("column '{}' conflicts with built-in attribute/method".format(k))
+                raise ModelDefinitionException("column '{0}' conflicts with built-in attribute/method".format(k))
 
             # counter column primary keys are not allowed
             if (v.primary_key or v.partition_key) and isinstance(v, (columns.Counter, columns.BaseContainerColumn)):
@@ -881,11 +881,11 @@ class ModelMetaClass(type):
         for v in column_dict.values():
             # check for duplicate column names
             if v.db_field_name in col_names:
-                raise ModelException("{} defines the column {} more than once".format(name, v.db_field_name))
+                raise ModelException("{0} defines the column {1} more than once".format(name, v.db_field_name))
             if v.clustering_order and not (v.primary_key and not v.partition_key):
                 raise ModelException("clustering_order may be specified only for clustering primary keys")
             if v.clustering_order and v.clustering_order.lower() not in ('asc', 'desc'):
-                raise ModelException("invalid clustering order {} for column {}".format(repr(v.clustering_order), v.db_field_name))
+                raise ModelException("invalid clustering order {0} for column {1}".format(repr(v.clustering_order), v.db_field_name))
             col_names.add(v.db_field_name)
 
         # create db_name -> model name map for loading

--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -434,7 +434,7 @@ class BaseModel(object):
                 klass = poly_base._get_model_by_discriminator_value(disc_key)
                 if klass is None:
                     raise PolyMorphicModelException(
-                        'unrecognized polymorphic key {0} for class {1}'.format(poly_key, poly_base.__name__)
+                        'unrecognized discriminator column {0} for class {1}'.format(poly_key, poly_base.__name__)
                     )
 
             if not issubclass(klass, cls):
@@ -442,7 +442,7 @@ class BaseModel(object):
                     '{0} is not a subclass of {1}'.format(klass.__name__, cls.__name__)
                 )
 
-            field_dict = dict((k, v) for (k, v) in field_dict.items() if k in klass._columns.keys())
+            field_dict = dict((k, v) for k, v in field_dict.items() if k in klass._columns.keys())
 
         else:
             klass = cls

--- a/cassandra/cqlengine/named.py
+++ b/cassandra/cqlengine/named.py
@@ -63,7 +63,7 @@ class NamedColumn(AbstractQueryableColumn):
         return self.get_cql()
 
     def get_cql(self):
-        return '"{}"'.format(self.name)
+        return '"{0}"'.format(self.name)
 
     def to_database(self, val):
         return val
@@ -97,7 +97,7 @@ class NamedTable(object):
         otherwise, it creates it from the module and class name
         """
         if include_keyspace:
-            return '{}.{}'.format(self.keyspace, self.name)
+            return '{0}.{1}'.format(self.keyspace, self.name)
         else:
             return self.name
 

--- a/cassandra/cqlengine/operators.py
+++ b/cassandra/cqlengine/operators.py
@@ -50,7 +50,7 @@ class BaseQueryOperator(UnicodeMixin):
         try:
             return cls.opmap[symbol.upper()]
         except KeyError:
-            raise QueryOperatorException("{} doesn't map to a QueryOperator".format(symbol))
+            raise QueryOperatorException("{0} doesn't map to a QueryOperator".format(symbol))
 
 
 class BaseWhereOperator(BaseQueryOperator):

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -174,7 +174,7 @@ class BatchQuery(object):
         :param **kwargs: Named arguments to be passed to the callback at the time of execution
         """
         if not callable(fn):
-            raise ValueError("Value for argument 'fn' is {} and is not a callable object.".format(type(fn)))
+            raise ValueError("Value for argument 'fn' is {0} and is not a callable object.".format(type(fn)))
         self._callbacks.append((fn, args, kwargs))
 
     def execute(self):
@@ -197,7 +197,7 @@ class BatchQuery(object):
             else:
                 raise ValueError("Batch expects a long, a timedelta, or a datetime")
 
-            opener += ' USING TIMESTAMP {}'.format(ts)
+            opener += ' USING TIMESTAMP {0}'.format(ts)
 
         query_list = [opener]
         parameters = {}
@@ -453,7 +453,7 @@ class AbstractQuerySet(object):
         elif len(statement) == 2:
             return statement[0], statement[1]
         else:
-            raise QueryException("Can't parse '{}'".format(arg))
+            raise QueryException("Can't parse '{0}'".format(arg))
 
     def iff(self, *args, **kwargs):
         """Adds IF statements to queryset"""
@@ -463,7 +463,7 @@ class AbstractQuerySet(object):
         clone = copy.deepcopy(self)
         for operator in args:
             if not isinstance(operator, TransactionClause):
-                raise QueryException('{} is not a valid query operator'.format(operator))
+                raise QueryException('{0} is not a valid query operator'.format(operator))
             clone._transaction.append(operator)
 
         for col_name, val in kwargs.items():
@@ -476,7 +476,7 @@ class AbstractQuerySet(object):
                         raise QueryException("Virtual column 'pk__token' may only be compared to Token() values")
                     column = columns._PartitionKeysToken(self.model)
                 else:
-                    raise QueryException("Can't resolve column name: '{}'".format(col_name))
+                    raise QueryException("Can't resolve column name: '{0}'".format(col_name))
 
             if isinstance(val, Token):
                 if col_name != 'pk__token':
@@ -484,7 +484,7 @@ class AbstractQuerySet(object):
                 partition_columns = column.partition_columns
                 if len(partition_columns) != len(val.value):
                     raise QueryException(
-                        'Token() received {} arguments but model has {} partition keys'.format(
+                        'Token() received {0} arguments but model has {1} partition keys'.format(
                             len(val.value), len(partition_columns)))
                 val.set_columns(partition_columns)
 
@@ -512,7 +512,7 @@ class AbstractQuerySet(object):
         clone = copy.deepcopy(self)
         for operator in args:
             if not isinstance(operator, WhereClause):
-                raise QueryException('{} is not a valid query operator'.format(operator))
+                raise QueryException('{0} is not a valid query operator'.format(operator))
             clone._where.append(operator)
 
         for arg, val in kwargs.items():
@@ -528,7 +528,7 @@ class AbstractQuerySet(object):
                     column = columns._PartitionKeysToken(self.model)
                     quote_field = False
                 else:
-                    raise QueryException("Can't resolve column name: '{}'".format(col_name))
+                    raise QueryException("Can't resolve column name: '{0}'".format(col_name))
 
             if isinstance(val, Token):
                 if col_name != 'pk__token':
@@ -536,7 +536,7 @@ class AbstractQuerySet(object):
                 partition_columns = column.partition_columns
                 if len(partition_columns) != len(val.value):
                     raise QueryException(
-                        'Token() received {} arguments but model has {} partition keys'.format(
+                        'Token() received {0} arguments but model has {1} partition keys'.format(
                             len(val.value), len(partition_columns)))
                 val.set_columns(partition_columns)
 
@@ -580,7 +580,7 @@ class AbstractQuerySet(object):
         if len(self._result_cache) == 0:
             raise self.model.DoesNotExist
         elif len(self._result_cache) > 1:
-            raise self.model.MultipleObjectsReturned('{} objects found'.format(len(self._result_cache)))
+            raise self.model.MultipleObjectsReturned('{0} objects found'.format(len(self._result_cache)))
         else:
             return self[0]
 
@@ -628,7 +628,7 @@ class AbstractQuerySet(object):
 
         conditions = []
         for colname in colnames:
-            conditions.append('"{}" {}'.format(*self._get_ordering_condition(colname)))
+            conditions.append('"{0}" {1}'.format(*self._get_ordering_condition(colname)))
 
         clone = copy.deepcopy(self)
         clone._order.extend(conditions)
@@ -689,7 +689,7 @@ class AbstractQuerySet(object):
         missing_fields = [f for f in fields if f not in self.model._columns.keys()]
         if missing_fields:
             raise QueryException(
-                "Can't resolve fields {} in {}".format(
+                "Can't resolve fields {0} in {1}".format(
                     ', '.join(missing_fields), self.model.__name__))
 
         if action == 'defer':
@@ -821,12 +821,12 @@ class ModelQuerySet(AbstractQuerySet):
 
         column = self.model._columns.get(colname)
         if column is None:
-            raise QueryException("Can't resolve the column name: '{}'".format(colname))
+            raise QueryException("Can't resolve the column name: '{0}'".format(colname))
 
         # validate the column selection
         if not column.primary_key:
             raise QueryException(
-                "Can't order on '{}', can only order on (clustered) primary keys".format(colname))
+                "Can't order on '{0}', can only order on (clustered) primary keys".format(colname))
 
         pks = [v for k, v in self.model._columns.items() if v.primary_key]
         if column == pks[0]:
@@ -971,10 +971,10 @@ class ModelQuerySet(AbstractQuerySet):
             col = self.model._columns.get(col_name)
             # check for nonexistant columns
             if col is None:
-                raise ValidationError("{}.{} has no column named: {}".format(self.__module__, self.model.__name__, col_name))
+                raise ValidationError("{0}.{1} has no column named: {2}".format(self.__module__, self.model.__name__, col_name))
             # check for primary key update attempts
             if col.is_primary_key:
-                raise ValidationError("Cannot apply update to primary key '{}' for {}.{}".format(col_name, self.__module__, self.model.__name__))
+                raise ValidationError("Cannot apply update to primary key '{0}' for {1}.{2}".format(col_name, self.__module__, self.model.__name__))
 
             # we should not provide default values in this use case.
             val = col.validate(val)

--- a/cassandra/cqlengine/statements.py
+++ b/cassandra/cqlengine/statements.py
@@ -108,7 +108,7 @@ class WhereClause(BaseClause):
         """
         if not isinstance(operator, BaseWhereOperator):
             raise StatementException(
-                "operator must be of type {}, got {}".format(BaseWhereOperator, type(operator))
+                "operator must be of type {0}, got {1}".format(BaseWhereOperator, type(operator))
             )
         super(WhereClause, self).__init__(field, value)
         self.operator = operator
@@ -116,8 +116,8 @@ class WhereClause(BaseClause):
         self.quote_field = quote_field
 
     def __unicode__(self):
-        field = ('"{}"' if self.quote_field else '{}').format(self.field)
-        return u'{} {} {}'.format(field, self.operator, six.text_type(self.query_value))
+        field = ('"{0}"' if self.quote_field else '{0}').format(self.field)
+        return u'{0} {1} {2}'.format(field, self.operator, six.text_type(self.query_value))
 
     def __hash__(self):
         return super(WhereClause, self).__hash__() ^ hash(self.operator)
@@ -145,7 +145,7 @@ class AssignmentClause(BaseClause):
     """ a single variable st statement """
 
     def __unicode__(self):
-        return u'"{}" = %({})s'.format(self.field, self.context_id)
+        return u'"{0}" = %({1})s'.format(self.field, self.context_id)
 
     def insert_tuple(self):
         return self.field, self.context_id
@@ -155,7 +155,7 @@ class TransactionClause(BaseClause):
     """ A single variable iff statement """
 
     def __unicode__(self):
-        return u'"{}" = %({})s'.format(self.field, self.context_id)
+        return u'"{0}" = %({1})s'.format(self.field, self.context_id)
 
     def insert_tuple(self):
         return self.field, self.context_id
@@ -199,9 +199,9 @@ class SetUpdateClause(ContainerUpdateClause):
                 self._assignments is None and
                 self._additions is None and
                 self._removals is None):
-            qs += ['"{}" = %({})s'.format(self.field, ctx_id)]
+            qs += ['"{0}" = %({1})s'.format(self.field, ctx_id)]
         if self._assignments is not None:
-            qs += ['"{}" = %({})s'.format(self.field, ctx_id)]
+            qs += ['"{0}" = %({1})s'.format(self.field, ctx_id)]
             ctx_id += 1
         if self._additions is not None:
             qs += ['"{0}" = "{0}" + %({1})s'.format(self.field, ctx_id)]
@@ -270,7 +270,7 @@ class ListUpdateClause(ContainerUpdateClause):
         qs = []
         ctx_id = self.context_id
         if self._assignments is not None:
-            qs += ['"{}" = %({})s'.format(self.field, ctx_id)]
+            qs += ['"{0}" = %({1})s'.format(self.field, ctx_id)]
             ctx_id += 1
 
         if self._prepend is not None:
@@ -398,10 +398,10 @@ class MapUpdateClause(ContainerUpdateClause):
 
         ctx_id = self.context_id
         if self.previous is None and not self._updates:
-            qs += ['"{}" = %({})s'.format(self.field, ctx_id)]
+            qs += ['"{0}" = %({1})s'.format(self.field, ctx_id)]
         else:
             for _ in self._updates or []:
-                qs += ['"{}"[%({})s] = %({})s'.format(self.field, ctx_id, ctx_id + 1)]
+                qs += ['"{0}"[%({1})s] = %({2})s'.format(self.field, ctx_id, ctx_id + 1)]
                 ctx_id += 2
 
         return ', '.join(qs)
@@ -436,7 +436,7 @@ class FieldDeleteClause(BaseDeleteClause):
         super(FieldDeleteClause, self).__init__(field, None)
 
     def __unicode__(self):
-        return '"{}"'.format(self.field)
+        return '"{0}"'.format(self.field)
 
     def update_context(self, ctx):
         pass
@@ -473,7 +473,7 @@ class MapDeleteClause(BaseDeleteClause):
     def __unicode__(self):
         if not self._analyzed:
             self._analyze()
-        return ', '.join(['"{}"[%({})s]'.format(self.field, self.context_id + i) for i in range(len(self._removals))])
+        return ', '.join(['"{0}"[%({1})s]'.format(self.field, self.context_id + i) for i in range(len(self._removals))])
 
 
 class BaseCQLStatement(UnicodeMixin):
@@ -550,7 +550,7 @@ class BaseCQLStatement(UnicodeMixin):
 
     @property
     def _where(self):
-        return 'WHERE {}'.format(' AND '.join([six.text_type(c) for c in self.where_clauses]))
+        return 'WHERE {0}'.format(' AND '.join([six.text_type(c) for c in self.where_clauses]))
 
 
 class SelectStatement(BaseCQLStatement):
@@ -587,17 +587,17 @@ class SelectStatement(BaseCQLStatement):
         if self.count:
             qs += ['COUNT(*)']
         else:
-            qs += [', '.join(['"{}"'.format(f) for f in self.fields]) if self.fields else '*']
+            qs += [', '.join(['"{0}"'.format(f) for f in self.fields]) if self.fields else '*']
         qs += ['FROM', self.table]
 
         if self.where_clauses:
             qs += [self._where]
 
         if self.order_by and not self.count:
-            qs += ['ORDER BY {}'.format(', '.join(six.text_type(o) for o in self.order_by))]
+            qs += ['ORDER BY {0}'.format(', '.join(six.text_type(o) for o in self.order_by))]
 
         if self.limit:
-            qs += ['LIMIT {}'.format(self.limit)]
+            qs += ['LIMIT {0}'.format(self.limit)]
 
         if self.allow_filtering:
             qs += ['ALLOW FILTERING']
@@ -681,24 +681,24 @@ class InsertStatement(AssignmentStatement):
         raise StatementException("Cannot add where clauses to insert statements")
 
     def __unicode__(self):
-        qs = ['INSERT INTO {}'.format(self.table)]
+        qs = ['INSERT INTO {0}'.format(self.table)]
 
         # get column names and context placeholders
         fields = [a.insert_tuple() for a in self.assignments]
         columns, values = zip(*fields)
 
-        qs += ["({})".format(', '.join(['"{}"'.format(c) for c in columns]))]
+        qs += ["({0})".format(', '.join(['"{0}"'.format(c) for c in columns]))]
         qs += ['VALUES']
-        qs += ["({})".format(', '.join(['%({})s'.format(v) for v in values]))]
+        qs += ["({0})".format(', '.join(['%({0})s'.format(v) for v in values]))]
 
         if self.if_not_exists:
             qs += ["IF NOT EXISTS"]
 
         if self.ttl:
-            qs += ["USING TTL {}".format(self.ttl)]
+            qs += ["USING TTL {0}".format(self.ttl)]
 
         if self.timestamp:
-            qs += ["USING TIMESTAMP {}".format(self.timestamp_normalized)]
+            qs += ["USING TIMESTAMP {0}".format(self.timestamp_normalized)]
 
         return ' '.join(qs)
 
@@ -732,13 +732,13 @@ class UpdateStatement(AssignmentStatement):
         using_options = []
 
         if self.ttl:
-            using_options += ["TTL {}".format(self.ttl)]
+            using_options += ["TTL {0}".format(self.ttl)]
 
         if self.timestamp:
-            using_options += ["TIMESTAMP {}".format(self.timestamp_normalized)]
+            using_options += ["TIMESTAMP {0}".format(self.timestamp_normalized)]
 
         if using_options:
-            qs += ["USING {}".format(" AND ".join(using_options))]
+            qs += ["USING {0}".format(" AND ".join(using_options))]
 
         qs += ['SET']
         qs += [', '.join([six.text_type(c) for c in self.assignments])]
@@ -771,7 +771,7 @@ class UpdateStatement(AssignmentStatement):
         return ctx
 
     def _get_transactions(self):
-        return 'IF {}'.format(' AND '.join([six.text_type(c) for c in self.transactions]))
+        return 'IF {0}'.format(' AND '.join([six.text_type(c) for c in self.transactions]))
 
     def update_context_id(self, i):
         super(UpdateStatement, self).update_context_id(i)
@@ -820,16 +820,16 @@ class DeleteStatement(BaseCQLStatement):
     def __unicode__(self):
         qs = ['DELETE']
         if self.fields:
-            qs += [', '.join(['{}'.format(f) for f in self.fields])]
+            qs += [', '.join(['{0}'.format(f) for f in self.fields])]
         qs += ['FROM', self.table]
 
         delete_option = []
 
         if self.timestamp:
-            delete_option += ["TIMESTAMP {}".format(self.timestamp_normalized)]
+            delete_option += ["TIMESTAMP {0}".format(self.timestamp_normalized)]
 
         if delete_option:
-            qs += [" USING {} ".format(" AND ".join(delete_option))]
+            qs += [" USING {0} ".format(" AND ".join(delete_option))]
 
         if self.where_clauses:
             qs += [self._where]

--- a/cassandra/cqlengine/usertype.py
+++ b/cassandra/cqlengine/usertype.py
@@ -56,7 +56,7 @@ class BaseUserType(object):
         return not self.__eq__(other)
 
     def __str__(self):
-        return "{{{}}}".format(', '.join("'{}': {}".format(k, getattr(self, k)) for k, v in six.iteritems(self._values)))
+        return "{{{0}}}".format(', '.join("'{0}': {1}".format(k, getattr(self, k)) for k, v in six.iteritems(self._values)))
 
     def has_changed_fields(self):
         return any(v.changed for v in self._values.values())
@@ -116,7 +116,7 @@ class BaseUserType(object):
             type_name = cls.__type_name__.lower()
         else:
             camelcase = re.compile(r'([a-z])([A-Z])')
-            ccase = lambda s: camelcase.sub(lambda v: '{}_{}'.format(v.group(1), v.group(2)), s)
+            ccase = lambda s: camelcase.sub(lambda v: '{0}_{1}'.format(v.group(1), v.group(2)), s)
 
             type_name = ccase(cls.__name__)
             # trim to less than 48 characters or cassandra will complain
@@ -157,7 +157,7 @@ class UserTypeMetaClass(type):
         for k, v in field_defs:
             # don't allow a field with the same name as a built-in attribute or method
             if k in BaseUserType.__dict__:
-                raise UserTypeDefinitionException("field '{}' conflicts with built-in attribute/method".format(k))
+                raise UserTypeDefinitionException("field '{0}' conflicts with built-in attribute/method".format(k))
             _transform_column(k, v)
 
         # create db_name -> model name map for loading


### PR DESCRIPTION
Here it comes the backport I already did for the standalone cqlengine fork, now adapted to python driver one.

I have tested this one with a Cassandra 2.1 deployment and it worked fine. Integration tests are pending to be backported as well (they use the '{}'.format() syntax and probably more 2.7 idioms).