### PR TITLE
Raise error on primary key update only if its value changed

### DIFF
--- a/tests/integration/cqlengine/model/test_updates.py
+++ b/tests/integration/cqlengine/model/test_updates.py
@@ -91,11 +91,13 @@ class ModelUpdateTests(BaseCassEngTestCase):
             m0.update(count=5)
         assert execute.call_count == 0
 
-        with self.assertRaises(ValidationError):
+        with patch.object(self.session, 'execute') as execute:
             m0.update(partition=m0.partition)
+        assert execute.call_count == 0
 
-        with self.assertRaises(ValidationError):
+        with patch.object(self.session, 'execute') as execute:
             m0.update(cluster=m0.cluster)
+        assert execute.call_count == 0
 
     def test_noop_model_assignation_update(self):
         """ Tests that assigning the same value on a model will do nothing. """


### PR DESCRIPTION
This PR follows up on #622, and only raise an error on primary key update attempt if their values effectively changed.
