### PR TITLE
Fix EventletConnection without ssl on recent versions of eventlet

### DIFF
--- a/cassandra/io/eventletreactor.py
+++ b/cassandra/io/eventletreactor.py
@@ -38,7 +38,8 @@ def is_timeout(err):
     return (
         err in (EINPROGRESS, EALREADY, EWOULDBLOCK) or
         (err == EINVAL and os.name in ('nt', 'ce')) or
-        (isinstance(err, ssl.SSLError) and err.args[0] == 'timed out')
+        (isinstance(err, ssl.SSLError) and err.args[0] == 'timed out') or
+        isinstance(err, socket.timeout)
     )
 
 


### PR DESCRIPTION
It seems recent versions of eventlet (tested on 0.18.4) has changed
which exception is raised on timeout during recv(). This was not
handled properly by PR #485 which caused a regression.