### PR TITLE
Fix for #Python-533. Secondary index on set field

### DIFF
--- a/cassandra/cqlengine/management.py
+++ b/cassandra/cqlengine/management.py
@@ -113,7 +113,8 @@ def _get_index_name_by_column(table, column_name):
     """
     for _, index_metadata in six.iteritems(table.indexes):
         options = dict(index_metadata.index_options)
-        if 'target' in options and options['target'] == column_name:
+        possible_index_values = [column_name, "values(%s)" % column_name]
+        if 'target' in options and options['target'] in possible_index_values:
             return index_metadata.name
 
     return None


### PR DESCRIPTION
Sync table fails on complex fields with index=True. It tries to create duplicate index. 

This happens because for complex field - index target look like "values(<column_name>)" instead of "<column_name>".  

Jira Issue: https://datastax-oss.atlassian.net/browse/PYTHON-533?jql=text%20~%20%22secondary%22 