### PR TITLE
PYTHON-346 - cqle: allow db_field for fields in UDTs

### DIFF
--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -384,7 +384,7 @@ class BaseModel(object):
         # and translate that into our local fields
         # the db_map is a db_field -> model field map
         items = values.items()
-        field_dict = dict([(cls._db_map.get(k, k), v) for k, v in items])
+        field_dict = dict((cls._db_map.get(k, k), v) for k, v in items)
 
         if cls._is_polymorphic:
             disc_key = field_dict.get(cls._discriminator_column_name)

--- a/cassandra/cqlengine/usertype.py
+++ b/cassandra/cqlengine/usertype.py
@@ -27,7 +27,6 @@ class BaseUserType(object):
 
     def __init__(self, **values):
         self._values = {}
-
         if self._db_map:
             values = dict((self._db_map.get(k, k), v) for k, v in values.items())
 
@@ -169,7 +168,15 @@ class UserTypeMetaClass(type):
             _transform_column(k, v)
 
         attrs['_fields'] = field_dict
-        attrs['_db_map'] = dict((field.db_field_name, name) for name, field in field_dict.items() if field.db_field_name != name)
+
+        db_map = {}
+        for field_name, field in field_dict.items():
+            db_field = field.db_field_name
+            if db_field != field_name:
+                if db_field in field_dict:
+                    raise UserTypeDefinitionException("db_field '{0}' for field '{1}' conflicts with another attribute name".format(db_field, field_name))
+                db_map[db_field] = field_name
+        attrs['_db_map'] = db_map
 
         klass = super(UserTypeMetaClass, cls).__new__(cls, name, bases, attrs)
 

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -1048,6 +1048,8 @@ def cython_protocol_handler(colparser):
         my_opcodes[FastResultMessage.opcode] = FastResultMessage
         message_types_by_opcode = my_opcodes
 
+        col_parser = colparser
+
     return CythonProtocolHandler
 
 

--- a/tests/integration/cqlengine/model/test_udts.py
+++ b/tests/integration/cqlengine/model/test_udts.py
@@ -22,7 +22,7 @@ from mock import Mock
 from uuid import UUID, uuid4
 
 from cassandra.cqlengine.models import Model
-from cassandra.cqlengine.usertype import UserType
+from cassandra.cqlengine.usertype import UserType, UserTypeDefinitionException
 from cassandra.cqlengine import columns, connection
 from cassandra.cqlengine.management import sync_table, sync_type, create_keyspace_simple, drop_keyspace
 from cassandra.util import Date, Time
@@ -483,3 +483,9 @@ class UserDefinedTypeTests(BaseCassEngTestCase):
         # also excercise the db_Field mapping
         self.assertEqual(info.a, age)
         self.assertEqual(info.n, name)
+
+    def test_db_field_overload(self):
+        with self.assertRaises(UserTypeDefinitionException):
+            class something_silly(UserType):
+                first_col = columns.Integer()
+                second_col = columns.Text(db_field='first_col')


### PR DESCRIPTION
Previously UDTs with different db_fields would not map properly, resulting in None for all fields
inserted or queried.