### PR TITLE
Potential fix for python-440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -307,7 +307,7 @@ On OSX, via homebrew:
             try:
                 from Cython.Build import cythonize
                 cython_candidates = ['cluster', 'concurrent', 'connection', 'cqltypes', 'metadata',
-                                     'pool', 'protocol', 'query', 'util']
+                                     'pool', 'protocol', 'query']
                 compile_args = [] if is_windows else ['-Wno-unused-function']
                 self.extensions.extend(cythonize(
                     [Extension('cassandra.%s' % m, ['cassandra/%s.py' % m],


### PR DESCRIPTION
Potential fix for python-440. Removing util from the list of modules that are cythonized.