### PR TITLE
Initial Appveryor enablement

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+      cassandra_version: 3.0.5
+      ci_type: standard
+    - PYTHON: "C:\\Python34"
+      cassandra_version: 3.0.5
+      ci_type: unit
+os: Visual Studio 2015
+platform:
+  - x64
+install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - ps: .\appveyor\appveyor.ps1
+build_script:
+  - cmd: |
+      "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
+      python setup.py install --no-cython
+test_script:
+  -  ps: .\appveyor\run_test.ps1
+cache:
+  - C:\Users\appveyor\.m2
+  - C:\ProgramData\chocolatey\bin
+  - C:\ProgramData\chocolatey\lib
+  - C:\Users\appveyor\jce_policy-1.7.0.zip
+  - C:\Users\appveyor\jce_policy-1.8.0.zip

--- a/appveyor/appveyor.ps1
+++ b/appveyor/appveyor.ps1
@@ -1,0 +1,66 @@
+$env:JAVA_HOME="C:\Program Files\Java\jdk1.8.0"
+$env:PATH="$($env:JAVA_HOME)\bin;$($env:PATH)"
+$env:CCM_PATH="C:\Users\appveyor\ccm"
+$env:CASSANDRA_VERSION=$env:cassandra_version
+python --version
+python -c "import platform; print(platform.architecture())"
+# Install Ant
+Start-Process cinst -ArgumentList @("-y","ant") -Wait -NoNewWindow
+# Workaround for ccm, link ant.exe -> ant.bat
+If (!(Test-Path C:\ProgramData\chocolatey\bin\ant.bat)) {
+  cmd /c mklink C:\ProgramData\chocolatey\bin\ant.bat C:\ProgramData\chocolatey\bin\ant.exe
+}
+
+
+$jce_indicator = "$target\README.txt"
+# Install Java Cryptographic Extensions, needed for SSL.
+If (!(Test-Path $jce_indicator)) {
+  $zip = "C:\Users\appveyor\jce_policy-$($env:java_version).zip"
+  $target = "$($env:JAVA_HOME)\jre\lib\security"
+  # If this file doesn't exist we know JCE hasn't been installed.
+  $url = "https://www.dropbox.com/s/po4308hlwulpvep/UnlimitedJCEPolicyJDK7.zip?dl=1"
+  $extract_folder = "UnlimitedJCEPolicy"
+  If ($env:java_version -eq "1.8.0") {
+    $url = "https://www.dropbox.com/s/al1e6e92cjdv7m7/jce_policy-8.zip?dl=1"
+    $extract_folder = "UnlimitedJCEPolicyJDK8"
+  }
+  # Download zip to staging area if it doesn't exist, we do this because
+  # we extract it to the directory based on the platform and we want to cache
+  # this file so it can apply to all platforms.
+  if(!(Test-Path $zip)) {
+    (new-object System.Net.WebClient).DownloadFile($url, $zip)
+  }
+
+  Add-Type -AssemblyName System.IO.Compression.FileSystem
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($zip, $target)
+
+  $jcePolicyDir = "$target\$extract_folder"
+  Move-Item $jcePolicyDir\* $target\ -force
+  Remove-Item $jcePolicyDir
+}
+
+# Install Python Dependencies for CCM.
+Start-Process python -ArgumentList "-m pip install psutil pyYaml six numpy" -Wait -NoNewWindow
+
+# Clone ccm from git and use master.
+If (!(Test-Path $env:CCM_PATH)) {
+  Start-Process git -ArgumentList "clone https://github.com/pcmanus/ccm.git $($env:CCM_PATH)" -Wait -NoNewWindow
+}
+
+
+# Copy ccm -> ccm.py so windows knows to run it.
+If (!(Test-Path $env:CCM_PATH\ccm.py)) {
+  Copy-Item "$env:CCM_PATH\ccm" "$env:CCM_PATH\ccm.py"
+}
+
+$env:PYTHONPATH="$($env:CCM_PATH);$($env:PYTHONPATH)"
+$env:PATH="$($env:CCM_PATH);$($env:PATH)"
+
+# Predownload cassandra version for CCM if it isn't already downloaded.
+If (!(Test-Path C:\Users\appveyor\.ccm\repository\$env:cassandra_version)) {
+  Start-Process python -ArgumentList "$($env:CCM_PATH)\ccm.py create -v $($env:cassandra_version) -n 1 predownload" -Wait -NoNewWindow
+  Start-Process python -ArgumentList "$($env:CCM_PATH)\ccm.py remove predownload" -Wait -NoNewWindow
+}
+
+Start-Process python -ArgumentList "-m pip install -r test-requirements.txt" -Wait -NoNewWindow
+Start-Process python -ArgumentList "-m pip install nose-ignore-docstring" -Wait -NoNewWindow

--- a/appveyor/run_test.ps1
+++ b/appveyor/run_test.ps1
@@ -1,0 +1,35 @@
+Set-ExecutionPolicy Unrestricted
+Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope Process -force
+Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -force
+Get-ExecutionPolicy -List
+echo $env:Path
+echo $env:JAVA_HOME
+echo $env:PYTHONPATH
+echo $env:CASSANDRA_VERSION
+echo $env:ci_type
+python --version
+python -c "import platform; print(platform.architecture())"
+
+$wc = New-Object 'System.Net.WebClient'
+nosetests -s -v --with-ignore-docstrings --with-xunit --xunit-file=unit_results.xml .\tests\unit
+echo "uploading unit results"
+$wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\unit_results.xml))
+
+if($env:ci_type -eq 'standard' -Or $env:ci_type -eq 'long'){
+    echo "Running CQLEngine integration tests"
+    nosetests -s -v --with-ignore-docstrings --with-xunit --xunit-file=cqlengine_results.xml .\tests\integration\cqlengine
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\cqlengine_results.xml))
+    echo "uploading CQLEngine test results"
+
+    echo "Running standard integration tests"
+    nosetests -s -v --with-ignore-docstrings --with-xunit --xunit-file=standard_results.xml .\tests\integration\standard
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\standard_results.xml))
+    echo "uploading standard integration test results"
+}
+
+if($env:ci_type -eq 'long'){
+    nosetests -s -v --with-ignore-docstrings --with-xunit --xunit-file=cqlengine_results.xml .\tests\integration\cqlengine
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\cqlengine_results.xml))
+    echo "uploading standard integration test results"
+}
+exit 0

--- a/tests/unit/test_concurrent.py
+++ b/tests/unit/test_concurrent.py
@@ -211,10 +211,11 @@ class ConcurrencyTest((unittest.TestCase)):
 
         t = TimedCallableInvoker(our_handler, slowdown=slowdown)
         t.start()
-        results = execute_concurrent(mock_session, statements_and_params, results_generator=True)
-
-        self.validate_result_ordering(results)
-        t.stop()
+        try:
+            results = execute_concurrent(mock_session, statements_and_params, results_generator=True)
+            self.validate_result_ordering(results)
+        finally:
+            t.stop()
 
     def validate_result_ordering(self, results):
         """


### PR DESCRIPTION
This contains all the scripts, and necessary yaml files to get our project building in the appveyor environment. 

It's currently configured to run unit tests against python3.4, and standard Integration tests against 2.7. 
Both against C* 3.0.5

It can also be configured to run long tests and different python/cassandra versions by toggling the values in the matrix portion of the yaml.