### PR TITLE
Don't modify the Metadatas' hosts structure while iterating over it

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -324,7 +324,7 @@ class Metadata(object):
         Returns a list of all known :class:`.Host` instances in the cluster.
         """
         with self._hosts_lock:
-            return self._hosts.values()
+            return list(self._hosts.values())
 
 
 REPLICATION_STRATEGY_CLASS_PREFIX = "org.apache.cassandra.locator."

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -30,7 +30,9 @@ from cassandra.metadata import (Murmur3Token, MD5Token,
                                 LocalStrategy, protect_name,
                                 protect_names, protect_value, is_valid_name,
                                 UserType, KeyspaceMetadata, get_schema_parser,
-                                _UnknownStrategy, ColumnMetadata, TableMetadata, IndexMetadata, Function, Aggregate)
+                                _UnknownStrategy, ColumnMetadata, TableMetadata,
+                                IndexMetadata, Function, Aggregate,
+                                Metadata)
 from cassandra.policies import SimpleConvictionPolicy
 from cassandra.pool import Host
 
@@ -474,3 +476,17 @@ class UnicodeIdentifiersTests(unittest.TestCase):
     def test_user_type(self):
         um = UserType(self.name, self.name, [self.name, self.name], [u'int', u'text'])
         um.export_as_string()
+
+
+class HostsTests(unittest.TestCase):
+    def test_iterate_all_hosts_and_modify(self):
+        metadata = Metadata()
+        metadata.add_or_return_host(Host('dc1.1', SimpleConvictionPolicy))
+        metadata.add_or_return_host(Host('dc1.2', SimpleConvictionPolicy))
+
+        assert len(metadata.all_hosts()) == 2
+
+        for host in metadata.all_hosts():
+            metadata.remove_host(host)
+
+        assert len(metadata.all_hosts()) == 0


### PR DESCRIPTION
On Python 3.x, dict.values() returns a view object and not a list of the
values.
Updating the content of the original dict while iterating over the
values may raise a RuntimeError exception, which is the case in the
Cluster._refresh_node_list_and_token_map() method to remove discovered
hosts which are not part of the specified cluster contact points.

The bug doesn't happen using Python 2.x as dict.values() returns a new
list containing the values of the dictionary, without any other
reference to original dictionary object.

This fix forces the original Python 2.x behavior to be the same in
Python 3.x as well.

PYTHON-572