### PR TITLE
Fix check for CQL compatibility of COMPACT STORAGE tables

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1227,8 +1227,12 @@ class TableMetadata(object):
         """
         # no such thing as DCT in CQL
         incompatible = issubclass(self.comparator, types.DynamicCompositeType)
-        # no compact storage with more than one column beyond PK
-        incompatible |= self.is_compact_storage and len(self.columns) > len(self.primary_key) + 1
+
+        # no compact storage with more than one column beyond PK if there
+        # are clustering columns
+        incompatible |= (self.is_compact_storage and
+                         len(self.columns) > len(self.primary_key) + 1 and
+                         len(self.clustering_key) >= 1)
 
         return not incompatible
 


### PR DESCRIPTION
If there are not any clustering columns, a COMPACT STORAGE table can have any number of non-PRIMARY KEY columns and still be CQL-compatible.

See: [CASSANDRA-9647](https://issues.apache.org/jira/browse/CASSANDRA-9647)

Done for [PYTHON-360](https://datastax-oss.atlassian.net/browse/PYTHON-360)