### PR TITLE
PYTHON-354 - DateType.deserialize being called with one argument vs two

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -18,7 +18,7 @@ import logging
 import six
 
 from cassandra import util
-from cassandra.cqltypes import DateType, SimpleDateType
+from cassandra.cqltypes import SimpleDateType
 from cassandra.cqlengine import ValidationError
 from cassandra.cqlengine.functions import get_total_seconds
 
@@ -435,10 +435,8 @@ class DateTime(Column):
             return value
         elif isinstance(value, date):
             return datetime(*(value.timetuple()[:6]))
-        try:
-            return datetime.utcfromtimestamp(value)
-        except TypeError:
-            return datetime.utcfromtimestamp(DateType.deserialize(value))
+
+        return datetime.utcfromtimestamp(value)
 
     def to_database(self, value):
         value = super(DateTime, self).to_database(value)

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -88,6 +88,17 @@ class TestDatetime(BaseCassEngTestCase):
         dts = self.DatetimeTest.objects.filter(test_id=1).values_list('created_at')
         assert dts[0][0] is None
 
+    def test_datetime_invalid(self):
+        dt_value= 'INVALID'
+        with self.assertRaises(TypeError):
+            self.DatetimeTest.objects.create(test_id=2, created_at=dt_value)
+
+    def test_datetime_timestamp(self):
+        dt_value = 1454520554
+        self.DatetimeTest.objects.create(test_id=2, created_at=dt_value)
+        dt2 = self.DatetimeTest.objects(test_id=2).first()
+        assert dt2.created_at == datetime.utcfromtimestamp(dt_value)
+
 
 class TestBoolDefault(BaseCassEngTestCase):
     class BoolDefaultValueTest(Model):


### PR DESCRIPTION
* Remove the DateType.deserialized() use since the mapper should not deal with serialized data
* Add DateTime tests for a timestamps and invalid inputs