### PR TITLE
PYTHON-397 Adding requirements for gevent and eventlet in test.

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,3 +10,5 @@ pytz
 sure
 pure-sasl
 twisted
+gevent>=1.0
+eventlet


### PR DESCRIPTION
Adding gevent, and eventlet requirements to the test-requirements.txt. We have unit tests that require them to run, and I think it's fair to require them for validation purposes.