### PR TITLE
416 test

### DIFF
--- a/cassandra/cqlengine/connection.py
+++ b/cassandra/cqlengine/connection.py
@@ -33,7 +33,7 @@ Host = namedtuple('Host', ['name', 'port'])
 cluster = None
 session = None
 lazy_connect_args = None
-default_consistency_level = ConsistencyLevel.ONE
+default_consistency_level = ConsistencyLevel.LOCAL_QUORUM
 
 
 # Because type models may be registered before a connection is present,

--- a/tests/integration/cqlengine/__init__.py
+++ b/tests/integration/cqlengine/__init__.py
@@ -14,6 +14,7 @@
 
 import os
 import warnings
+from cassandra import ConsistencyLevel
 
 from cassandra.cqlengine import connection
 from cassandra.cqlengine.management import create_keyspace_simple, CQLENG_ALLOW_SCHEMA_MANAGEMENT
@@ -29,6 +30,7 @@ def setup_package():
 
     keyspace = 'cqlengine_test'
     connection.setup(['127.0.0.1'],
+                     consistency=ConsistencyLevel.ONE,
                      protocol_version=PROTOCOL_VERSION,
                      default_keyspace=keyspace)
 

--- a/tests/integration/cqlengine/test_consistency.py
+++ b/tests/integration/cqlengine/test_consistency.py
@@ -15,8 +15,10 @@
 import mock
 from uuid import uuid4
 
-from cassandra import ConsistencyLevel as CL
+from cassandra import ConsistencyLevel as CL, ConsistencyLevel
+from cassandra.cluster import Session
 from cassandra.cqlengine import columns
+from cassandra.cqlengine import connection
 from cassandra.cqlengine.management import sync_table, drop_table
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.query import BatchQuery
@@ -110,3 +112,12 @@ class TestConsistency(BaseConsistencyTest):
 
         args = m.call_args
         self.assertEqual(CL.ALL, args[0][0].consistency_level)
+
+    def test_default_consistency(self):
+        # verify global assumed default
+        self.assertEqual(Session.default_consistency_level, ConsistencyLevel.LOCAL_QUORUM)
+
+        # verify that this session default is set according to connection.setup
+        # assumes tests/cqlengine/__init__ setup uses CL.ONE
+        session = connection.get_session()
+        self.assertEqual(session.default_consistency_level, ConsistencyLevel.ONE)

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -29,7 +29,6 @@ from cassandra.marshal import uint8_pack, uint32_pack, int32_pack
 from cassandra.protocol import (write_stringmultimap, write_int, write_string,
                                 SupportedMessage, ProtocolHandler)
 
-import cassandra.cqlengine.connection
 
 class ConnectionTest(unittest.TestCase):
 
@@ -414,21 +413,3 @@ class ConnectionHeartbeatTest(unittest.TestCase):
         self.assertIsInstance(exc, Exception)
         self.assertEqual(exc.args, Exception('Connection heartbeat failure').args)
         holder.return_connection.assert_has_calls([call(connection)] * get_holders.call_count)
-
-
-class ConnectionDefaultTest(unittest.TestCase):
-        """
-        Test to ensure object mapper and base driver default cl's are the same.
-
-
-        @since 3.0.0
-        @jira_ticket PYTHON-416
-        @expected_result cl's matchy between object mapper and base driver.
-
-        @test_category consistency
-        """
-        def test_default_cl(self, *args):
-            base_driver_cl = Session.default_consistency_level
-            cqlengine_cl = cassandra.cqlengine.connection.default_consistency_level
-            self.assertEqual(base_driver_cl, cqlengine_cl)
-

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -22,13 +22,14 @@ from six import BytesIO
 import time
 from threading import Lock
 
-from cassandra.cluster import Cluster
+from cassandra.cluster import Cluster, Session
 from cassandra.connection import (Connection, HEADER_DIRECTION_TO_CLIENT, ProtocolError,
                                   locally_supported_compressions, ConnectionHeartbeat, _Frame)
 from cassandra.marshal import uint8_pack, uint32_pack, int32_pack
 from cassandra.protocol import (write_stringmultimap, write_int, write_string,
                                 SupportedMessage, ProtocolHandler)
 
+import cassandra.cqlengine.connection
 
 class ConnectionTest(unittest.TestCase):
 
@@ -413,3 +414,21 @@ class ConnectionHeartbeatTest(unittest.TestCase):
         self.assertIsInstance(exc, Exception)
         self.assertEqual(exc.args, Exception('Connection heartbeat failure').args)
         holder.return_connection.assert_has_calls([call(connection)] * get_holders.call_count)
+
+
+class ConnectionDefaultTest(unittest.TestCase):
+        """
+        Test to ensure object mapper and base driver default cl's are the same.
+
+
+        @since 3.0.0
+        @jira_ticket PYTHON-416
+        @expected_result cl's matchy between object mapper and base driver.
+
+        @test_category consistency
+        """
+        def test_default_cl(self, *args):
+            base_driver_cl = Session.default_consistency_level
+            cqlengine_cl = cassandra.cqlengine.connection.default_consistency_level
+            self.assertEqual(base_driver_cl, cqlengine_cl)
+


### PR DESCRIPTION
Making local quorum default for cqlengine. Adding test to ensure default consistency level from base driver and clqengine remain the same.