### PR TITLE
Benchmarks read

### DIFF
--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -136,7 +136,7 @@ def benchmark(thread_class):
         for i in range(options.num_columns):
             insert_query += ", col{}".format(i)
 
-        insert_query += ") VALUES ('{}'".format('key')
+        insert_query += ") VALUES ('{key}'"
 
         for i in range(options.num_columns):
             insert_query += ", {}".format(COLUMN_VALUES[options.column_type])

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -63,8 +63,7 @@ TABLE = "testtable"
 def setup(hosts):
     log.info("Using 'cassandra' package from %s", cassandra.__path__)
 
-    cluster = Cluster(hosts, protocol_version=1)
-    cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
+    cluster = Cluster(hosts)
     try:
         session = cluster.connect()
 
@@ -91,8 +90,7 @@ def setup(hosts):
 
 
 def teardown(hosts):
-    cluster = Cluster(hosts, protocol_version=1)
-    cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
+    cluster = Cluster(hosts)
     session = cluster.connect()
     session.execute("DROP KEYSPACE " + KEYSPACE)
     cluster.shutdown()

--- a/benchmarks/callback_full_pipeline.py
+++ b/benchmarks/callback_full_pipeline.py
@@ -41,8 +41,10 @@ class Runner(BenchmarkThread):
             if next(self.num_finished) >= self.num_queries:
                 self.event.set()
 
-        if next(self.num_started) <= self.num_queries:
-            future = self.session.execute_async(self.query, self.values, timeout=None)
+        i = next(self.num_started)
+        if  i <= self.num_queries:
+            key = "{}-{}".format(self.thread_num, i)
+            future = self.session.execute_async(self.query.format(key=key), timeout=None)
             future.add_callbacks(self.insert_next, self.insert_next)
 
     def run(self):

--- a/benchmarks/callback_full_pipeline.py
+++ b/benchmarks/callback_full_pipeline.py
@@ -44,7 +44,7 @@ class Runner(BenchmarkThread):
         i = next(self.num_started)
         if  i <= self.num_queries:
             key = "{}-{}".format(self.thread_num, i)
-            future = self.session.execute_async(self.query.format(key=key), timeout=None)
+            future = self.run_query(key, timeout=None)
             future.add_callbacks(self.insert_next, self.insert_next)
 
     def run(self):

--- a/benchmarks/future_batches.py
+++ b/benchmarks/future_batches.py
@@ -35,7 +35,8 @@ class Runner(BenchmarkThread):
                     except queue.Empty:
                         break
 
-            future = self.session.execute_async(self.query, self.values)
+            key = "{}-{}".format(self.thread_num, i)
+            future = self.session.execute_async(self.query.format(key=key))
             futures.put_nowait(future)
 
         while True:

--- a/benchmarks/future_batches.py
+++ b/benchmarks/future_batches.py
@@ -36,7 +36,7 @@ class Runner(BenchmarkThread):
                         break
 
             key = "{}-{}".format(self.thread_num, i)
-            future = self.session.execute_async(self.query.format(key=key))
+            future = self.run_query(key)
             futures.put_nowait(future)
 
         while True:

--- a/benchmarks/future_full_pipeline.py
+++ b/benchmarks/future_full_pipeline.py
@@ -32,7 +32,7 @@ class Runner(BenchmarkThread):
                 old_future.result()
 
             key = "{}-{}".format(self.thread_num, i)
-            future = self.session.execute_async(self.query.format(key=key))
+            future = self.run_query(key)
             futures.put_nowait(future)
 
         while True:

--- a/benchmarks/future_full_pipeline.py
+++ b/benchmarks/future_full_pipeline.py
@@ -31,7 +31,8 @@ class Runner(BenchmarkThread):
                 old_future = futures.get_nowait()
                 old_future.result()
 
-            future = self.session.execute_async(self.query, self.values)
+            key = "{}-{}".format(self.thread_num, i)
+            future = self.session.execute_async(self.query.format(key=key))
             futures.put_nowait(future)
 
         while True:

--- a/benchmarks/future_full_throttle.py
+++ b/benchmarks/future_full_throttle.py
@@ -25,8 +25,9 @@ class Runner(BenchmarkThread):
 
         self.start_profile()
 
-        for _ in range(self.num_queries):
-            future = self.session.execute_async(self.query, self.values)
+        for i in range(self.num_queries):
+            key = "{}-{}".format(self.thread_num, i)
+            future = self.session.execute_async(self.query.format(key=key))
             futures.append(future)
 
         for future in futures:

--- a/benchmarks/future_full_throttle.py
+++ b/benchmarks/future_full_throttle.py
@@ -27,7 +27,7 @@ class Runner(BenchmarkThread):
 
         for i in range(self.num_queries):
             key = "{}-{}".format(self.thread_num, i)
-            future = self.session.execute_async(self.query.format(key=key))
+            future = self.run_query(key)
             futures.append(future)
 
         for future in futures:


### PR DESCRIPTION
Add the read benchmark support. As well as the main addition, these features are now also available:

* Specify the keyspace name (-k)
* Keep the data after the benchmark (--keep-data)
* Specify the number of columns for the schema (-c)
* Specify the column type for the schema (--column-type)
* The benchmark now writes N partition keys rather than a single one