### PR TITLE
Correctly encode UDT types

### DIFF
--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -138,8 +138,11 @@ class Encoder(object):
     def cql_encode_object(self, val):
         """
         Default encoder for all objects that do not have a specific encoder function
-        registered. This function simply calls :meth:`str()` on the object.
+        registered. If this object has _asdict() defined (e.g. namedtuple), it will be called first.
+        Otherwise, this function simply calls :meth:`str()` on the object.
         """
+        if hasattr(val, '_asdict'):
+            return self.cql_encode_map_collection(val._asdict())
         return str(val)
 
     def cql_encode_float(self, val):


### PR DESCRIPTION
User-defined types are not currently encoded correctly.
If there's a UDT type "Point" with fields "x" and "y", it is currently encoded as:
Point(x=1.23, y=12.2)
However, in CQL, it should be encoded as:
{x: 1.23, y=12.2}
