### PR TITLE
PYTHNON-525. Adding decorator for counting underlying query execution

### DIFF
--- a/tests/integration/cqlengine/__init__.py
+++ b/tests/integration/cqlengine/__init__.py
@@ -90,9 +90,13 @@ def execute_count(expected):
             count.get_counter()
             # DeMonkey Patch our code
             cassandra.cqlengine.connection.execute = original_function
+            # Check to see if we have a pre-existing test case to work from.
+            if len(args) is 0:
+                test_case = unittest.TestCase("__init__")
+            else:
+                test_case = args[0]
             # Check to see if the count is what you expect
-            tc = unittest.TestCase("__init__")
-            tc.assertEquals(count.get_counter(), expected, "Expected number of cassandra.cqlengine.connection.execute calls doesn't match actual number invoked Expected: {0}, Invoked {1}".format(count.get_counter(), expected))
+            test_case.assertEqual(count.get_counter(), expected, msg="Expected number of cassandra.cqlengine.connection.execute calls doesn't match actual number invoked Expected: {0}, Invoked {1}".format(count.get_counter(), expected))
             return to_return
         # Name of the wrapped function must match the original or unittest will error out.
         wrapped_function.__name__ = fn.__name__

--- a/tests/integration/cqlengine/__init__.py
+++ b/tests/integration/cqlengine/__init__.py
@@ -14,13 +14,21 @@
 
 import os
 import warnings
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa
 from cassandra import ConsistencyLevel
 
 from cassandra.cqlengine import connection
 from cassandra.cqlengine.management import create_keyspace_simple, CQLENG_ALLOW_SCHEMA_MANAGEMENT
+import cassandra
 
 from tests.integration import get_server_versions, use_single_node, PROTOCOL_VERSION
 DEFAULT_KEYSPACE = 'cqlengine_test'
+
+
+CQL_SKIP_EXECUTE = bool(os.getenv('CQL_SKIP_EXECUTE', False))
 
 
 def setup_package():
@@ -44,3 +52,57 @@ def setup_connection(keyspace_name):
                      consistency=ConsistencyLevel.ONE,
                      protocol_version=PROTOCOL_VERSION,
                      default_keyspace=keyspace_name)
+
+
+class StatementCounter(object):
+    """
+    Simple python object used to hold a count of the number of times
+    the wrapped method has been invoked
+    """
+    def __init__(self, patched_func):
+        self.func = patched_func
+        self.counter = 0
+
+    def wrapped_execute(self, *args, **kwargs):
+        self.counter += 1
+        return self.func(*args, **kwargs)
+
+    def get_counter(self):
+        return self.counter
+
+
+def execute_count(expected):
+    """
+    A decorator used wrap cassandra.cqlengine.connection.execute. It counts the number of times this method is invoked
+    then compares it to the number expected. If they don't match it throws an assertion error.
+    This function can be disabled by running the test harness with the env variable CQL_SKIP_EXECUTE=1 set
+    """
+    def innerCounter(fn):
+        def wrapped_function(*args, **kwargs):
+            # Create a counter monkey patch into cassandra.cqlengine.connection.execute
+            count = StatementCounter(cassandra.cqlengine.connection.execute)
+            original_function = cassandra.cqlengine.connection.execute
+            # Monkey patch in our StatementCounter wrapper
+            cassandra.cqlengine.connection.execute = count.wrapped_execute
+            # Invoked the underlying unit test
+            to_return = fn(*args, **kwargs)
+            # Get the count from our monkey patched counter
+            count.get_counter()
+            # DeMonkey Patch our code
+            cassandra.cqlengine.connection.execute = original_function
+            # Check to see if the count is what you expect
+            tc = unittest.TestCase("__init__")
+            tc.assertEquals(count.get_counter(), expected, "Expected number of cassandra.cqlengine.connection.execute calls doesn't match actual number invoked Expected: {0}, Invoked {1}".format(count.get_counter(), expected))
+            return to_return
+        # Name of the wrapped function must match the original or unittest will error out.
+        wrapped_function.__name__ = fn.__name__
+        wrapped_function.__doc__ = fn.__doc__
+        # Escape hatch
+        if(CQL_SKIP_EXECUTE):
+            return fn
+        else:
+            return wrapped_function
+
+    return innerCounter
+
+

--- a/tests/integration/cqlengine/query/test_datetime_queries.py
+++ b/tests/integration/cqlengine/query/test_datetime_queries.py
@@ -20,15 +20,17 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 
 from cassandra.cqlengine.management import sync_table
 from cassandra.cqlengine.management import drop_table
-from cassandra.cqlengine.models import Model, ModelException
+from cassandra.cqlengine.models import Model
 from cassandra.cqlengine import columns
-from cassandra.cqlengine import query
+from tests.integration.cqlengine import execute_count
+
 
 class DateTimeQueryTestModel(Model):
 
-    user        = columns.Integer(primary_key=True)
-    day         = columns.DateTime(primary_key=True)
-    data        = columns.Text()
+    user = columns.Integer(primary_key=True)
+    day = columns.DateTime(primary_key=True)
+    data = columns.Text()
+
 
 class TestDateTimeQueries(BaseCassEngTestCase):
 
@@ -46,12 +48,12 @@ class TestDateTimeQueries(BaseCassEngTestCase):
                     data=str(uuid4())
                 )
 
