### PR TITLE
PYTHON-609: Align Text and Ascii columns behaviour

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -338,7 +338,6 @@ class Text(Column):
                 raise ValueError(
                     'Minimum length is not allowed to be negative.')
 
-        self.max_length = max_length
         if self.max_length is not None:
             if self.max_length < 0:
                 raise ValueError(
@@ -348,15 +347,13 @@ class Text(Column):
 
     def validate(self, value):
         value = super(Text, self).validate(value)
-        if value is None:
-            return
         if not isinstance(value, (six.string_types, bytearray)) and value is not None:
             raise ValidationError('{0} {1} is not a string'.format(self.column_name, type(value)))
         if self.max_length is not None:
-            if len(value) > self.max_length:
+            if value and len(value) > self.max_length:
                 raise ValidationError('{0} is longer than {1} characters'.format(self.column_name, self.max_length))
-        if self.min_length is not None:
-            if len(value) < self.min_length:
+        if self.min_length:
+            if (self.min_length and not value) or len(value) < self.min_length:
                 raise ValidationError('{0} is shorter than {1} characters'.format(self.column_name, self.min_length))
         return value
 

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -309,13 +309,6 @@ class Blob(Column):
 Bytes = Blob
 
 
-class Ascii(Column):
-    """
-    Stores a US-ASCII character string
-    """
-    db_type = 'ascii'
-
-
 class Inet(Column):
     """
     Stores an IP address in IPv4 or IPv6 format
@@ -352,6 +345,13 @@ class Text(Column):
             if len(value) < self.min_length:
                 raise ValidationError('{0} is shorter than {1} characters'.format(self.column_name, self.min_length))
         return value
+
+
+class Ascii(Text):
+    """
+    Stores a US-ASCII character string
+    """
+    db_type = 'ascii'
 
 
 class Integer(Column):

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -370,6 +370,25 @@ class Ascii(Text):
     """
     db_type = 'ascii'
 
+    def validate(self, value):
+        """ Only allow ASCII and None values.
+
+        Check against US-ASCII, a.k.a. 7-bit ASCII, a.k.a. ISO646-US, a.k.a.
+        the Basic Latin block of the Unicode character set.
+
+        Source: https://github.com/apache/cassandra/blob
+        /3dcbe90e02440e6ee534f643c7603d50ca08482b/src/java/org/apache/cassandra
+        /serializers/AsciiSerializer.java#L29
+        """
+        value = super(Ascii, self).validate(value)
+        if value:
+            charset = value if isinstance(
+                value, (bytearray, )) else map(ord, value)
+            if not set(range(128)).issuperset(charset):
+                raise ValidationError(
+                    '{!r} is not an ASCII string.'.format(value))
+        return value
+
 
 class Integer(Column):
     """

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -330,6 +330,18 @@ class Text(Column):
         """
         self.min_length = min_length or (1 if kwargs.get('required', False) else None)
         self.max_length = max_length
+
+        if self.min_length is not None:
+            if self.min_length < 0:
+                raise ValueError(
+                    'Minimum length is not allowed to be negative.')
+
+        self.max_length = max_length
+        if self.max_length is not None:
+            if self.max_length < 0:
+                raise ValueError(
+                    'Maximum length is not allowed to be negative.')
+
         super(Text, self).__init__(**kwargs)
 
     def validate(self, value):

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -328,7 +328,9 @@ class Text(Column):
             Defaults to 1 if this is a ``required`` column. Otherwise, None.
         :param int max_length: Sets the maximum length of this string, for validation purposes.
         """
-        self.min_length = min_length or (1 if kwargs.get('required', False) else None)
+        self.min_length = (
+            1 if not min_length and kwargs.get('required', False)
+            else min_length)
         self.max_length = max_length
 
         if self.min_length is not None:

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -343,6 +343,12 @@ class Text(Column):
                 raise ValueError(
                     'Maximum length is not allowed to be negative.')
 
+        if self.min_length is not None and self.max_length is not None:
+            if self.max_length < self.min_length:
+                raise ValueError(
+                    'Maximum length must be greater or equal '
+                    'to minimum length.')
+
         super(Text, self).__init__(**kwargs)
 
     def validate(self, value):

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -338,10 +338,10 @@ class Text(Column):
             return
         if not isinstance(value, (six.string_types, bytearray)) and value is not None:
             raise ValidationError('{0} {1} is not a string'.format(self.column_name, type(value)))
-        if self.max_length:
+        if self.max_length is not None:
             if len(value) > self.max_length:
                 raise ValidationError('{0} is longer than {1} characters'.format(self.column_name, self.max_length))
-        if self.min_length:
+        if self.min_length is not None:
             if len(value) < self.min_length:
                 raise ValidationError('{0} is shorter than {1} characters'.format(self.column_name, self.min_length))
         return value

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -392,6 +392,18 @@ class TestAscii(BaseCassEngTestCase):
         with self.assertRaises(ValueError):
             Ascii(max_length=-1)
 
+    def test_length_range(self):
+        Ascii(min_length=0, max_length=0)
+        Ascii(min_length=0, max_length=1)
+        Ascii(min_length=10, max_length=10)
+        Ascii(min_length=10, max_length=11)
+
+        with self.assertRaises(ValueError):
+            Ascii(min_length=10, max_length=9)
+
+        with self.assertRaises(ValueError):
+            Ascii(min_length=1, max_length=0)
+
     def test_type_checking(self):
         Ascii().validate('string')
         Ascii().validate(u'unicode')
@@ -416,11 +428,29 @@ class TestAscii(BaseCassEngTestCase):
 
     def test_required_validation(self):
         """ Tests that validation raise on none and blank values if value required. """
+        Ascii(required=True).validate('k')
+
         with self.assertRaises(ValidationError):
             Ascii(required=True).validate('')
 
         with self.assertRaises(ValidationError):
             Ascii(required=True).validate(None)
+
+        # With min_length set.
+        Ascii(required=True, min_length=0).validate('k')
+        Ascii(required=True, min_length=1).validate('k')
+
+        with self.assertRaises(ValidationError):
+            Ascii(required=True, min_length=2).validate('k')
+
+        # With max_length set.
+        Ascii(required=True, max_length=1).validate('k')
+
+        with self.assertRaises(ValidationError):
+            Ascii(required=True, max_length=2).validate('kevin')
+
+        with self.assertRaises(ValueError):
+            Ascii(required=True, max_length=0)
 
 
 class TestText(BaseCassEngTestCase):
@@ -477,6 +507,18 @@ class TestText(BaseCassEngTestCase):
         with self.assertRaises(ValueError):
             Text(max_length=-1)
 
+    def test_length_range(self):
+        Text(min_length=0, max_length=0)
+        Text(min_length=0, max_length=1)
+        Text(min_length=10, max_length=10)
+        Text(min_length=10, max_length=11)
+
+        with self.assertRaises(ValueError):
+            Text(min_length=10, max_length=9)
+
+        with self.assertRaises(ValueError):
+            Text(min_length=1, max_length=0)
+
     def test_type_checking(self):
         Text().validate('string')
         Text().validate(u'unicode')
@@ -501,11 +543,29 @@ class TestText(BaseCassEngTestCase):
 
     def test_required_validation(self):
         """ Tests that validation raise on none and blank values if value required. """
+        Text(required=True).validate('b')
+
         with self.assertRaises(ValidationError):
             Text(required=True).validate('')
 
         with self.assertRaises(ValidationError):
             Text(required=True).validate(None)
+
+        # With min_length set.
+        Text(required=True, min_length=0).validate('b')
+        Text(required=True, min_length=1).validate('b')
+
+        with self.assertRaises(ValidationError):
+            Text(required=True, min_length=2).validate('b')
+
+        # With max_length set.
+        Text(required=True, max_length=1).validate('b')
+
+        with self.assertRaises(ValidationError):
+            Text(required=True, max_length=2).validate('blake')
+
+        with self.assertRaises(ValueError):
+            Text(required=True, max_length=0)
 
 
 class TestExtraFieldsRaiseException(BaseCassEngTestCase):

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -366,6 +366,9 @@ class TestAscii(BaseCassEngTestCase):
         with self.assertRaises(ValidationError):
             Ascii(min_length=6).validate('kevin')
 
+        with self.assertRaises(ValueError):
+            Ascii(min_length=-1)
+
     def test_max_length(self):
         """ Test arbitrary maximal lengths requirements. """
         Ascii(max_length=0).validate('')
@@ -385,6 +388,9 @@ class TestAscii(BaseCassEngTestCase):
 
         with self.assertRaises(ValidationError):
             Ascii(max_length=5).validate('blaketastic')
+
+        with self.assertRaises(ValueError):
+            Ascii(max_length=-1)
 
     def test_type_checking(self):
         Ascii().validate('string')
@@ -445,6 +451,9 @@ class TestText(BaseCassEngTestCase):
         with self.assertRaises(ValidationError):
             Text(min_length=6).validate('blake')
 
+        with self.assertRaises(ValueError):
+            Text(min_length=-1)
+
     def test_max_length(self):
         """ Test arbitrary maximal lengths requirements. """
         Text(max_length=0).validate('')
@@ -464,6 +473,9 @@ class TestText(BaseCassEngTestCase):
 
         with self.assertRaises(ValidationError):
             Text(max_length=5).validate('blaketastic')
+
+        with self.assertRaises(ValueError):
+            Text(max_length=-1)
 
     def test_type_checking(self):
         Text().validate('string')

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -417,9 +417,9 @@ class TestAscii(BaseCassEngTestCase):
 
     def test_unaltering_validation(self):
         """ Test the validation step doesn't re-interpret values. """
-        self.assertEquals(Ascii().validate(''), '')
-        self.assertEquals(Ascii().validate(None), None)
-        self.assertEquals(Ascii().validate('yo'), 'yo')
+        self.assertEqual(Ascii().validate(''), '')
+        self.assertEqual(Ascii().validate(None), None)
+        self.assertEqual(Ascii().validate('yo'), 'yo')
 
     def test_non_required_validation(self):
         """ Tests that validation is ok on none and blank values if required is False. """
@@ -532,9 +532,9 @@ class TestText(BaseCassEngTestCase):
 
     def test_unaltering_validation(self):
         """ Test the validation step doesn't re-interpret values. """
-        self.assertEquals(Text().validate(''), '')
-        self.assertEquals(Text().validate(None), None)
-        self.assertEquals(Text().validate('yo'), 'yo')
+        self.assertEqual(Text().validate(''), '')
+        self.assertEqual(Text().validate(None), None)
+        self.assertEqual(Text().validate('yo'), 'yo')
 
     def test_non_required_validation(self):
         """ Tests that validation is ok on none and blank values if required is False """

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -415,6 +415,14 @@ class TestAscii(BaseCassEngTestCase):
         with self.assertRaises(ValidationError):
             Ascii().validate(True)
 
+        Ascii().validate("!#$%&\'()*+,-./")
+
+        with self.assertRaises(ValidationError):
+            Ascii().validate('Beyonc' + chr(233))
+
+        with self.assertRaises(ValidationError):
+            Ascii().validate(u'Beyonc' + unichr(233))
+
     def test_unaltering_validation(self):
         """ Test the validation step doesn't re-interpret values. """
         self.assertEqual(Ascii().validate(''), '')
@@ -529,6 +537,10 @@ class TestText(BaseCassEngTestCase):
 
         with self.assertRaises(ValidationError):
             Text().validate(True)
+
+        Text().validate("!#$%&\'()*+,-./")
+        Text().validate('Beyonc' + chr(233))
+        Text().validate(u'Beyonc' + unichr(233))
 
     def test_unaltering_validation(self):
         """ Test the validation step doesn't re-interpret values. """


### PR DESCRIPTION
This PR:
* Add full unit-tests of CQLengine's `Ascii` columns.
* Extend `Text` columns unit-tests for minimal and maximal length.
* Thoroughly cover edge-cases on empty / blank / `None` value strings handling, especially in relation to the `required` column parameter.
* Align `Ascii` column behaviour to `Text`, by adding `min_length` and `max_length` parameter support.