### PR TITLE
escape literal asterisks in docstring

### DIFF
--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -274,8 +274,8 @@ class ContextQuery(object):
     A Context manager to allow a Model to switch context easily. Presently, the context only
     specifies a keyspace for model IO.
 
-    :param *args: One or more models. A model should be a class type, not an instance.
-    :param **kwargs: (optional) Context parameters: can be *keyspace* or *connection*
+    :param \*args: One or more models. A model should be a class type, not an instance.
+    :param \*\*kwargs: (optional) Context parameters: can be *keyspace* or *connection*
 
     For example:
 


### PR DESCRIPTION
Addresses [PYTHON-645](https://datastax-oss.atlassian.net/browse/PYTHON-645).

I've tested locally with `python setup.py doc`, which no longer prints these warnings:

```/home/mambocab/cstar_src/python-driver/cassandra/cqlengine/query.py:docstring of cassandra.cqlengine.query.ContextQuery:4: WARNING: Inline emphasis start-string without end-string.
/home/mambocab/cstar_src/python-driver/cassandra/cqlengine/query.py:docstring of cassandra.cqlengine.query.ContextQuery:5: WARNING: Inline strong start-string without end-string.
```

I also viewed the docs locally with `python -m SimpleServer` and they look like I expect:

![driver-docs](https://cloud.githubusercontent.com/assets/3753769/20110298/e0b55638-a5b1-11e6-941b-f11ed3637ab8.png)
