### PR TITLE
Temporary fix for PYTHON-651

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3667,7 +3667,8 @@ class ResponseFuture(object):
             if response.kind == RESULT_KIND_PREPARED:
                 # result metadata is the only thing that could have changed from an alter
                 _, _, _, result_metadata = response.results
-                self.prepared_statement.result_metadata = result_metadata
+                if self.prepared_statement:
+                    self.prepared_statement.result_metadata = result_metadata
 
                 # use self._query to re-use the same host and
                 # at the same time properly borrow the connection


### PR DESCRIPTION
Whilst waiting for [PYTHON-651](https://github.com/datastax/python-driver/pull/665) to deliver a complete fix, I would like to merge this into cassandra-test to make sure it doesn't get forgotten in case we need to rebundle a new driver version before 651 is available, see [CASSANDRA-12736](https://issues.apache.org/jira/browse/CASSANDRA-12736) for more details.