### PR TITLE
PYTHON-331 - Change return conversion for murmur3 ext

### DIFF
--- a/cassandra/murmur3.c
+++ b/cassandra/murmur3.c
@@ -201,7 +201,7 @@ murmur3(PyObject *self, PyObject *args)
 
     // TODO handle x86 version?
     result = MurmurHash3_x64_128((void *)key, len, seed);
-    return (PyObject *) PyLong_FromLong((long int)result);
+    return (PyObject *) PyLong_FromLongLong(result);
 }
 
 static PyMethodDef murmur3_methods[] = {


### PR DESCRIPTION
Fixes an issue where the hash value was cast to a four-byte type on some
platforms.