### PR TITLE
PYTHON-323  Integration test for PYTHON-323  and other general test fixes

### DIFF
--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -26,6 +26,8 @@ from cassandra.query import dict_factory
 
 from tests.integration import PROTOCOL_VERSION, execute_with_long_wait_retry
 from tests.integration.cqlengine.base import BaseCassEngTestCase
+from tests.integration.cqlengine import DEFAULT_KEYSPACE, setup_connection
+from cassandra.cqlengine import models
 
 
 class TestConnectModel(Model):
@@ -38,6 +40,7 @@ class ConnectionTest(BaseCassEngTestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.original_cluster = connection.cluster
         cls.keyspace1 = 'ctest1'
         cls.keyspace2 = 'ctest2'
         super(ConnectionTest, cls).setUpClass()
@@ -52,7 +55,11 @@ class ConnectionTest(BaseCassEngTestCase):
     def tearDownClass(cls):
         execute_with_long_wait_retry(cls.setup_session, "DROP KEYSPACE {0}".format(cls.keyspace1))
         execute_with_long_wait_retry(cls.setup_session, "DROP KEYSPACE {0}".format(cls.keyspace2))
+        models.DEFAULT_KEYSPACE = DEFAULT_KEYSPACE
+        cls.original_cluster.shutdown()
         cls.setup_cluster.shutdown()
+        setup_connection(DEFAULT_KEYSPACE)
+        models.DEFAULT_KEYSPACE
 
     def setUp(self):
         self.c = Cluster(protocol_version=PROTOCOL_VERSION)

--- a/tests/integration/cqlengine/management/test_compaction_settings.py
+++ b/tests/integration/cqlengine/management/test_compaction_settings.py
@@ -83,7 +83,7 @@ class AlterTableTest(BaseCassEngTestCase):
 
         table_meta = _get_table_metadata(tmp)
 
-        self.assertRegex(table_meta.export_as_string(), '.*SizeTieredCompactionStrategy.*')
+        self.assertRegexpMatches(table_meta.export_as_string(), '.*SizeTieredCompactionStrategy.*')
 
     def test_alter_options(self):
 
@@ -97,11 +97,11 @@ class AlterTableTest(BaseCassEngTestCase):
         drop_table(AlterTable)
         sync_table(AlterTable)
         table_meta = _get_table_metadata(AlterTable)
-        self.assertRegex(table_meta.export_as_string(), ".*'sstable_size_in_mb': '64'.*")
+        self.assertRegexpMatches(table_meta.export_as_string(), ".*'sstable_size_in_mb': '64'.*")
         AlterTable.__options__['compaction']['sstable_size_in_mb'] = '128'
         sync_table(AlterTable)
         table_meta = _get_table_metadata(AlterTable)
-        self.assertRegex(table_meta.export_as_string(), ".*'sstable_size_in_mb': '128'.*")
+        self.assertRegexpMatches(table_meta.export_as_string(), ".*'sstable_size_in_mb': '128'.*")
 
 
 class OptionsTest(BaseCassEngTestCase):

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -207,7 +207,7 @@ class TablePropertiesTests(BaseCassEngTestCase):
         option = 'no way will this ever be an option'
         try:
             ModelWithTableProperties.__options__[option] = 'what was I thinking?'
-            self.assertRaisesRegex(KeyError, "Invalid table option.*%s.*" % option, sync_table, ModelWithTableProperties)
+            self.assertRaisesRegexp(KeyError, "Invalid table option.*%s.*" % option, sync_table, ModelWithTableProperties)
         finally:
             ModelWithTableProperties.__options__.pop(option, None)
 

--- a/tests/integration/cqlengine/test_batch_query.py
+++ b/tests/integration/cqlengine/test_batch_query.py
@@ -223,7 +223,7 @@ class BatchQueryCallbacksTests(BaseCassEngTestCase):
                 batch.execute()
             batch.execute()
         self.assertEqual(len(w), 2)  # package filter setup to warn always
-        self.assertRegex(str(w[0].message), r"^Batch.*multiple.*")
+        self.assertRegexpMatches(str(w[0].message), r"^Batch.*multiple.*")
 
     def test_disable_multiple_callback_warning(self):
         """


### PR DESCRIPTION
TestCase for PYTHON-323.
Fix for test_connection.py so that it returns to the default keyspace.
Regex assertion fixes