### PR TITLE
The default protocol version seems to be 4, not 2

### DIFF
--- a/docs/query_paging.rst
+++ b/docs/query_paging.rst
@@ -4,7 +4,7 @@ Paging Large Queries
 ====================
 Cassandra 2.0+ offers support for automatic query paging.  Starting with
 version 2.0 of the driver, if :attr:`~.Cluster.protocol_version` is set to
-:const:`2` (it is by default), queries returning large result sets will be
+:const:`4` (it is by default), queries returning large result sets will be
 automatically paged.
 
 Controlling the Page Size


### PR DESCRIPTION
But I imagine paging is also enabled when for protocol version 4?