### PR TITLE
PYTHON-538: cqlengine deprecate Model.__default_ttl__

### DIFF
--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -352,7 +352,7 @@ class BaseModel(object):
     _table_name = None  # used internally to cache a derived table name
 
     def __init__(self, **values):
-        self._ttl = self.__default_ttl__
+        self._ttl = None
         self._timestamp = None
         self._conditional = None
         self._batch = None
@@ -691,7 +691,6 @@ class BaseModel(object):
 
         self._set_persisted()
 
-        self._ttl = self.__default_ttl__
         self._timestamp = None
 
         return self
@@ -738,7 +737,6 @@ class BaseModel(object):
 
         self._set_persisted()
 
-        self._ttl = self.__default_ttl__
         self._timestamp = None
 
         return self
@@ -794,6 +792,7 @@ class ModelMetaClass(type):
         # short circuit __discriminator_value__ inheritance
         attrs['__discriminator_value__'] = attrs.get('__discriminator_value__')
 
+        # TODO __default__ttl__ should be removed in the next major release
         options = attrs.get('__options__') or {}
         attrs['__default_ttl__'] = options.get('default_time_to_live')
 

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -299,7 +299,7 @@ class AbstractQuerySet(object):
         self._count = None
 
         self._batch = None
-        self._ttl = getattr(model, '__default_ttl__', None)
+        self._ttl =  None
         self._consistency = None
         self._timestamp = None
         self._if_not_exists = False

--- a/docs/api/cassandra/cqlengine/models.rst
+++ b/docs/api/cassandra/cqlengine/models.rst
@@ -32,8 +32,10 @@ Model
 
     .. autoattribute:: __keyspace__
 
-    .. _ttl-change:
-    .. autoattribute:: __default_ttl__
+    .. attribute:: __default_ttl__
+        :annotation:  = None
+
+        Will be deprecated in release 4.0. You can set the default ttl by configuring the table ``__options__``. See :ref:`ttl-change` for more details.
 
     .. autoattribute:: __discriminator_value__
 

--- a/docs/cqlengine/queryset.rst
+++ b/docs/cqlengine/queryset.rst
@@ -343,6 +343,42 @@ None means no timeout.
     Setting the timeout on the model is meaningless and will raise an AssertionError.
 
 
+.. _ttl-change:
+
+Default TTL and Per Query TTL
+=============================
+
+Model default TTL now relies on the *default_time_to_live* feature, introduced in Cassandra 2.0. It is not handled anymore in the CQLEngine Model (cassandra-driver >=3.6). You can set the default TTL of a table like this:
+
+    Example:
+
+    .. code-block:: python
+
+        class User(Model):
+            __options__ = {'default_time_to_live': 20}
+
+            user_id = columns.UUID(primary_key=True)
+            ...
+
+You can set TTL per-query if needed. Here are a some examples:
+
+    Example:
+
+    .. code-block:: python
+
+        class User(Model):
+            __options__ = {'default_time_to_live': 20}
+
+            user_id = columns.UUID(primary_key=True)
+            ...
+
+        user = User.objects.create(user_id=1)  # Default TTL 20 will be set automatically on the server
+
+        user.ttl(30).update(age=21)            # Update the TTL to 30
+        User.objects.ttl(10).create(user_id=1)  # TTL 10
+        User(user_id=1, age=21).ttl(10).save()  # TTL 10
+
+
 Named Tables
 ===================
 

--- a/tests/integration/cqlengine/test_ttl.py
+++ b/tests/integration/cqlengine/test_ttl.py
@@ -18,6 +18,7 @@ try:
 except ImportError:
     import unittest  # noqa
 
+from cassandra import InvalidRequest
 from cassandra.cqlengine.management import sync_table, drop_table
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from cassandra.cqlengine.models import Model
@@ -158,6 +159,16 @@ class TTLBlindUpdateTest(BaseTTLTest):
 
 @unittest.skipIf(CASSANDRA_VERSION < '2.0', "default_time_to_Live was introduce in C* 2.0, currently running {0}".format(CASSANDRA_VERSION))
 class TTLDefaultTest(BaseDefaultTTLTest):
+    def get_default_ttl(self, table_name):
+        session = get_session()
+        try:
+            default_ttl = session.execute("SELECT default_time_to_live FROM system_schema.tables "
+                                          "WHERE keyspace_name = 'cqlengine_test' AND table_name = '{0}'".format(table_name))
+        except InvalidRequest:
+            default_ttl = session.execute("SELECT default_time_to_live FROM system.schema_columnfamilies "
+                                          "WHERE keyspace_name = 'cqlengine_test' AND columnfamily_name = '{0}'".format(table_name))
+        return default_ttl[0]['default_time_to_live']
+
     def test_default_ttl_not_set(self):
         session = get_session()
 
@@ -165,6 +176,9 @@ class TTLDefaultTest(BaseDefaultTTLTest):
         tid = o.id
 
         self.assertIsNone(o._ttl)
+
+        default_ttl = self.get_default_ttl('test_ttlmodel')
+        self.assertEqual(default_ttl, 0)
 
         with mock.patch.object(session, 'execute') as m:
             TestTTLModel.objects(id=tid).update(text="aligators")
@@ -174,23 +188,44 @@ class TTLDefaultTest(BaseDefaultTTLTest):
 
     def test_default_ttl_set(self):
         session = get_session()
+
         o = TestDefaultTTLModel.create(text="some text on ttl")
         tid = o.id
 
-        self.assertEqual(o._ttl, TestDefaultTTLModel.__default_ttl__)
+        # Should not be set, it's handled by Cassandra
+        self.assertIsNone(o._ttl)
+
+        default_ttl = self.get_default_ttl('test_default_ttlmodel')
+        self.assertEqual(default_ttl, 20)
 
         with mock.patch.object(session, 'execute') as m:
-            TestDefaultTTLModel.objects(id=tid).update(text="aligators expired")
+            TestTTLModel.objects(id=tid).update(text="aligators expired")
 
+        # Should not be set either
         query = m.call_args[0][0].query_string
-        self.assertIn("USING TTL", query)
+        self.assertNotIn("USING TTL", query)
+
+    def test_default_ttl_modify(self):
+        session = get_session()
+
+        default_ttl = self.get_default_ttl('test_default_ttlmodel')
+        self.assertEqual(default_ttl, 20)
+
+        TestDefaultTTLModel.__options__ = {'default_time_to_live': 10}
+        sync_table(TestDefaultTTLModel)
+
+        default_ttl = self.get_default_ttl('test_default_ttlmodel')
+        self.assertEqual(default_ttl, 10)
+
+        # Restore default TTL
+        TestDefaultTTLModel.__options__ = {'default_time_to_live': 20}
+        sync_table(TestDefaultTTLModel)
 
     def test_override_default_ttl(self):
         session = get_session()
         o = TestDefaultTTLModel.create(text="some text on ttl")
         tid = o.id
 
-        self.assertEqual(o._ttl, TestDefaultTTLModel.__default_ttl__)
         o.ttl(3600)
         self.assertEqual(o._ttl, 3600)
 


### PR DESCRIPTION
__default_ttl__ will be deprecated in 4.0. We now relies on the cassandra default_time_to_live feature.