-
     @classmethod
     def tearDownClass(cls):
         super(TestDateTimeQueries, cls).tearDownClass()
         drop_table(DateTimeQueryTestModel)
 
+    @execute_count(1)
     def test_range_query(self):
         """ Tests that loading from a range of dates works properly """
         start = datetime(*self.base_date.timetuple()[:3])
@@ -60,6 +62,7 @@ class TestDateTimeQueries(BaseCassEngTestCase):
         results = DateTimeQueryTestModel.filter(user=0, day__gte=start, day__lt=end)
         assert len(results) == 3
 
+    @execute_count(3)
     def test_datetime_precision(self):
         """ Tests that millisecond resolution is preserved when saving datetime objects """
         now = datetime.now()

--- a/tests/integration/cqlengine/query/test_named.py
+++ b/tests/integration/cqlengine/query/test_named.py
@@ -25,7 +25,7 @@ from cassandra.cqlengine.query import ResultObject
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.cqlengine import models
 
-from tests.integration.cqlengine import setup_connection
+from tests.integration.cqlengine import setup_connection, execute_count
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query.test_queryset import BaseQuerySetUsage
 
@@ -134,6 +134,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
         cls.keyspace = NamedKeyspace(ks)
         cls.table = cls.keyspace.table(tn)
 
+    @execute_count(2)
     def test_count(self):
         """ Tests that adding filtering statements affects the count query as expected """
         assert self.table.objects.count() == 12
@@ -141,6 +142,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
         q = self.table.objects(test_id=0)
         assert q.count() == 4
 
+    @execute_count(2)
     def test_query_expression_count(self):
         """ Tests that adding query statements affects the count query as expected """
         assert self.table.objects.count() == 12
@@ -148,6 +150,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
         q = self.table.objects(self.table.column('test_id') == 0)
         assert q.count() == 4
 
+    @execute_count(3)
     def test_iteration(self):
         """ Tests that iterating over a query set pulls back all of the expected results """
         q = self.table.objects(test_id=0)
@@ -181,6 +184,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
             compare_set.remove(val)
         assert len(compare_set) == 0
 
+    @execute_count(2)
     def test_multiple_iterations_work_properly(self):
         """ Tests that iterating over a query set more than once works """
         # test with both the filtering method and the query method
@@ -201,6 +205,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
                 compare_set.remove(val)
             assert len(compare_set) == 0
 
+    @execute_count(2)
     def test_multiple_iterators_are_isolated(self):
         """
         tests that the use of one iterator does not affect the behavior of another
@@ -214,6 +219,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
                 assert next(iter1).attempt_id == attempt_id
                 assert next(iter2).attempt_id == attempt_id
 
+    @execute_count(3)
     def test_get_success_case(self):
         """
         Tests that the .get() method works on new and existing querysets
@@ -235,6 +241,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
         assert m.test_id == 0
         assert m.attempt_id == 0
 
+    @execute_count(3)
     def test_query_expression_get_success_case(self):
         """
         Tests that the .get() method works on new and existing querysets
@@ -256,6 +263,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
         assert m.test_id == 0
         assert m.attempt_id == 0
 
+    @execute_count(1)
     def test_get_doesnotexist_exception(self):
         """
         Tests that get calls that don't return a result raises a DoesNotExist error
@@ -263,6 +271,7 @@ class TestQuerySetCountSelectionAndIteration(BaseQuerySetUsage):
         with self.assertRaises(self.table.DoesNotExist):
             self.table.objects.get(test_id=100)
 
+    @execute_count(1)
     def test_get_multipleobjects_exception(self):
         """
         Tests that get calls that return multiple results raise a MultipleObjectsReturned error
@@ -286,6 +295,7 @@ class TestNamedWithMV(BasicSharedKeyspaceUnitTestCase):
         super(TestNamedWithMV, cls).tearDownClass()
 
     @greaterthanorequalcass30
+    @execute_count(5)
     def test_named_table_with_mv(self):
         """
         Test NamedTable access to materialized views

--- a/tests/integration/cqlengine/query/test_queryoperators.py
+++ b/tests/integration/cqlengine/query/test_queryoperators.py
@@ -24,6 +24,7 @@ from cassandra.cqlengine.operators import EqualsOperator
 from cassandra.cqlengine.statements import WhereClause
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
 from tests.integration.cqlengine.base import BaseCassEngTestCase
+from tests.integration.cqlengine import execute_count
 
 
 class TestQuerySetOperation(BaseCassEngTestCase):
@@ -71,6 +72,7 @@ class TestTokenFunction(BaseCassEngTestCase):
         super(TestTokenFunction, self).tearDown()
         drop_table(TokenTestModel)
 
+    @execute_count(14)
     def test_token_function(self):
         """ Tests that token functions work properly """
         assert TokenTestModel.objects().count() == 0
@@ -127,6 +129,7 @@ class TestTokenFunction(BaseCassEngTestCase):
         func = functions.Token('a')
         self.assertRaises(query.QueryException, TestModel.objects.filter, pk__token__gt=func)
 
+    @execute_count(7)
     def test_named_table_pk_token_function(self):
         """
         Test to ensure that token function work with named tables.


### PR DESCRIPTION
 Also Updating some tests to add expected query counts.

There are more places we can annotate, such as table syncs and UDTS, but this is a decent enough start, and would have caught the error that spawned this issue. 
 

