### PR TITLE
PYTHON-669: Don't prepare queries on ignored hosts on_up

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1330,8 +1330,9 @@ class Cluster(object):
                 log.debug("Now that host %s is up, cancelling the reconnection handler", host)
                 reconnector.cancel()
 
-            self._prepare_all_queries(host)
-            log.debug("Done preparing all queries for host %s, ", host)
+            if self.profile_manager.distance(host) != HostDistance.IGNORED:
+                self._prepare_all_queries(host)
+                log.debug("Done preparing all queries for host %s, ", host)
 
             for session in self.sessions:
                 session.remove_pool(host)

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -1130,8 +1130,3 @@ class BetaProtocolTest(unittest.TestCase):
         session = cluster.connect()
         self.assertEqual(cluster.protocol_version, MAX_SUPPORTED_VERSION)
         self.assertTrue(session.execute("select release_version from system.local")[0])
-
-
-
-
-


### PR DESCRIPTION
Adds a test for PYTHON-669 and fixes the behavior it tests for.