### PR TITLE
Corrected incorrect reference to self._columns in UserType

### DIFF
--- a/cassandra/cqlengine/usertype.py
+++ b/cassandra/cqlengine/usertype.py
@@ -95,7 +95,7 @@ class BaseUserType(object):
         try:
             return self._len
         except:
-            self._len = len(self._columns.keys())
+            self._len = len(self._fields.keys())
             return self._len
 
     def keys(self):

--- a/tests/integration/cqlengine/model/test_udts.py
+++ b/tests/integration/cqlengine/model/test_udts.py
@@ -489,3 +489,12 @@ class UserDefinedTypeTests(BaseCassEngTestCase):
             class something_silly(UserType):
                 first_col = columns.Integer()
                 second_col = columns.Text(db_field='first_col')
+
+    def test_set_udt_fields(self):
+        class User(UserType):
+            age = columns.Integer()
+            name = columns.Text()
+
+        u = User()
+        u.age = 20
+        self.assertEqual(20, u.age)


### PR DESCRIPTION
This is a very small fix for [PYTHON-502](https://datastax-oss.atlassian.net/browse/PYTHON-502). 

Please let me know if the unit test I added to confirm the fix is not in the correct place.