### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ DataStax Python Driver for Apache Cassandra
 
 A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ and highly-tunable Python client library for Apache Cassandra (1.2+) and DataStax Enterprise (3.1+) using exclusively Cassandra's binary protocol and Cassandra Query Language v3.
 
-The driver supports Python 2.6, 2.7, 3.3, and 3.4*.
+The driver supports Python 2.6, 2.7, 3.3, and 3.4.
 
 Feedback Requested
 ------------------


### PR DESCRIPTION
This asterisk is no longer needed. It was for a footnote that was deleted in b47cbd627924fc574660fa81c67b175f733b98d1