### PR TITLE
PYTHON-352 - For meta export, don't copy in default min/max compaction thresholds

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1207,7 +1207,6 @@ class TableMetadata(object):
         "rows_per_partition_to_cache",
         "memtable_flush_period_in_ms",
         "populate_io_cache_on_flush",
-        "compaction",
         "compression",
         "default_time_to_live")
 
@@ -1350,17 +1349,13 @@ class TableMetadata(object):
     def _make_option_strings(self):
         ret = []
         options_copy = dict(self.options.items())
-        if not options_copy.get('compaction'):
-            options_copy.pop('compaction', None)
 
-            actual_options = json.loads(options_copy.pop('compaction_strategy_options', '{}'))
-            for system_table_name, compact_option_name in self.compaction_options.items():
-                value = options_copy.pop(system_table_name, None)
-                if value:
-                    actual_options.setdefault(compact_option_name, value)
+        actual_options = json.loads(options_copy.pop('compaction_strategy_options', '{}'))
+        value = options_copy.pop("compaction_strategy_class", None)
+        actual_options.setdefault("class", value)
 
-            compaction_option_strings = ["'%s': '%s'" % (k, v) for k, v in actual_options.items()]
-            ret.append('compaction = {%s}' % ', '.join(compaction_option_strings))
+        compaction_option_strings = ["'%s': '%s'" % (k, v) for k, v in actual_options.items()]
+        ret.append('compaction = {%s}' % ', '.join(compaction_option_strings))
 
         for system_table_name in self.compaction_options.keys():
             options_copy.pop(system_table_name, None)  # delete if present

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -313,6 +313,30 @@ class SchemaMetadataTests(unittest.TestCase):
         tablemeta = self.get_table_metadata()
         self.assertIn("compression = {}", tablemeta.export_as_string())
 
+    def test_non_size_tiered_compaction(self):
+        """
+        test options for non-size-tiered compaction strategy
+
+        Creates a table with LeveledCompactionStrategy, specifying one non-default option. Verifies that the option is
+        present in generated CQL, and that other legacy table parameters (min_threshold, max_threshold) are not included.
+
+        @since 2.6.0
+        @jira_ticket PYTHON-352
+        @expected_result the options map for LeveledCompactionStrategy does not contain min_threshold, max_threshold
+
+        @test_category metadata
+        """
+        create_statement = self.make_create_statement(["a"], [], ["b", "c"])
+        create_statement += "WITH COMPACTION = {'class': 'LeveledCompactionStrategy', 'tombstone_threshold': '0.3'}"
+        self.session.execute(create_statement)
+
+        table_meta = self.get_table_metadata()
+        cql = table_meta.export_as_string()
+        self.assertIn("'tombstone_threshold': '0.3'", cql)
+        self.assertIn("LeveledCompactionStrategy", cql)
+        self.assertNotIn("min_threshold", cql)
+        self.assertNotIn("max_threshold", cql)
+
     def test_refresh_schema_metadata(self):
         """
         test for synchronously refreshing all cluster metadata
@@ -670,7 +694,7 @@ CREATE TABLE export_udts.users (
 ) WITH bloom_filter_fp_chance = 0.01
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
@@ -691,7 +715,7 @@ CREATE TABLE export_udts.users (
 ) WITH bloom_filter_fp_chance = 0.01
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
@@ -926,7 +950,7 @@ CREATE TABLE legacy.composite_comp_with_col (
     AND CLUSTERING ORDER BY (t ASC, b ASC, s ASC)
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = 'Stores file meta data'
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
@@ -948,7 +972,7 @@ CREATE TABLE legacy.nested_composite_key (
 ) WITH COMPACT STORAGE
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
@@ -967,7 +991,7 @@ CREATE TABLE legacy.composite_partition_with_col (
 ) WITH COMPACT STORAGE
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
@@ -988,7 +1012,7 @@ CREATE TABLE legacy.composite_partition_no_col (
     AND CLUSTERING ORDER BY (column1 ASC)
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
@@ -1005,7 +1029,7 @@ CREATE TABLE legacy.simple_with_col (
 ) WITH COMPACT STORAGE
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
@@ -1025,7 +1049,7 @@ CREATE TABLE legacy.simple_no_col (
     AND CLUSTERING ORDER BY (column1 ASC)
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = ''
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0
@@ -1052,7 +1076,7 @@ CREATE TABLE legacy.composite_comp_no_col (
     AND CLUSTERING ORDER BY (column1 ASC, column1 ASC, column2 ASC)
     AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
     AND comment = 'Stores file meta data'
-    AND compaction = {'min_threshold': '4', 'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32'}
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
     AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
     AND dclocal_read_repair_chance = 0.1
     AND default_time_to_live = 0


### PR DESCRIPTION
Fixes an issue where table meta export would contain min/max_threshold
settings, even for compaction strategies that do not accept those.
Resulting CQL would cause "ConfigurationException ... code=2300 ...
Properties specified [min_threshold, max_threshold] are not
understood by [some compaction strategy]"