### PR TITLE
PYTHON-559 - normalize BytesToken values to binary type

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1519,10 +1519,8 @@ class BytesToken(Token):
 
     def __init__(self, token_string):
         """ `token_string` should be string representing the token. """
-        if not isinstance(token_string, six.string_types):
-            raise TypeError(
-                "Tokens for ByteOrderedPartitioner should be strings (got %s)"
-                % (type(token_string),))
+        if isinstance(token_string, six.text_type):
+            token_string = token_string.encode('utf-8')
         self.value = token_string
 
 

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1536,6 +1536,9 @@ class BytesToken(Token):
     @classmethod
     def from_string(cls, token_string):
         """ `token_string` should be the string representation from the server. """
+        # unhexlify works fine with unicode input in everythin but pypy3, where it Raises "TypeError: 'str' does not support the buffer interface"
+        if isinstance(token_string, six.text_type):
+            token_string = token_string.encode('ascii')
         # The BOP stores a hex string
         return cls(unhexlify(token_string))
 

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from binascii import unhexlify
 from bisect import bisect_right
 from collections import defaultdict, Mapping
 from hashlib import md5
@@ -271,7 +272,7 @@ class Metadata(object):
         ring = []
         for host, token_strings in six.iteritems(token_map):
             for token_string in token_strings:
-                token = token_class(token_string)
+                token = token_class.from_string(token_string)
                 ring.append(token)
                 token_to_host_owner[token] = host
 
