### PR TITLE
Fix pool size changing during iteration

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2189,7 +2189,7 @@ class Session(object):
             else:
                 self.is_shutdown = True
 
-        for pool in self._pools.values():
+        for pool in list(self._pools.values()):
             pool.shutdown()
 
     def __enter__(self):


### PR DESCRIPTION
I'm seeing quite a few errors in the test harness where we are iterating over the pool values while they are changing.

The errors look like this.
`
File "/home/jenkins/.pyenv/versions/3.4.3/lib/python3.4/site-packages/unittest2/case.py", line 67, in testPartExecutor
   yield
 File "/home/jenkins/.pyenv/versions/3.4.3/lib/python3.4/site-packages/unittest2/case.py", line 625, in run
   testMethod()
 File "/home/jenkins/workspace/datastax.python-driver.master/e86c5da2/tests/integration/standard/test_metadata.py", line 830, in test_export_keyspace_schema
   cluster.shutdown()
 File "/home/jenkins/workspace/datastax.python-driver.master/e86c5da2/cassandra/cluster.py", line 1204, in shutdown
   session.shutdown()
 File "/home/jenkins/workspace/datastax.python-driver.master/e86c5da2/cassandra/cluster.py", line 2192, in shutdown
   for pool in self._pools.values():
dictionary changed size during iteration`

They only occur in python3. I believe this is because py2 makes a copy on the values() call andy py3 does not.

Explicitly wrapping it in a list seems the remedy the problem and creates a copy on both.
Not sure if this is the best solution, but judging by the regression output it seems to fix the problem