### PR TITLE
Timer race condition

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -117,7 +117,7 @@ DEFAULT_MAX_CONNECTIONS_PER_REMOTE_HOST = 2
 
 
 _NOT_SET = object()
-_INVALID = object()
+_FINALIZED = object()
 
 
 class NoHostAvailable(Exception):
@@ -3289,10 +3289,10 @@ class ResponseFuture(object):
                 self._timer = self.session.cluster.connection_class.create_timer(self._time_remaining, self._on_timeout)
 
     def _finalize_timer(self):
-        if self._timer:
+        if self._timer and self._timer is not _FINALIZED:
             self._timer.cancel()
         else:
-            self._timer = _INVALID
+            self._timer = _FINALIZED
 
     def _on_timeout(self):
         errors = self._errors


### PR DESCRIPTION
Using the *execute_async()* method, it may happen either *_set_final_result()* or *_set_final_exception()* is called before the *_start_timer()* execution.
Since both *_set_final_result()*  and  *_set_final_exception()* are responsible for cancelling the timer contained in the *ResponseFuture* object, in the case above the started timer won't be cancelled until the timeout condition is triggered even if the result has been already returned