### PR TITLE
PYTHON-381 - Use connect_timeout for socket connect in addition to negotiation

### DIFF
--- a/cassandra/io/twistedreactor.py
+++ b/cassandra/io/twistedreactor.py
@@ -200,7 +200,8 @@ class TwistedConnection(Connection):
         """
         self.connector = reactor.connectTCP(
             host=self.host, port=self.port,
-            factory=TwistedConnectionClientFactory(self))
+            factory=TwistedConnectionClientFactory(self),
+            timeout=self.connect_timeout)
 
     def client_connection_made(self):
         """


### PR DESCRIPTION
PYTHON-381