### PR TITLE
Added cql types to result set for CASSANDRA-11534

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3264,6 +3264,7 @@ class ResponseFuture(object):
     _req_id = None
     _final_result = _NOT_SET
     _col_names = None
+    _col_types = None
     _final_exception = None
     _query_traces = None
     _callbacks = None
@@ -3531,6 +3532,7 @@ class ResponseFuture(object):
                     results = getattr(response, 'results', None)
                     if results is not None and response.kind == RESULT_KIND_ROWS:
                         self._paging_state = response.paging_state
+                        self._col_types = response.col_types
                         self._col_names = results[0]
                         results = self.row_factory(*results)
                     self._set_final_result(results)
@@ -3954,6 +3956,7 @@ class ResultSet(object):
     def __init__(self, response_future, initial_response):
         self.response_future = response_future
         self.column_names = response_future._col_names
+        self.column_types = response_future._col_types
         self._set_current_rows(initial_response)
         self._page_iter = None
         self._list_mode = False

--- a/cassandra/row_parser.pyx
+++ b/cassandra/row_parser.pyx
@@ -35,6 +35,6 @@ def make_recv_results_rows(ColumnParser colparser):
         reader = BytesIOReader(f.read())
         parsed_rows = colparser.parse_rows(reader, desc)
 
-        return (paging_state, (colnames, parsed_rows))
+        return (paging_state, coltypes, (colnames, parsed_rows))
 
     return recv_results_rows

--- a/tests/unit/test_concurrent.py
+++ b/tests/unit/test_concurrent.py
@@ -37,6 +37,7 @@ class MockResponseResponseFuture():
 
     _query_trace = None
     _col_names = None
+    _col_types = None
 
     # a list pending callbacks, these will be prioritized in reverse or normal orderd
     pending_callbacks = PriorityQueue()

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -50,7 +50,7 @@ class ResponseFutureTests(unittest.TestCase):
         return ResponseFuture(session, message, query, 1)
 
     def make_mock_response(self, results):
-        return Mock(spec=ResultMessage, kind=RESULT_KIND_ROWS, results=results, paging_state=None)
+        return Mock(spec=ResultMessage, kind=RESULT_KIND_ROWS, results=results, paging_state=None, col_types=None)
 
     def test_result_message(self):
         session = self.make_basic_session()


### PR DESCRIPTION
As discussed in [CASSANDRA-11534](https://issues.apache.org/jira/browse/CASSANDRA-11534), we need CQL types in the result set in order to reliably format results with column aliases.