### PR TITLE
Adding integration test for PYTHON-486

### DIFF
--- a/tests/integration/cqlengine/columns/test_container_columns.py
+++ b/tests/integration/cqlengine/columns/test_container_columns.py
@@ -566,7 +566,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         """
         Tests creation and insertion of tuple types with models
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result Model is successfully crated
 
@@ -580,7 +580,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         Tests creation and insertion of tuple types with models,
         and their retrieval.
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result Model is successfully crated
 
@@ -596,7 +596,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         Tests creation and insertion of various types with models,
         and their retrieval.
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result Model is successfully created and fetched correctly
 
@@ -617,7 +617,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         """
         Tests to make sure tuple type validation occurs
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result validation errors are raised
 
@@ -632,7 +632,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         Tests that columns instantiated with a column class work properly
         and that the class is instantiated in the constructor
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result types are instantiated correctly
 
@@ -648,7 +648,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         """
         Tests that the default empty container is not saved if it hasn't been updated
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result empty tuple is not upserted
 
@@ -667,7 +667,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         """
         Tests that updates can be preformed on tuple containers
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result tuple is replaced
 
@@ -687,7 +687,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         """
         Tests that explcit none updates are processed correctly on tuples
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result tuple is replaced with none
 
@@ -705,7 +705,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         """
         Tests that Tuples can be created as none
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result tuple is created as none
 
@@ -719,7 +719,7 @@ class TestTupleColumn(BaseCassEngTestCase):
         """
         Tests that Tuples can be updated from none
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-306
         @expected_result tuple is created as none, but upserted to contain values
 
@@ -766,7 +766,7 @@ class TestNestedType(BaseCassEngTestCase):
         """
         Tests creation and insertion of nested collection types with models
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-478
         @expected_result Model is successfully created
 
@@ -780,7 +780,7 @@ class TestNestedType(BaseCassEngTestCase):
         Tests creation and insertion of nested collection types with models,
         and their retrieval.
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-478
         @expected_result Model is successfully crated
 
@@ -798,7 +798,7 @@ class TestNestedType(BaseCassEngTestCase):
         Tests creation and insertion of various nested collection types with models,
         and their retrieval.
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-378
         @expected_result Model is successfully created and fetched correctly
 
@@ -825,7 +825,7 @@ class TestNestedType(BaseCassEngTestCase):
         """
         Tests to make sure nested collection type validation occurs
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-478
         @expected_result validation errors are raised
 
@@ -852,7 +852,7 @@ class TestNestedType(BaseCassEngTestCase):
         Tests that columns instantiated with a column class work properly
         and that the class is instantiated in the constructor
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-478
         @expected_result types are instantiated correctly
 
@@ -872,7 +872,7 @@ class TestNestedType(BaseCassEngTestCase):
         """
         Tests that the default empty nested collection container is not saved if it hasn't been updated
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-478
         @expected_result empty nested collection is not upserted
 
@@ -897,7 +897,7 @@ class TestNestedType(BaseCassEngTestCase):
         """
         Tests that updates can be preformed on nested collections
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-478
         @expected_result nested collection is replaced
 
@@ -926,7 +926,7 @@ class TestNestedType(BaseCassEngTestCase):
         """
         Tests that explcit none updates are processed correctly on tuples
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-478
         @expected_result nested collection is replaced with none
 
@@ -950,7 +950,7 @@ class TestNestedType(BaseCassEngTestCase):
         """
         Tests that Tuples can be created as none
 
-        @since 3.2
+        @since 3.1
         @jira_ticket PYTHON-478
         @expected_result nested collection is created as none
 

--- a/tests/integration/cqlengine/connections/__init__.py
+++ b/tests/integration/cqlengine/connections/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2013-2016 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -1,0 +1,91 @@
+# Copyright 2013-2016 DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa
+
+
+from cassandra.cqlengine.models import Model
+from cassandra.cqlengine import columns, connection
+from cassandra.cqlengine.management import sync_table
+from cassandra.cluster import Cluster
+from cassandra.query import dict_factory
+
+from tests.integration import PROTOCOL_VERSION, execute_with_long_wait_retry
+from tests.integration.cqlengine.base import BaseCassEngTestCase
+
+
+class TestConnectModel(Model):
+
+    id = columns.Integer(primary_key=True)
+    keyspace = columns.Text()
+
+
+class ConnectionTest(BaseCassEngTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.keyspace1 = 'ctest1'
+        cls.keyspace2 = 'ctest2'
+        super(ConnectionTest, cls).setUpClass()
+        cls.setup_cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.setup_session = cls.setup_cluster.connect()
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}}".format(cls.keyspace1, 1)
+        execute_with_long_wait_retry(cls.setup_session, ddl)
+        ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}}".format(cls.keyspace2, 1)
+        execute_with_long_wait_retry(cls.setup_session, ddl)
+
+    @classmethod
+    def tearDownClass(cls):
+        execute_with_long_wait_retry(cls.setup_session, "DROP KEYSPACE {0}".format(cls.keyspace1))
+        execute_with_long_wait_retry(cls.setup_session, "DROP KEYSPACE {0}".format(cls.keyspace2))
+        cls.setup_cluster.shutdown()
+
+    def setUp(self):
+        self.c = Cluster(protocol_version=PROTOCOL_VERSION)
+        self.session1 = self.c.connect(keyspace=self.keyspace1)
+        self.session1.row_factory = dict_factory
+        self.session2 = self.c.connect(keyspace=self.keyspace2)
+        self.session2.row_factory = dict_factory
+
+    def tearDown(self):
+        self.c.shutdown()
+
+    def test_connection_session_switch(self):
+        """
+        Test to ensure that when the default keyspace is changed in a session and that session,
+        is set in the connection class, that the new defaul keyspace is honored.
+
+        @since 3.1
+        @jira_ticket PYTHON-486
+        @expected_result CQLENGINE adopts whatever keyspace is passed in vai the set_session method as default
+
+        @test_category object_mapper
+        """
+
+        connection.set_session(self.session1)
+        sync_table(TestConnectModel)
+        TCM1 = TestConnectModel.create(id=1, keyspace=self.keyspace1)
+        connection.set_session(self.session2)
+        sync_table(TestConnectModel)
+        TCM2 = TestConnectModel.create(id=1, keyspace=self.keyspace2)
+        connection.set_session(self.session1)
+        self.assertEqual(1, TestConnectModel.objects.count())
+        self.assertEqual(TestConnectModel.objects.first(), TCM1)
+        connection.set_session(self.session2)
+        self.assertEqual(1, TestConnectModel.objects.count())
+        self.assertEqual(TestConnectModel.objects.first(), TCM2)
+


### PR DESCRIPTION
Fixing some bad test documentation, and adding integration test for PYTHON-486.