### PR TITLE
Don't use a kwarg to pass a callback to weakref.ref

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2260,7 +2260,7 @@ class ControlConnection(object):
         # _clear_watcher will be called when this ControlConnection is about to be finalized
         # _watch_callback will get the actual callback from the Connection and relay it to
         # this object (after a dereferencing a weakref)
-        self_weakref = weakref.ref(self, callback=partial(_clear_watcher, weakref.proxy(connection)))
+        self_weakref = weakref.ref(self, partial(_clear_watcher, weakref.proxy(connection)))
         try:
             connection.register_watchers({
                 "TOPOLOGY_CHANGE": partial(_watch_callback, self_weakref, '_handle_topology_change'),


### PR DESCRIPTION
Turns out that until recently, weakref.ref() silently ignored its kwargs, but
a recent Python patch causes it to throw an exception instead. This makes cqlsh
error out immediately when using it with the latest Python version.

In order to correctly register the weakref callback, pass it as a regular
argument instead of using a kwarg.

For more information, see this Python issue and related Python 2.7 commit:

    https://bugs.python.org/issue17765
    https://hg.python.org/cpython/rev/60de9c6188cc