### PR TITLE
Fix UnicodeDecodeError of UserType

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1955,7 +1955,7 @@ class Session(object):
 
         def encode(val):
             return '{ %s }' % ' , '.join('%s : %s' % (
-                field_name.encode('utf-8'),
+                field_name.encode('utf-8') if six.PY2 and isinstance(field_name, six.text_type) else field_name,
                 self.encoder.cql_encode_all_types(getattr(val, field_name, None))
             ) for field_name in type_meta.field_names)
 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1955,7 +1955,7 @@ class Session(object):
 
         def encode(val):
             return '{ %s }' % ' , '.join('%s : %s' % (
-                field_name,
+                field_name.encode('utf-8'),
                 self.encoder.cql_encode_all_types(getattr(val, field_name, None))
             ) for field_name in type_meta.field_names)
 


### PR DESCRIPTION
```
from cassandra.cqlengine import columns
from cassandra.cqlengine.models import Model
from cassandra.cqlengine.management import sync_table
from cassandra.cqlengine.connection import setup
import uuid
from cassandra.cqlengine.usertype import UserType

setup(['127.0.0.1'], 'mykeyspace', protocol_version=3)

class User(UserType):
    age = columns.Integer()
    name = columns.Text()


class Person(Model):
    __keyspace__ = 'mykeyspace'

    id = columns.UUID(primary_key=True)
    first_name = columns.Text()
    last_name = columns.Text(default='')
    user = columns.UserDefinedType(User)

sync_table(Person)

Person.create(id=uuid.uuid4(), first_name=u"名字".encode('utf8'), user=User(age=10, name=u'字'))
```
raise UnicodeDecodeError: 'ascii' codec can't decode byte 0xe5 in position 1: ordinal not in range(128)

