### PR TITLE
Fix problem in detecting schema mismatch due to peer.is_up = None

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2945,7 +2945,10 @@ class ControlConnection(object):
                 continue
             addr = self._rpc_from_peer_row(row)
             peer = self._cluster.metadata.get_host(addr)
-            if peer and peer.is_up and pm.distance(peer) != HostDistance.IGNORED:
+            # Are we sure we need to consider the distance? Even if we do not contact
+            # a remote host directly, mutations are still propagated to it, can we at
+            # least have a parameter to ignore it?
+            if peer and peer.is_up is not False and pm.distance(peer) != HostDistance.IGNORED:
                 versions[schema_ver].add(addr)
 
         if len(versions) == 1:


### PR DESCRIPTION
Whilst working on CASSANDRA-11950, I was having problems eliminating `UnknownColumnFamilyException` warnings from the logs. The cause is two-fold:

* `peer.is_up` can be None rather than True
* the distance can be `HostDistance.IGNORED` for remote nodes, unless we use a DC aware load balancing policy with `used_hosts_per_remote_dc` set to the maximum number of remote nodes.

I'm not sure we should exclude nodes with distance ignored because even if the client doesn't contact them directly, they can still have mutations propagated to them, for example at EACH_QUORUM, at a minimum could we make this configurable?