### PR TITLE
Fix: crash while working with UDTs

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -790,10 +790,11 @@ class Map(BaseContainerColumn):
 class UDTValueManager(BaseValueManager):
     @property
     def changed(self):
-        return self.value != self.previous_value or self.value.has_changed_fields()
+        return self.value != self.previous_value or (None != self.value and self.value.has_changed_fields())
 
     def reset_previous_value(self):
-        self.value.reset_changed_fields()
+        if None != self.value:
+            self.value.reset_changed_fields()
         self.previous_value = copy(self.value)
 
 


### PR DESCRIPTION
In some cases the ``value`` attribute is ``None``, and without checking we are accessing a method assuming it's a valid object. This fix helps achieving the desired functionality/outcome for such cases without breaking the intended logic.