### PR TITLE
Don't reference cython genexp from core modules

### DIFF
--- a/cassandra/obj_parser.pyx
+++ b/cassandra/obj_parser.pyx
@@ -38,8 +38,6 @@ cdef class LazyParser(ColumnParser):
         # supported in cpdef methods
         return parse_rows_lazy(reader, desc)
 
-    cpdef get_cython_generator_type(self):
-        return get_cython_generator_type()
 
 def parse_rows_lazy(BytesIOReader reader, ParseDesc desc):
     cdef Py_ssize_t i, rowcount
@@ -47,8 +45,6 @@ def parse_rows_lazy(BytesIOReader reader, ParseDesc desc):
     cdef RowParser rowparser = TupleRowParser()
     return (rowparser.unpack_row(reader, desc) for i in range(rowcount))
 
-def get_cython_generator_type():
-    return type((i for i in range(0)))
 
 cdef class TupleRowParser(RowParser):
     """

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -1000,8 +1000,6 @@ class ProtocolHandler(object):
 
         return msg
 
-_RESULT_SEQUENCE_TYPES = (list, tuple)  # types retuned by ResultMessages
-
 def cython_protocol_handler(colparser):
     """
     Given a column parser to deserialize ResultMessages, return a suitable
@@ -1046,9 +1044,6 @@ def cython_protocol_handler(colparser):
 if HAVE_CYTHON:
     from cassandra.obj_parser import ListParser, LazyParser
     ProtocolHandler = cython_protocol_handler(ListParser())
-
-    lazy_parser = LazyParser()
-    _RESULT_SEQUENCE_TYPES += (lazy_parser.get_cython_generator_type(),)
     LazyProtocolHandler = cython_protocol_handler(LazyParser())
 else:
     # Use Python-based ProtocolHandler


### PR DESCRIPTION
Fixes a not-well-understood issue that would cause segfualts when
building with Cython < 0.22