### PR TITLE
PYTHON-452 - Fix Cython deserializer date overflow with large timestamp

### DIFF
--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -23,7 +23,7 @@ class NullHandler(logging.Handler):
 logging.getLogger('cassandra').addHandler(NullHandler())
 
 
-__version_info__ = (3, 1, '0a2')
+__version_info__ = (3, 1, '0a2', 'post0')
 __version__ = '.'.join(map(str, __version_info__))
 
 

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -23,7 +23,7 @@ class NullHandler(logging.Handler):
 logging.getLogger('cassandra').addHandler(NullHandler())
 
 
-__version_info__ = (3, 1, '0a1', 'post0')
+__version_info__ = (3, 1, '0a2')
 __version__ = '.'.join(map(str, __version_info__))
 
 

--- a/cassandra/cython_utils.pyx
+++ b/cassandra/cython_utils.pyx
@@ -35,10 +35,15 @@ from cassandra.util import is_little_endian
 
 import_datetime()
 
+DEF DAY_IN_SECONDS = 86400
+
 DATETIME_EPOC = datetime.datetime(1970, 1, 1)
 
 
 cdef datetime_from_timestamp(double timestamp):
-    cdef int seconds = <int> timestamp
-    cdef int microseconds = (<int64_t> (timestamp * 1000000)) % 1000000
-    return DATETIME_EPOC + timedelta_new(0, seconds, microseconds)
+    cdef int days = <int> (timestamp / DAY_IN_SECONDS)
+    cdef int64_t days_in_seconds = (<int64_t> days) * DAY_IN_SECONDS
+    cdef int seconds = <int> (timestamp - days_in_seconds)
+    cdef int microseconds = <int> ((timestamp - days_in_seconds - seconds) * 1000000)
+
+    return DATETIME_EPOC + timedelta_new(days, seconds, microseconds)

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,6 @@ Some optional C extensions are not supported in PyPy. Only murmur3 will be built
 =================================================================================
 """
 
-
 is_windows = os.name == 'nt'
 
 is_pypy = "PyPy" in sys.version
@@ -323,6 +322,54 @@ On OSX, via homebrew:
                 sys.stderr.write("Failed to cythonize one or more modules. These will not be compiled as extensions (optional).\n")
 
 
+def pre_build_check():
+    """
+    Try to verify build tools
+    """
+    if os.environ.get('CASS_DRIVER_NO_PRE_BUILD_CHECK'):
+        return True
+
+    try:
+        from distutils.ccompiler import new_compiler
+        from distutils.sysconfig import customize_compiler
+        from distutils.dist import Distribution
+
+        # base build_ext just to emulate compiler option setup
+        be = build_ext(Distribution())
+        be.initialize_options()
+        be.finalize_options()
+
+        # First, make sure we have a Python include directory
+        have_python_include = any(os.path.isfile(os.path.join(p, 'Python.h')) for p in be.include_dirs)
+        if not have_python_include:
+            sys.stderr.write("Did not find 'Python.h' in %s.\n" % (be.include_dirs,))
+            return False
+
+        compiler = new_compiler(compiler=be.compiler)
+        customize_compiler(compiler)
+
+        executables = []
+        if compiler.compiler_type in ('unix', 'cygwin'):
+            executables = [compiler.executables[exe][0] for exe in ('compiler_so', 'linker_so')]
+        elif compiler.compiler_type == 'nt':
+            executables = [getattr(compiler, exe) for exe in ('cc', 'linker')]
+
+        if executables:
+            from distutils.spawn import find_executable
+            for exe in executables:
+                if not find_executable(exe):
+                    sys.stderr.write("Failed to find %s for compiler type %s.\n" % (exe, compiler.compiler_type))
+                    return False
+
+    except Exception as exc:
+        sys.stderr.write('%s\n' % str(exc))
+        sys.stderr.write("Failed pre-build check. Attempting anyway.\n")
+
+    # if we are unable to positively id the compiler type, or one of these assumptions fails,
+    # just proceed as we would have without the check
+    return True
+
+
 def run_setup(extensions):
 
     kw = {'cmdclass': {'doc': DocCommand}}
@@ -336,7 +383,14 @@ def run_setup(extensions):
     kw['ext_modules'] = [Extension('DUMMY', [])]  # dummy extension makes sure build_ext is called for install
 
     if try_cython:
-        kw['setup_requires'] = ['Cython>=0.20']
+        # precheck compiler before adding to setup_requires
+        # we don't actually negate try_cython because:
+        # 1.) build_ext eats errors at compile time, letting the install complete while producing useful feedback
+        # 2.) there could be a case where the python environment has cython installed but the system doesn't have build tools
+        if pre_build_check():
+            kw['setup_requires'] = ['Cython>=0.20']
+        else:
+            sys.stderr.write("Bypassing Cython setup requirement\n")
 
     dependencies = ['six >=1.6']
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -89,6 +89,8 @@ def _get_cass_version_from_dse(dse_version):
         cass_ver = "2.0"
     elif dse_version.startswith('4.7') or dse_version.startswith('4.8'):
         cass_ver = "2.1"
+    elif dse_version.startswith('5.0'):
+        cass_ver = "3.0"
     else:
         log.error("Uknown dse version found {0}, defaulting to 2.1".format(dse_version))
         cass_ver = "2.1"

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -17,8 +17,12 @@ try:
 except ImportError:
     import unittest  # noqa
 
+import logging
+import os
 import socket
-import os, six, time, sys, logging, traceback
+import sys
+import time
+import traceback
 from threading import Event
 from subprocess import call
 from itertools import groupby
@@ -147,9 +151,9 @@ lessthancass30 = unittest.skipUnless(CASSANDRA_VERSION < '3.0', 'Cassandra versi
 def wait_for_node_socket(node, timeout):
     binary_itf = node.network_interfaces['binary']
     if not common.check_socket_listening(binary_itf, timeout=timeout):
-        print("Unable to connect to binary socket for node"+str(node))
+        log.warn("Unable to connect to binary socket for node " + node.name)
     else:
-        print("Node is up and listening "+str(node))
+        log.debug("Node %s is up and listening " % (node.name,))
 
 
 def check_socket_listening(itf, timeout=60):
@@ -267,13 +271,13 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True):
         if start:
             log.debug("Starting CCM cluster: {0}".format(cluster_name))
             CCM_CLUSTER.start(wait_for_binary_proto=True, wait_other_notice=True, jvm_args=jvm_args)
-            #Added to wait for slow nodes to start up
+            # Added to wait for slow nodes to start up
             for node in CCM_CLUSTER.nodes.values():
                 wait_for_node_socket(node, 120)
             setup_keyspace(ipformat=ipformat)
     except Exception:
         log.exception("Failed to start CCM cluster; removing cluster.")
-        
+
         if os.name == "nt":
             if CCM_CLUSTER:
                 for node in CCM_CLUSTER.nodes.itervalues():
@@ -588,5 +592,3 @@ class BasicExistingSegregatedKeyspaceUnitTestCase(BasicKeyspaceUnitTestCase):
 
     def tearDown(self):
         self.cluster.shutdown()
-
-

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -161,7 +161,7 @@ def check_socket_listening(itf, timeout=60):
             sock.close()
             return True
         except socket.error:
-            # Try again in another 200ms                                         
+            # Try again in another 200ms
             time.sleep(.2)
             continue
     return False

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -88,6 +88,23 @@ class TestDatetime(BaseCassEngTestCase):
         dts = self.DatetimeTest.objects.filter(test_id=1).values_list('created_at')
         assert dts[0][0] is None
 
+    def test_datetime_invalid(self):
+        dt_value= 'INVALID'
+        with self.assertRaises(TypeError):
+            self.DatetimeTest.objects.create(test_id=2, created_at=dt_value)
+
+    def test_datetime_timestamp(self):
+        dt_value = 1454520554
+        self.DatetimeTest.objects.create(test_id=2, created_at=dt_value)
+        dt2 = self.DatetimeTest.objects(test_id=2).first()
+        assert dt2.created_at == datetime.utcfromtimestamp(dt_value)
+
+    def test_datetime_large(self):
+        dt_value = datetime(2038, 12, 31, 10, 10, 10, 123000)
+        self.DatetimeTest.objects.create(test_id=2, created_at=dt_value)
+        dt2 = self.DatetimeTest.objects(test_id=2).first()
+        assert dt2.created_at == dt_value
+
 
 class TestBoolDefault(BaseCassEngTestCase):
     class BoolDefaultValueTest(Model):

--- a/tests/unit/cython/test_types.py
+++ b/tests/unit/cython/test_types.py
@@ -1,0 +1,28 @@
+# Copyright 2013-2016 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests.unit.cython.utils import cyimport, cythontest
+types_testhelper = cyimport('tests.unit.cython.types_testhelper')
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa
+
+
+class TypesTest(unittest.TestCase):
+
+    @cythontest
+    def test_datetype(self):
+        types_testhelper.test_datetype(self.assertEqual)

--- a/tests/unit/cython/test_utils.py
+++ b/tests/unit/cython/test_utils.py
@@ -1,0 +1,29 @@
+# Copyright 2013-2016 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tests.unit.cython.utils import cyimport, cythontest
+utils_testhelper = cyimport('tests.unit.cython.utils_testhelper')
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa
+
+
+class UtilsTest(unittest.TestCase):
+    """Test Cython Utils functions"""
+
+    @cythontest
+    def test_datetime_from_timestamp(self):
+        utils_testhelper.test_datetime_from_timestamp(self.assertEqual)

--- a/tests/unit/cython/types_testhelper.pyx
+++ b/tests/unit/cython/types_testhelper.pyx
@@ -1,0 +1,65 @@
+# Copyright 2013-2016 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import time
+import datetime
+
+include '../../../cassandra/ioutils.pyx'
+
+from cassandra.cqltypes import DateType
+from cassandra.deserializers import find_deserializer
+from cassandra.bytesio cimport BytesIOReader
+from cassandra.buffer cimport Buffer
+from cassandra.deserializers cimport from_binary, Deserializer
+
+
+def test_datetype(assert_equal):
+
+    cdef Deserializer des = find_deserializer(DateType)
+
+    def deserialize(timestamp):
+        """Serialize a datetime and deserialize it using the cython deserializer"""
+
+        cdef BytesIOReader reader
+        cdef Buffer buf
+
+        dt = datetime.datetime.utcfromtimestamp(timestamp)
+        reader = BytesIOReader(b'\x00\x00\x00\x08' + DateType.serialize(dt, 0))
+        get_buf(reader, &buf)
+        deserialized_dt = from_binary(des, &buf, 0)
+
+        return deserialized_dt
+
+    # deserialize
+    # epoc
+    expected = 0
+    assert_equal(deserialize(expected), datetime.datetime.utcfromtimestamp(expected))
+
+    # beyond 32b
+    expected = 2 ** 33
+    assert_equal(deserialize(expected), datetime.datetime(2242, 3, 16, 12, 56, 32))
+
+    # less than epoc (PYTHON-119)
+    expected = -770172256
+    assert_equal(deserialize(expected), datetime.datetime(1945, 8, 5, 23, 15, 44))
+
+    # work around rounding difference among Python versions (PYTHON-230)
+    # This wont pass with the cython extension until we fix the microseconds alignment with CPython
+    #expected = 1424817268.274
+    #assert_equal(deserialize(expected), datetime.datetime(2015, 2, 24, 22, 34, 28, 274000))
+
+    # Large date overflow (PYTHON-452)
+    expected = 2177403010.123
+    assert_equal(deserialize(expected), datetime.datetime(2038, 12, 31, 10, 10, 10, 123000))

--- a/tests/unit/cython/utils_testhelper.pyx
+++ b/tests/unit/cython/utils_testhelper.pyx
@@ -1,0 +1,23 @@
+# Copyright 2013-2016 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+from cassandra.cython_utils cimport datetime_from_timestamp
+
+
+def test_datetime_from_timestamp(assert_equal):
+    assert_equal(datetime_from_timestamp(1454781157.123456), datetime.datetime(2016, 2, 6, 17, 52, 37, 123456))
+    # PYTHON-452
+    assert_equal(datetime_from_timestamp(2177403010.123456), datetime.datetime(2038, 12, 31, 10, 10, 10, 123456))

--- a/tests/unit/test_time_util.py
+++ b/tests/unit/test_time_util.py
@@ -36,6 +36,8 @@ class TimeUtilTest(unittest.TestCase):
 
         self.assertEqual(util.datetime_from_timestamp(0.123456), datetime.datetime(1970, 1, 1, 0, 0, 0, 123456))
 
+        self.assertEqual(util.datetime_from_timestamp(2177403010.123456), datetime.datetime(2038, 12, 31, 10, 10, 10, 123456))
+
     def test_times_from_uuid1(self):
         node = uuid.getnode()
         now = time.time()

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -204,6 +204,10 @@ class TypeTests(unittest.TestCase):
         expected = 1424817268.274
         self.assertEqual(DateType.deserialize(int64_pack(int(1000 * expected)), 0), datetime.datetime(2015, 2, 24, 22, 34, 28, 274000))
 
+        # Large date overflow (PYTHON-452)
+        expected = 2177403010.123
+        self.assertEqual(DateType.deserialize(int64_pack(int(1000 * expected)), 0), datetime.datetime(2038, 12, 31, 10, 10, 10, 123000))
+
     def test_write_read_string(self):
         with tempfile.TemporaryFile() as f:
             value = u'test'


### PR DESCRIPTION
* Fix date overflow with large timestamp
* Fix microseconds precision for large timestamp. Due to the "double" data type, there was a difference between the cython ext and the pure python implementation. Now, the code uses int64 and avoid floating values to get the same result than the python impl. 