### PR TITLE
Expose conflicting data in case of LWTException

### DIFF
--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -40,7 +40,17 @@ class IfNotExistsWithCounterColumn(CQLEngineException):
 
 
 class LWTException(CQLEngineException):
-    pass
+    """Lightweight transaction exception.
+
+    This exception will be raised when a write using an `IF` clause could not be
+    applied due to existing data violating the condition. The existing data is
+    available through the ``existing`` attribute.
+
+    :param existing: The current state of the data which prevented the write.
+    """
+    def __init__(self, existing):
+        super(LWTException, self).__init__(self)
+        self.existing = existing
 
 
 class DoesNotExist(QueryException):
@@ -58,7 +68,7 @@ def check_applied(result):
     applied to database.
     """
     if result and '[applied]' in result[0] and not result[0]['[applied]']:
-        raise LWTException('')
+        raise LWTException(result[0])
 
 
 class AbstractQueryableColumn(UnicodeMixin):

--- a/docs/api/cassandra/cqlengine/models.rst
+++ b/docs/api/cassandra/cqlengine/models.rst
@@ -68,7 +68,7 @@ Model
     .. attribute:: __replicate_on_write__
 
 
-    *Model presently supports specifying compaction options via class attributes. 
+    *Model presently supports specifying compaction options via class attributes.
     cqlengine will only use your compaction options if you have a strategy set.
     When a table is synced, it will be altered to match the compaction options set on your table.
     This means that if you are changing settings manually they will be changed back on resync.*
@@ -139,7 +139,7 @@ Model
         object is determined by its primary key(s). And please note using this flag
         would incur performance cost.
 
-        if the insertion didn't applied, a LWTException exception would be raised.
+        If the insertion isn't applied, a :class:`~cassandra.cqlengine.query.LWTException` is raised.
 
         .. code-block:: python
 
@@ -161,7 +161,7 @@ Model
         Simply specify the column(s) and the expected value(s).  As with if_not_exists,
         this incurs a performance cost.
 
-        If the insertion isn't applied, a LWTException is raised
+        If the insertion isn't applied, a :class:`~cassandra.cqlengine.query.LWTException` is raised.
 
         .. code-block:: python
 
@@ -169,7 +169,8 @@ Model
             try:
                  t.iff(count=5).update('other text')
             except LWTException as e:
-                # handle failure
+                # handle failure case
+                print e.existing # existing object
 
     .. automethod:: get
 

--- a/docs/api/cassandra/cqlengine/query.rst
+++ b/docs/api/cassandra/cqlengine/query.rst
@@ -40,3 +40,4 @@ The mehtods here are used to filter, order, and constrain results.
 
 .. autoclass:: MultipleObjectsReturned
 
+.. autoclass:: LWTException

--- a/tests/integration/cqlengine/test_ifnotexists.py
+++ b/tests/integration/cqlengine/test_ifnotexists.py
@@ -78,8 +78,16 @@ class IfNotExistsInsertTests(BaseIfNotExistsTest):
         id = uuid4()
 
         TestIfNotExistsModel.create(id=id, count=8, text='123456789')
-        with self.assertRaises(LWTException):
+
+        with self.assertRaises(LWTException) as assertion:
             TestIfNotExistsModel.if_not_exists().create(id=id, count=9, text='111111111111')
+
+        self.assertEquals(assertion.exception.existing, {
+            'count': 8,
+            'id': id,
+            'text': '123456789',
+            '[applied]': False,
+        })
 
         q = TestIfNotExistsModel.objects(id=id)
         self.assertEqual(len(q), 1)
@@ -114,8 +122,15 @@ class IfNotExistsInsertTests(BaseIfNotExistsTest):
 
         b = BatchQuery()
         TestIfNotExistsModel.batch(b).if_not_exists().create(id=id, count=9, text='111111111111')
-        with self.assertRaises(LWTException):
+        with self.assertRaises(LWTException) as assertion:
             b.execute()
+
+        self.assertEquals(assertion.exception.existing, {
+            'count': 8,
+            'id': id,
+            'text': '123456789',
+            '[applied]': False,
+        })
 
         q = TestIfNotExistsModel.objects(id=id)
         self.assertEqual(len(q), 1)

--- a/tests/integration/cqlengine/test_transaction.py
+++ b/tests/integration/cqlengine/test_transaction.py
@@ -26,8 +26,9 @@ from cassandra.cqlengine.statements import TransactionClause
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration import CASSANDRA_VERSION
 
+
 class TestTransactionModel(Model):
-    id = columns.UUID(primary_key=True, default=lambda:uuid4())
+    id = columns.UUID(primary_key=True, default=uuid4)
     count = columns.Integer()
     text = columns.Text(required=False)
 
@@ -68,7 +69,14 @@ class TestTransaction(BaseCassEngTestCase):
         t = TestTransactionModel.create(text='blah blah')
         t.text = 'new blah'
         t = t.iff(text='something wrong')
-        self.assertRaises(LWTException, t.save)
+
+        with self.assertRaises(LWTException) as assertion:
+            t.save()
+
+        self.assertEqual(assertion.exception.existing, {
+            'text': 'blah blah',
+            '[applied]': False,
+        })
 
     def test_blind_update(self):
         t = TestTransactionModel.create(text='blah blah')
@@ -86,7 +94,13 @@ class TestTransaction(BaseCassEngTestCase):
         t.text = 'something else'
         uid = t.id
         qs = TestTransactionModel.objects(id=uid).iff(text='Not dis!')
-        self.assertRaises(LWTException, qs.update, text='this will never work')
+        with self.assertRaises(LWTException) as assertion:
+            qs.update(text='this will never work')
+
+        self.assertEqual(assertion.exception.existing, {
+            'text': 'blah blah',
+            '[applied]': False,
+        })
 
     def test_transaction_clause(self):
         tc = TransactionClause('some_value', 23)
@@ -106,7 +120,14 @@ class TestTransaction(BaseCassEngTestCase):
 
         b = BatchQuery()
         updated.batch(b).iff(count=6).update(text='and another thing')
-        self.assertRaises(LWTException, b.execute)
+        with self.assertRaises(LWTException) as assertion:
+            b.execute()
+
+        self.assertEqual(assertion.exception.existing, {
+            'id': id,
+            'count': 5,
+            '[applied]': False,
+        })
 
         updated = TestTransactionModel.objects(id=id).first()
         self.assertEqual(updated.text, 'something else')


### PR DESCRIPTION
Adds a custom attribute, `existing`, to the LWTException instance which
allows the application layer to inspect the values read from Cassandra
which conflicted with the attempted conditional write.

The documentation already referred to the `existing` attribute but it
was not implemented.