### PR TITLE
Fix Python3 bug with Timers and heaps

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -1020,6 +1020,9 @@ class Timer(object):
         if timeout < 0:
             self.callback()
 
+    def __lt__(self, other):
+        return self.end < other.end
+
     def cancel(self):
         self.canceled = True
 


### PR DESCRIPTION
Add comparison operator to allow Timers with the same end time to be
pushed into heaps. It's poorly documented, but the warning can be found
here:
https://docs.python.org/2/library/heapq.html#priority-queue-implementation-notes
"In the future with Python 3, tuple comparison breaks for (priority,
task) pairs if the priorities are equal and the tasks do not have a
default comparison order."