### PR TITLE
PYTHON-618 - add hash function to cqlengine.columns.Column

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -198,6 +198,9 @@ class Column(object):
             return self.position >= other.position
         return NotImplemented
 
+    def __hash__(self):
+        return id(self)
+
     def validate(self, value):
         """
         Returns a cleaned and validated value. Raises a ValidationError


### PR DESCRIPTION
restore hashability to Column in Python 3.x

