### PR TITLE
Handle case where query trace returns nothing

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -884,7 +884,7 @@ class QueryTrace(object):
             session_results = self._execute(
                 self._SELECT_SESSIONS_FORMAT, (self.trace_id,), time_spent, max_wait)
 
-            is_complete = session_results[0].duration is not None
+            is_complete = session_results and session_results[0].duration is not None
             if not session_results or (wait_for_complete and not is_complete):
                 time.sleep(self._BASE_RETRY_SLEEP * (2 ** attempt))
                 attempt += 1


### PR DESCRIPTION
Currently it throws an exception because we are trying to get the 0th element, but if there are no results we should just say the trace isn't yet incomplete.

This can occur when the tracing stage is backed up and the response is sent before the session has been persisted.