### PR TITLE
setup.py: build libev extension on pypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,9 +166,9 @@ The optional C extensions are not supported on big-endian systems.
 
 pypy_unsupported_msg = \
 """
-=================================================================================
-Some optional C extensions are not supported in PyPy. Only murmur3 will be built.
-=================================================================================
+===================================================================================
+Some optional C extensions are not supported in PyPy. murmur3, libev will be built.
+===================================================================================
 """
 
 is_windows = os.name == 'nt'
@@ -186,7 +186,7 @@ elif not is_supported_arch:
 
 try_extensions = "--no-extensions" not in sys.argv and is_supported_platform and is_supported_arch and not os.environ.get('CASS_DRIVER_NO_EXTENSIONS')
 try_murmur3 = try_extensions and "--no-murmur3" not in sys.argv
-try_libev = try_extensions and "--no-libev" not in sys.argv and not is_pypy and not is_windows
+try_libev = try_extensions and "--no-libev" not in sys.argv and not is_windows
 try_cython = try_extensions and "--no-cython" not in sys.argv and not is_pypy and not os.environ.get('CASS_DRIVER_NO_CYTHON')
 try_cython &= 'egg_info' not in sys.argv  # bypass setup_requires for pip egg_info calls, which will never have --install-option"--no-cython" coming fomr pip
 


### PR DESCRIPTION
Enable libev extension on pypy as I don't see any good reason not to do it.
Tested on pypy 5.3.1