### PR TITLE
PYTHON-395 - cqle: guard against formatting an invalid keyspace in a query

### DIFF
--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -480,7 +480,10 @@ class BaseModel(object):
         """
         cf_name = protect_name(cls._raw_column_family_name())
         if include_keyspace:
-            return '{0}.{1}'.format(protect_name(cls._get_keyspace()), cf_name)
+            keyspace = cls._get_keyspace()
+            if not keyspace:
+                raise CQLEngineException("Model keyspace is not set and no default is available. Set model keyspace or setup connection before attempting to generate a query.")
+            return '{0}.{1}'.format(protect_name(keyspace), cf_name)
 
         return cf_name
 

--- a/tests/integration/cqlengine/model/test_model.py
+++ b/tests/integration/cqlengine/model/test_model.py
@@ -20,6 +20,7 @@ from mock import patch
 
 from cassandra.cqlengine import columns, CQLEngineException
 from cassandra.cqlengine.management import sync_table, drop_table, create_keyspace_simple, drop_keyspace
+from cassandra.cqlengine import models
 from cassandra.cqlengine.models import Model, ModelDefinitionException
 
 
@@ -111,7 +112,6 @@ class TestModel(unittest.TestCase):
         class TestModel(Model):
             k = columns.Integer(primary_key=True)
 
-        from cassandra.cqlengine import models
         # no model keyspace uses default
         self.assertEqual(TestModel.column_family_name(), "%s.test_model" % (models.DEFAULT_KEYSPACE,))
 


### PR DESCRIPTION
Resolves AttributeError when trying to query without a keyspace name,
instead raising a CQLEngineException.