### PR TITLE
PYTHON-600 - make connection timeout infinite by default

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -345,6 +345,7 @@ class Connection(object):
                     self._socket = self._ssl_impl.wrap_socket(self._socket, **self.ssl_options)
                 self._socket.settimeout(self.connect_timeout)
                 self._socket.connect(sockaddr)
+                self._socket.settimeout(None)
                 if self._check_hostname:
                     ssl.match_hostname(self._socket.getpeercert(), self.host)
                 sockerr = None

--- a/cassandra/io/eventletreactor.py
+++ b/cassandra/io/eventletreactor.py
@@ -16,13 +16,10 @@
 # Originally derived from MagnetoDB source:
 #   https://github.com/stackforge/magnetodb/blob/2015.1.0b1/magnetodb/common/cassandra/io/eventletreactor.py
 
-from errno import EALREADY, EINPROGRESS, EWOULDBLOCK, EINVAL
 import eventlet
 from eventlet.green import socket
-import ssl
 from eventlet.queue import Queue
 import logging
-import os
 from threading import Event
 import time
 
@@ -32,15 +29,6 @@ from cassandra.connection import Connection, ConnectionShutdown, Timer, TimerMan
 
 
 log = logging.getLogger(__name__)
-
-
-def is_timeout(err):
-    return (
-        err in (EINPROGRESS, EALREADY, EWOULDBLOCK) or
-        (err == EINVAL and os.name in ('nt', 'ce')) or
-        (isinstance(err, ssl.SSLError) and err.args[0] == 'timed out') or
-        isinstance(err, socket.timeout)
-    )
 
 
 class EventletConnection(Connection):
@@ -145,8 +133,6 @@ class EventletConnection(Connection):
                 buf = self._socket.recv(self.in_buffer_size)
                 self._iobuf.write(buf)
             except socket.error as err:
-                if is_timeout(err):
-                    continue
                 log.debug("Exception during socket recv for %s: %s",
                           self, err)
                 self.defunct(err)

--- a/cassandra/io/geventreactor.py
+++ b/cassandra/io/geventreactor.py
@@ -18,24 +18,14 @@ from gevent import socket
 import gevent.ssl
 
 import logging
-import os
 import time
 
 from six.moves import range
-
-from errno import EINVAL
 
 from cassandra.connection import Connection, ConnectionShutdown, Timer, TimerManager
 
 
 log = logging.getLogger(__name__)
-
-
-def is_timeout(err):
-    return (
-        (err == EINVAL and os.name in ('nt', 'ce')) or
-        isinstance(err, socket.timeout)
-    )
 
 
 class GeventConnection(Connection):
@@ -131,11 +121,9 @@ class GeventConnection(Connection):
                 buf = self._socket.recv(self.in_buffer_size)
                 self._iobuf.write(buf)
             except socket.error as err:
-                if not is_timeout(err):
-                    log.debug("Exception in read for %s: %s", self, err)
-                    self.defunct(err)
-                    return  # leave the read loop
-                continue
+                log.debug("Exception in read for %s: %s", self, err)
+                self.defunct(err)
+                return  # leave the read loop
 
             if self._iobuf.tell():
                 self.process_io_buffer()


### PR DESCRIPTION
removes the need for eventlet and gevent checking for timeouts