### PR TITLE
Update docs.yaml

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -7,9 +7,9 @@ sections:
     type: sphinx
     directory: docs
 versions:
-  - name: 3.6.0
+  - name: 3.6
     ref: 3.6-doc
-  - name: 3.5.0
+  - name: 3.5
     ref: 3.5-doc
 -redirects:
 -  - \A\/(.*)/\Z: /\1.html


### PR DESCRIPTION
We decided to limit the version labels (names) to major and minor, i.e., X.Y.