### PR TITLE
PYTHON-351 - fix various queries when using db_type on partition key column

### DIFF
--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -229,7 +229,6 @@ class ColumnQueryEvaluator(query.AbstractQueryableColumn):
         return self.column.db_field_name
 
     def _get_column(self):
-        """ :rtype: ColumnQueryEvaluator """
         return self.column
 
 
@@ -845,11 +844,11 @@ class ModelMetaClass(type):
         for v in column_dict.values():
             # check for duplicate column names
             if v.db_field_name in col_names:
-                raise ModelException("{0} defines the column {1} more than once".format(name, v.db_field_name))
+                raise ModelException("{0} defines the column '{1}' more than once".format(name, v.db_field_name))
             if v.clustering_order and not (v.primary_key and not v.partition_key):
                 raise ModelException("clustering_order may be specified only for clustering primary keys")
             if v.clustering_order and v.clustering_order.lower() not in ('asc', 'desc'):
-                raise ModelException("invalid clustering order {0} for column {1}".format(repr(v.clustering_order), v.db_field_name))
+                raise ModelException("invalid clustering order '{0}' for column '{1}'".format(repr(v.clustering_order), v.db_field_name))
             col_names.add(v.db_field_name)
 
         # create db_name -> model name map for loading
@@ -857,8 +856,6 @@ class ModelMetaClass(type):
         for col_name, field in column_dict.items():
             db_field = field.db_field_name
             if db_field != col_name:
-                if db_field in column_dict:
-                    raise ModelDefinitionException("db_field '{0}' for column '{1}' conflicts with another attribute name".format(db_field, col_name))
                 db_map[db_field] = col_name
 
         # add management members to the class

--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -451,6 +451,13 @@ class BaseModel(object):
         """
         return cls._columns[name]
 
+    @classmethod
+    def _get_column_by_db_name(cls, name):
+        """
+        Returns the column, mapped by db_field name
+        """
+        return cls._columns.get(cls._db_map.get(name, name))
+
     def __eq__(self, other):
         if self.__class__ != other.__class__:
             return False

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -841,7 +841,7 @@ class ModelQuerySet(AbstractQuerySet):
     def _validate_select_where(self):
         """ Checks that a filterset will not create invalid select statement """
         # check that there's either a =, a IN or a CONTAINS (collection) relationship with a primary key or indexed field
-        equal_ops = [self.model._columns.get(w.field) for w in self._where if isinstance(w.operator, EqualsOperator)]
+        equal_ops = [self.model._get_column_by_db_name(w.field) for w in self._where if isinstance(w.operator, EqualsOperator)]
         token_comparison = any([w for w in self._where if isinstance(w.value, Token)])
         if not any([w.primary_key or w.index for w in equal_ops]) and not token_comparison and not self._allow_filtering:
             raise QueryException(('Where clauses require either  =, a IN or a CONTAINS (collection) '

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -780,8 +780,8 @@ class AbstractQuerySet(object):
         Deletes the contents of a query
         """
         # validate where clause
-        partition_key = [x for x in self.model._primary_keys.values()][0]
-        if not any([c.field == partition_key.column_name for c in self._where]):
+        partition_keys = set(x.db_field_name for x in self.model._partition_keys.values())
+        if partition_keys - set(c.field for c in self._where):
             raise QueryException("The partition key must be defined on delete queries")
 
         dq = DeleteStatement(

--- a/tests/integration/cqlengine/columns/test_container_columns.py
+++ b/tests/integration/cqlengine/columns/test_container_columns.py
@@ -449,7 +449,7 @@ class TestMapColumn(BaseCassEngTestCase):
         m.save()
 
         m2 = TestMapModel.get(partition=m.partition)
-        self.assertEquals(m2.int_map, expected)
+        self.assertEqual(m2.int_map, expected)
 
         m2.int_map = None
         m2.save()

--- a/tests/integration/cqlengine/management/test_compaction_settings.py
+++ b/tests/integration/cqlengine/management/test_compaction_settings.py
@@ -83,7 +83,7 @@ class AlterTableTest(BaseCassEngTestCase):
 
         table_meta = _get_table_metadata(tmp)
 
-        self.assertRegexpMatches(table_meta.export_as_string(), '.*SizeTieredCompactionStrategy.*')
+        self.assertRegex(table_meta.export_as_string(), '.*SizeTieredCompactionStrategy.*')
 
     def test_alter_options(self):
 
@@ -97,11 +97,11 @@ class AlterTableTest(BaseCassEngTestCase):
         drop_table(AlterTable)
         sync_table(AlterTable)
         table_meta = _get_table_metadata(AlterTable)
-        self.assertRegexpMatches(table_meta.export_as_string(), ".*'sstable_size_in_mb': '64'.*")
+        self.assertRegex(table_meta.export_as_string(), ".*'sstable_size_in_mb': '64'.*")
         AlterTable.__options__['compaction']['sstable_size_in_mb'] = '128'
         sync_table(AlterTable)
         table_meta = _get_table_metadata(AlterTable)
-        self.assertRegexpMatches(table_meta.export_as_string(), ".*'sstable_size_in_mb': '128'.*")
+        self.assertRegex(table_meta.export_as_string(), ".*'sstable_size_in_mb': '128'.*")
 
 
 class OptionsTest(BaseCassEngTestCase):

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -209,7 +209,7 @@ class TablePropertiesTests(BaseCassEngTestCase):
         option = 'no way will this ever be an option'
         try:
             ModelWithTableProperties.__options__[option] = 'what was I thinking?'
-            self.assertRaisesRegexp(KeyError, "Invalid table option.*%s.*" % option, sync_table, ModelWithTableProperties)
+            self.assertRaisesRegex(KeyError, "Invalid table option.*%s.*" % option, sync_table, ModelWithTableProperties)
         finally:
             ModelWithTableProperties.__options__.pop(option, None)
 

--- a/tests/integration/cqlengine/model/test_class_construction.py
+++ b/tests/integration/cqlengine/model/test_class_construction.py
@@ -69,9 +69,9 @@ class TestModelClassFunction(BaseCassEngTestCase):
         Tests that trying to create conflicting db column names will fail
         """
 
-        with self.assertRaises(ModelException):
+        with self.assertRaisesRegex(ModelException, r".*more than once$"):
             class BadNames(Model):
-                words = columns.Text()
+                words = columns.Text(primary_key=True)
                 content = columns.Text(db_field='words')
 
     def test_column_ordering_is_preserved(self):
@@ -94,7 +94,6 @@ class TestModelClassFunction(BaseCassEngTestCase):
 
                 count   = columns.Integer()
                 text    = columns.Text(required=False)
-
 
     def test_value_managers_are_keeping_model_instances_isolated(self):
         """


### PR DESCRIPTION
also, a bonus fix for delete queries on models with composite partition keys