### PR TITLE
Support empty string values in NumpyProtocolHandler

### DIFF
--- a/cassandra/deserializers.pyx
+++ b/cassandra/deserializers.pyx
@@ -44,6 +44,8 @@ cdef class Deserializer:
 
 cdef class DesBytesType(Deserializer):
     cdef deserialize(self, Buffer *buf, int protocol_version):
+        if buf.size == 0:
+            return ""
         return to_bytes(buf)
 
 # this is to facilitate cqlsh integration, which requires bytearrays for BytesType
@@ -51,6 +53,8 @@ cdef class DesBytesType(Deserializer):
 # deserializers.DesBytesType = deserializers.DesBytesTypeByteArray
 cdef class DesBytesTypeByteArray(Deserializer):
     cdef deserialize(self, Buffer *buf, int protocol_version):
+        if buf.size == 0:
+            return bytearray()
         return bytearray(buf.ptr[:buf.size])
 
 # TODO: Use libmpdec: http://www.bytereef.org/mpdecimal/index.html
@@ -84,6 +88,8 @@ cdef class DesByteType(Deserializer):
 
 cdef class DesAsciiType(Deserializer):
     cdef deserialize(self, Buffer *buf, int protocol_version):
+        if buf.size == 0:
+            return ""
         if PY2:
             return to_bytes(buf)
         return to_bytes(buf).decode('ascii')
@@ -169,6 +175,8 @@ cdef class DesTimeType(Deserializer):
 
 cdef class DesUTF8Type(Deserializer):
     cdef deserialize(self, Buffer *buf, int protocol_version):
+        if buf.size == 0:
+            return ""
         cdef val = to_bytes(buf)
         return val.decode('utf8')
 

--- a/tests/integration/standard/utils.py
+++ b/tests/integration/standard/utils.py
@@ -45,7 +45,11 @@ def get_all_primitive_params(key):
     """
     params = [key]
     for datatype in PRIMITIVE_DATATYPES:
-        params.append(get_sample(datatype))
+        # Also test for empty strings
+        if key == 1 and datatype == 'ascii':
+            params.append('')
+        else:
+            params.append(get_sample(datatype))
     return params
 
 


### PR DESCRIPTION
This PR addresses a bug in NumpyProtocolHandler to properly handle empty strings:

    https://datastax-oss.atlassian.net/browse/PYTHON-550

It doesn't support NULL string values however, which requires more invasive changes (e.g. making use of NumPy's missing values support).