### PR TITLE
fix unicode encoding issue for query.bind_params

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1653,8 +1653,6 @@ class Session(object):
 
         if isinstance(query, SimpleStatement):
             query_string = query.query_string
-            if six.PY2 and isinstance(query_string, six.text_type):
-                query_string = query_string.encode('utf-8')
             if parameters:
                 query_string = bind_params(query_string, parameters, self.encoder)
             message = QueryMessage(

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -793,6 +793,8 @@ For example::
 
 
 def bind_params(query, params, encoder):
+    if six.PY2 and isinstance(query, six.text_type):
+        query = query.encode('utf-8')
     if isinstance(params, dict):
         return query % dict((k, encoder.cql_encode_all_types(v)) for k, v in six.iteritems(params))
     else:


### PR DESCRIPTION
`bind_params` raises `UnicodeDecodeError` if query is unicode. Since `bind_params` is used by `Cluster.execute` and `BatchStatement.add` it is better to move type checking of query inside `bind_params`.