### PR TITLE
Enable C extensions on pypy and add pypy3 support

### DIFF
--- a/cassandra/murmur3.c
+++ b/cassandra/murmur3.c
@@ -20,6 +20,13 @@ typedef int Py_ssize_t;
 #define PY_SSIZE_T_MIN INT_MIN
 #endif
 
+#ifdef PYPY_VERSION
+#define COMPILING_IN_PYPY 1
+#define COMPILING_IN_CPYTHON 0
+#else
+#define COMPILING_IN_PYPY 0
+#define COMPILING_IN_CPYTHON 1
+#endif
 //-----------------------------------------------------------------------------
 // Platform-specific functions and macros
 
@@ -179,7 +186,8 @@ struct module_state {
     PyObject *error;
 };
 
-#if PY_MAJOR_VERSION >= 3
+// pypy3 doesn't have GetState yet.
+#if COMPILING_IN_CPYTHON && PY_MAJOR_VERSION >= 3
 #define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
 #else
 #define GETSTATE(m) (&_state)

--- a/setup.py
+++ b/setup.py
@@ -246,6 +246,7 @@ elif "--no-libev" in sys.argv:
     extensions.remove(libev_ext)
 
 is_windows = os.name == 'nt'
+
 if is_windows:
     # libev is difficult to build, and uses select in Windows.
     try:
@@ -282,8 +283,7 @@ The optional C extensions are not supported on big-endian systems.
 
 if extensions:
     if (sys.platform.startswith("java")
-            or sys.platform == "cli"
-            or "PyPy" in sys.version):
+        or sys.platform == "cli"):
         sys.stderr.write(platform_unsupported_msg)
         extensions = ()
     elif sys.byteorder == "big":

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34
+envlist = py26,py27,pypy,py33,py34,pypy3
 
 [base]
 deps = nose
@@ -25,5 +25,11 @@ deps = {[testenv]deps}
 deps = {[base]deps}
 commands = {envpython} setup.py build_ext --inplace
            nosetests --verbosity=2 tests/unit/
+
+[testenv:pypy3]
+deps = {[base]deps}
+commands = {envpython} setup.py build_ext --inplace
+           nosetests --verbosity=2 tests/unit/
+
 # cqlengine/test_timestamp.py uses sure, which fails in pypy presently
 # could remove sure usage


### PR DESCRIPTION
I'm not sure the history behind disabling these on pypy but they work just fine.  I also added a quick fix in the murmur3.c code to support pypy3