### PR TITLE
[CQLengine] Set default value of columns on instantiation

### DIFF
--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -361,19 +361,16 @@ class BaseModel(object):
 
         self._values = {}
         for name, column in self._columns.items():
-            value = values.get(name)
+            # Set default values on instantiation. Thanks to this, we don't have
+            # to wait anylonger for a call to validate() to have CQLengine set
+            # default columns values.
+            column_default = column.get_default() if column.has_default else None
+            value = values.get(name, column_default)
             if value is not None or isinstance(column, columns.BaseContainerColumn):
                 value = column.to_python(value)
             value_mngr = column.value_manager(self, column, value)
             value_mngr.explicit = name in values
             self._values[name] = value_mngr
-
-        # Set default values on instantiation. Thanks to this, we don't have
-        # to wait anylonger for a call to validate() to have CQLengine set
-        # default columns values.
-        for column_id, column_obj in self._columns.items():
-            if column_id not in values and column_obj.has_default:
-                setattr(self, column_id, column_obj.get_default())
 
     def __repr__(self):
         return '{0}({1})'.format(self.__class__.__name__,

--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -368,6 +368,13 @@ class BaseModel(object):
             value_mngr.explicit = name in values
             self._values[name] = value_mngr
 
+        # Set default values on instantiation. Thanks to this, we don't have
+        # to wait anylonger for a call to validate() to have CQLengine set
+        # default columns values.
+        for column_id, column_obj in self._columns.items():
+            if column_id not in values and column_obj.has_default:
+                setattr(self, column_id, column_obj.get_default())
+
     def __repr__(self):
         return '{0}({1})'.format(self.__class__.__name__,
                                ', '.join('{0}={1!r}'.format(k, getattr(self, k))

--- a/tests/integration/cqlengine/model/test_class_construction.py
+++ b/tests/integration/cqlengine/model/test_class_construction.py
@@ -47,7 +47,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         inst = TestModel()
         self.assertHasAttr(inst, 'id')
         self.assertHasAttr(inst, 'text')
-        self.assertIsNone(inst.id)
+        self.assertIsNotNone(inst.id)
         self.assertIsNone(inst.text)
 
     def test_db_map(self):

--- a/tests/integration/cqlengine/model/test_class_construction.py
+++ b/tests/integration/cqlengine/model/test_class_construction.py
@@ -50,6 +50,27 @@ class TestModelClassFunction(BaseCassEngTestCase):
         self.assertIsNotNone(inst.id)
         self.assertIsNone(inst.text)
 
+    def test_values_on_instantiation(self):
+        """
+        Tests defaults and user-provided values on instantiation.
+        """
+
+        class TestPerson(Model):
+            first_name = columns.Text(primary_key=True, default='kevin')
+            last_name = columns.Text(default='deldycke')
+
+        # Check that defaults are available at instantiation.
+        inst1 = TestPerson()
+        self.assertHasAttr(inst1, 'first_name')
+        self.assertHasAttr(inst1, 'last_name')
+        self.assertEquals(inst1.first_name, 'kevin')
+        self.assertEquals(inst1.last_name, 'deldycke')
+
+        # Check that values on instantiation overrides defaults.
+        inst2 = TestPerson(first_name='bob', last_name='joe')
+        self.assertEquals(inst2.first_name, 'bob')
+        self.assertEquals(inst2.last_name, 'joe')
+
     def test_db_map(self):
         """
         Tests that the db_map is properly defined

--- a/tests/integration/cqlengine/model/test_model_io.py
+++ b/tests/integration/cqlengine/model/test_model_io.py
@@ -38,8 +38,6 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
 
 
-
-
 class TestModel(Model):
 
     id = columns.UUID(primary_key=True, default=lambda: uuid4())

--- a/tests/integration/cqlengine/model/test_model_io.py
+++ b/tests/integration/cqlengine/model/test_model_io.py
@@ -72,7 +72,7 @@ class TestModelIO(BaseCassEngTestCase):
 
     def test_model_save_and_load(self):
         """
-        Tests that models can be saved and retrieved
+        Tests that models can be saved and retrieved, using the create method.
         """
         tm = TestModel.create(count=8, text='123456789')
         self.assertIsInstance(tm, TestModel)
@@ -82,6 +82,22 @@ class TestModelIO(BaseCassEngTestCase):
 
         for cname in tm._columns.keys():
             self.assertEqual(getattr(tm, cname), getattr(tm2, cname))
+
+    def test_model_instantiation_save_and_load(self):
+        """
+        Tests that models can be saved and retrieved, this time using the
+        natural model instantiation.
+        """
+        tm = TestModel(count=8, text='123456789')
+        # Tests that values are available on instantiation.
+        self.assertIsNotNone(tm['id'])
+        self.assertEquals(tm.count, 8)
+        self.assertEquals(tm.text, '123456789')
+        tm.save()
+        tm2 = TestModel.objects(id=tm.id).first()
+
+        for cname in tm._columns.keys():
+            self.assertEquals(getattr(tm, cname), getattr(tm2, cname))
 
     def test_model_read_as_dict(self):
         """


### PR DESCRIPTION
I just stumbled upon an inconsistency regarding the way `get_changed_columns()` reports columns whose values have been updated.

`get_changed_columns()` in itself works fine. The heavy lifting has been implemented a year ago through #373 and #348, and is upstream since the early days of v3.0.0.

But if the behaviour of [`get_changed_columns()` is thoroughly covered by unit-tests](https://github.com/datastax/python-driver/commit/17f2bc13c2fda731e9de8217790730b151f962ec), there's an edge case when an instance hasn't been persisted yet. This issue only concerns unset columns with a default value.

This issue is demonstrated in the unit-tests attached to this PR. The fix consists in setting the default value of a column right away at instantiation if no value has been provided by the user.

On my machine, no regression have been detected by both the `unit` and `integration` test suites.