### PR TITLE
Write timeouts being ignored with 0 responses

### DIFF
--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -816,7 +816,7 @@ class DowngradingConsistencyRetryPolicy(RetryPolicy):
                          required_responses, received_responses, retry_num):
         if retry_num != 0:
             return (self.RETHROW, None)
-        elif write_type in (WriteType.SIMPLE, WriteType.BATCH, WriteType.COUNTER):
+        elif write_type in (WriteType.SIMPLE, WriteType.BATCH, WriteType.COUNTER) and received_responses > 0:
             return (self.IGNORE, None)
         elif write_type == WriteType.UNLOGGED_BATCH:
             return self._pick_consistency(received_responses)

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1052,6 +1052,14 @@ class DowngradingConsistencyRetryPolicyTest(unittest.TestCase):
         self.assertEqual(retry, RetryPolicy.RETHROW)
         self.assertEqual(consistency, None)
 
+	    # On these type of writes failures should not be ignored
+        # if received_responses is 0
+        for write_type in (WriteType.SIMPLE, WriteType.BATCH, WriteType.COUNTER):
+            retry, consistency = policy.on_write_timeout(
+                query=None, consistency=ONE, write_type=write_type,
+                required_responses=1, received_responses=0, retry_num=0)
+            self.assertEqual(retry, RetryPolicy.RETHROW)
+
         # ignore failures on these types of writes
         for write_type in (WriteType.SIMPLE, WriteType.BATCH, WriteType.COUNTER):
             retry, consistency = policy.on_write_timeout(


### PR DESCRIPTION
DowngradingConsistencyRetryPolicy was ignoring write timeouts for
WriteTypes SIMPLE, BATCH and COUNTER even if responses received
was equal to 0.
It is valid to ignore the failure only if at least one response was
received.