### PR TITLE
PYTHON-348 - Track previous value of columns at instantiation

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -31,9 +31,12 @@ class BaseValueManager(object):
     def __init__(self, instance, column, value):
         self.instance = instance
         self.column = column
-        self.previous_value = deepcopy(value)
         self.value = value
-        self.explicit = False
+
+        # Brand new instances do no have previous value yet.
+        self.previous_value = None
+        if self.instance._is_persisted:
+            self.previous_value = deepcopy(value)
 
     @property
     def deleted(self):

--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -357,25 +357,25 @@ class BaseModel(object):
     _table_name = None  # used internally to cache a derived table name
 
     def __init__(self, **values):
-        self._values = {}
         self._ttl = self.__default_ttl__
         self._timestamp = None
         self._transaction = None
+        self._batch = None
+        self._timeout = connection.NOT_SET
 
+        # A flag set by the deserializer to indicate that update should be used
+        # when persisting changes.
+        self._is_persisted = values.pop('_is_persisted', False)
+
+        # Initialize each volumn to its provided or default right at
+        # instanciation. See PYTHON-348.
+        self._values = {}
         for name, column in self._columns.items():
             value = values.get(name, None)
             if value is not None or isinstance(column, columns.BaseContainerColumn):
                 value = column.to_python(value)
             value_mngr = column.value_manager(self, column, value)
-            if name in values:
-                value_mngr.explicit = True
             self._values[name] = value_mngr
-
-        # a flag set by the deserializer to indicate
-        # that update should be used when persisting changes
-        self._is_persisted = False
-        self._batch = None
-        self._timeout = connection.NOT_SET
 
     def __repr__(self):
         return '{0}({1})'.format(self.__class__.__name__,
@@ -447,9 +447,7 @@ class BaseModel(object):
         else:
             klass = cls
 
-        instance = klass(**field_dict)
-        instance._is_persisted = True
-        return instance
+        return klass(_is_persisted=True, **field_dict)
 
     def _can_update(self):
         """
@@ -541,7 +539,7 @@ class BaseModel(object):
         """
         for name, col in self._columns.items():
             v = getattr(self, name)
-            if v is None and not self._values[name].explicit and col.has_default:
+            if v is None and col.has_default:
                 v = col.get_default()
             val = col.validate(v)
             setattr(self, name, val)

--- a/cassandra/cqlengine/usertype.py
+++ b/cassandra/cqlengine/usertype.py
@@ -27,14 +27,13 @@ class BaseUserType(object):
 
     def __init__(self, **values):
         self._values = {}
+        self._is_persisted = False
 
         for name, field in self._fields.items():
             value = values.get(name, None)
             if value is not None or isinstance(field, columns.BaseContainerColumn):
                 value = field.to_python(value)
             value_mngr = field.value_manager(self, field, value)
-            if name in values:
-                value_mngr.explicit = True
             self._values[name] = value_mngr
 
     def __eq__(self, other):
@@ -134,7 +133,7 @@ class BaseUserType(object):
         pass
         for name, field in self._fields.items():
             v = getattr(self, name)
-            if v is None and not self._values[name].explicit and field.has_default:
+            if v is None and field.has_default:
                 v = field.get_default()
             val = field.validate(v)
             setattr(self, name, val)


### PR DESCRIPTION
The first unit-test (`test_previous_value_tracking_of_persisted_instance`) pass and the internal state of column's previous value and changed columns are properly tracked. The second (`test_previous_value_tracking_on_instanciation`), which run a scenario similar to the first, fail.

The difference ? The first test starts with a CQLengine instance that is already persisted to Cassandra (thanks to the use of `.create()`). The second test starts with an instance that hasn't been persisted yet.

I think we should change the way CQLengine operate on instantiation. So that both the internal `previous_value` property of each column and the object's `get_changed_columns()` method reflect the reality of an instance that is not yet persisted.