### PR TITLE
PYTHON-528 - cqle: support more comparisons in LWT conditional

### DIFF
--- a/cassandra/cqlengine/operators.py
+++ b/cassandra/cqlengine/operators.py
@@ -60,6 +60,11 @@ class EqualsOperator(BaseWhereOperator):
     cql_symbol = '='
 
 
+class NotEqualsOperator(BaseWhereOperator):
+    symbol = 'NE'
+    cql_symbol = '!='
+
+
 class InOperator(EqualsOperator):
     symbol = 'IN'
     cql_symbol = 'IN'

--- a/cassandra/cqlengine/statements.py
+++ b/cassandra/cqlengine/statements.py
@@ -527,8 +527,6 @@ class BaseCQLStatement(UnicodeMixin):
         :param clause: The clause that will be added to the iff statement
         :type clause: ConditionalClause
         """
-        if not isinstance(clause, ConditionalClause):
-            raise StatementException('only instances of AssignmentClause can be added to statements')
         clause.set_context_id(self.context_counter)
         self.context_counter += clause.get_context_size()
         self.conditionals.append(clause)


### PR DESCRIPTION
also fixes an issue where iff did not use the column's db_field

PYTHON-528