### PR TITLE
PYTHON-303 - Don't wait for schema agreement during startup.

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2118,7 +2118,7 @@ class ControlConnection(object):
                 peers_query, local_query, timeout=self._timeout)
 
             self._refresh_node_list_and_token_map(connection, preloaded_results=shared_results)
-            self._refresh_schema(connection, preloaded_results=shared_results)
+            self._refresh_schema(connection, preloaded_results=shared_results, schema_agreement_wait=-1)
             if not self._cluster.metadata.keyspaces:
                 log.warning("[control connection] No schema built on connect; retrying without wait for schema agreement")
                 self._refresh_schema(connection, preloaded_results=shared_results, schema_agreement_wait=0)

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -336,10 +336,7 @@ class ClusterTests(unittest.TestCase):
 
             # cluster agreement wait exceeded
             c = Cluster(protocol_version=PROTOCOL_VERSION, max_schema_agreement_wait=agreement_timeout)
-            start_time = time.time()
-            s = c.connect()
-            end_time = time.time()
-            self.assertGreaterEqual(end_time - start_time, agreement_timeout)
+            c.connect()
             self.assertTrue(c.metadata.keyspaces)
 
             # cluster agreement wait used for refresh


### PR DESCRIPTION
Fixes an issue where connect will stall when connecting to mixed version
clusters.
Should not affect model consistency since we are already registered for
schema_change events.