### PR TITLE
Extend no-op model update tests to primary keys

### DIFF
--- a/tests/integration/cqlengine/model/test_updates.py
+++ b/tests/integration/cqlengine/model/test_updates.py
@@ -79,8 +79,8 @@ class ModelUpdateTests(BaseCassEngTestCase):
         self.assertEqual(m2.count, m1.count)
         self.assertEqual(m2.text, m0.text)
 
-    def test_noop_model_update(self):
-        """ tests that calling update on a model with no changes will do nothing. """
+    def test_noop_model_direct_update(self):
+        """ Tests that calling update on a model with no changes will do nothing. """
         m0 = TestUpdateModel.create(count=5, text='monkey')
 
         with patch.object(self.session, 'execute') as execute:
@@ -89,6 +89,40 @@ class ModelUpdateTests(BaseCassEngTestCase):
 
         with patch.object(self.session, 'execute') as execute:
             m0.update(count=5)
+        assert execute.call_count == 0
+
+        with patch.object(self.session, 'execute') as execute:
+            m0.update(partition=m0.partition)
+        assert execute.call_count == 0
+
+        with patch.object(self.session, 'execute') as execute:
+            m0.update(cluster=m0.cluster)
+        assert execute.call_count == 0
+
+    def test_noop_model_assignation_update(self):
+        """ Tests that assigning the same value on a model will do nothing. """
+        # Create object and fetch it back to eliminate any hidden variable
+        # cache effect.
+        m0 = TestUpdateModel.create(count=5, text='monkey')
+        m1 = TestUpdateModel.get(partition=m0.partition, cluster=m0.cluster)
+
+        with patch.object(self.session, 'execute') as execute:
+            m1.save()
+        assert execute.call_count == 0
+
+        with patch.object(self.session, 'execute') as execute:
+            m1.count = 5
+            m1.save()
+        assert execute.call_count == 0
+
+        with patch.object(self.session, 'execute') as execute:
+            m1.partition = m0.partition
+            m1.save()
+        assert execute.call_count == 0
+
+        with patch.object(self.session, 'execute') as execute:
+            m1.cluster = m0.cluster
+            m1.save()
         assert execute.call_count == 0
 
     def test_invalid_update_kwarg(self):


### PR DESCRIPTION
This PR extends the initial no-op model update unit-tests to primary keys, as I expect the update operation to be skipped and ignored entirely if the value of the primary key hasn't changed a bit, mirroring the current behaviour on arbitrary columns.

I also added a new unit test section covering the same update operations trough the use of value assignation.