@@ -1441,6 +1442,9 @@ class Token(object):
     Abstract class representing a token.
     """
 
+    def __init__(self, token):
+        self.value = token
+
     @classmethod
     def hash_fn(cls, key):
         return key
@@ -1448,6 +1452,13 @@ class Token(object):
     @classmethod
     def from_key(cls, key):
         return cls(cls.hash_fn(key))
+
+    @classmethod
+    def from_string(cls, token_string):
+        raise NotImplementedError()
+        """ `token_string` should be the string representation from the server. """
+        # The hash partitioners just store the deciman value
+        return cls(int(token_string))
 
     def __cmp__(self, other):
         if self.value < other.value:
@@ -1478,7 +1489,16 @@ class NoMurmur3(Exception):
     pass
 
 
-class Murmur3Token(Token):
+class HashToken(Token):
+
+    @classmethod
+    def from_string(cls, token_string):
+        """ `token_string` should be the string representation from the server. """
+        # The hash partitioners just store the deciman value
+        return cls(int(token_string))
+
+
+class Murmur3Token(HashToken):
     """
     A token for ``Murmur3Partitioner``.
     """
@@ -1492,11 +1512,11 @@ class Murmur3Token(Token):
             raise NoMurmur3()
 
     def __init__(self, token):
-        """ `token` should be an int or string representing the token. """
+        """ `token` is an int or string representing the token. """
         self.value = int(token)
 
 
-class MD5Token(Token):
+class MD5Token(HashToken):
     """
     A token for ``RandomPartitioner``.
     """
@@ -1507,21 +1527,17 @@ class MD5Token(Token):
             key = key.encode('UTF-8')
         return abs(varint_unpack(md5(key).digest()))
 
-    def __init__(self, token):
-        """ `token` should be an int or string representing the token. """
-        self.value = int(token)
-
 
 class BytesToken(Token):
     """
     A token for ``ByteOrderedPartitioner``.
     """
 
-    def __init__(self, token_string):
-        """ `token_string` should be string representing the token. """
-        if isinstance(token_string, six.text_type):
-            token_string = token_string.encode('utf-8')
-        self.value = token_string
+    @classmethod
+    def from_string(cls, token_string):
+        """ `token_string` should be the string representation from the server. """
+        # The BOP stores a hex string
+        return cls(unhexlify(token_string))
 
 
 class TriggerMetadata(object):

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -1312,7 +1312,7 @@ class TokenMetadataTest(unittest.TestCase):
         cluster.shutdown()
 
     def test_getting_replicas(self):
-        tokens = [MD5Token(str(i)) for i in range(0, (2 ** 127 - 1), 2 ** 125)]
+        tokens = [MD5Token(i) for i in range(0, (2 ** 127 - 1), 2 ** 125)]
         hosts = [Host("ip%d" % i, SimpleConvictionPolicy) for i in range(len(tokens))]
         token_to_primary_replica = dict(zip(tokens, hosts))
         keyspace = KeyspaceMetadata("ks", True, "SimpleStrategy", {"replication_factor": "1"})
@@ -1327,12 +1327,12 @@ class TokenMetadataTest(unittest.TestCase):
 
         # shift the tokens back by one
         for token, expected_host in zip(tokens, hosts):
-            replicas = token_map.get_replicas("ks", MD5Token(str(token.value - 1)))
+            replicas = token_map.get_replicas("ks", MD5Token(token.value - 1))
             self.assertEqual(set(replicas), set([expected_host]))
 
         # shift the tokens forward by one
         for i, token in enumerate(tokens):
-            replicas = token_map.get_replicas("ks", MD5Token(str(token.value + 1)))
+            replicas = token_map.get_replicas("ks", MD5Token(token.value + 1))
             expected_host = hosts[(i + 1) % len(hosts)]
             self.assertEqual(set(replicas), set([expected_host]))
 

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -424,18 +424,18 @@ class UnicodeIdentifiersTests(unittest.TestCase):
 
     def test_keyspace_name(self):
         km = KeyspaceMetadata(self.name, False, 'SimpleStrategy', {'replication_factor': 1})
-        print(km.export_as_string())
+        km.export_as_string()
 
     def test_table_name(self):
         tm = TableMetadata(self.name, self.name)
-        print(tm.export_as_string())
+        tm.export_as_string()
 
     def test_column_name_single_partition(self):
         tm = TableMetadata('ks', 'table')
         cm = ColumnMetadata(tm, self.name, u'int')
         tm.columns[cm.name] = cm
         tm.partition_key.append(cm)
-        print(tm.export_as_string())
+        tm.export_as_string()
 
     def test_column_name_single_partition_single_clustering(self):
         tm = TableMetadata('ks', 'table')
@@ -445,7 +445,7 @@ class UnicodeIdentifiersTests(unittest.TestCase):
         cm = ColumnMetadata(tm, self.name + 'x', u'int')
         tm.columns[cm.name] = cm
         tm.clustering_key.append(cm)
-        print(tm.export_as_string())
+        tm.export_as_string()
 
     def test_column_name_multiple_partition(self):
         tm = TableMetadata('ks', 'table')
@@ -455,22 +455,22 @@ class UnicodeIdentifiersTests(unittest.TestCase):
         cm = ColumnMetadata(tm, self.name + 'x', u'int')
         tm.columns[cm.name] = cm
         tm.partition_key.append(cm)
-        print(tm.export_as_string())
+        tm.export_as_string()
 
     def test_index(self):
         im = IndexMetadata(self.name, self.name, self.name, kind='', index_options={'target': self.name})
-        print(im.export_as_string())
+        im.export_as_string()
         im = IndexMetadata(self.name, self.name, self.name, kind='CUSTOM', index_options={'target': self.name, 'class_name': 'Class'})
-        print(im.export_as_string())
+        im.export_as_string()
 
     def test_function(self):
         fm = Function(self.name, self.name, (u'int', u'int'), (u'x', u'y'), u'int', u'language', self.name, False)
-        print(fm.export_as_string())
+        fm.export_as_string()
 
     def test_aggregate(self):
         am = Aggregate(self.name, self.name, (u'text',), self.name, u'text', self.name, self.name, u'text')
-        print(am.export_as_string())
+        am.export_as_string()
 
     def test_user_type(self):
         um = UserType(self.name, self.name, [self.name, self.name], [u'int', u'text'])
-        print(um.export_as_string())
+        um.export_as_string()

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -311,7 +311,7 @@ class MD5TokensTest(unittest.TestCase):
 class BytesTokensTest(unittest.TestCase):
 
     def test_bytes_tokens(self):
-        bytes_token = BytesToken(unhexlify('01'))
+        bytes_token = BytesToken(unhexlify(six.b('01')))
         self.assertEqual(bytes_token.value, six.b('\x01'))
         self.assertEqual(str(bytes_token), "<BytesToken: %s>" % bytes_token.value)
         self.assertEqual(bytes_token.hash_fn('123'), '123')

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -315,12 +315,6 @@ class BytesTokensTest(unittest.TestCase):
         self.assertEqual(bytes_token.hash_fn(str(cassandra.metadata.MAX_LONG)), str(cassandra.metadata.MAX_LONG))
         self.assertEqual(str(bytes_token), "<BytesToken: -9223372036854775809>")
 
-        try:
-            bytes_token = BytesToken(cassandra.metadata.MIN_LONG - 1)
-            self.fail('Tokens for ByteOrderedPartitioner should be only strings')
-        except TypeError:
-            pass
-
 
 class KeyspaceMetadataTest(unittest.TestCase):
 


### PR DESCRIPTION
fixes UnicodeDecodeError when one value has non-ascii values

