### PR TITLE
PYTHON-644

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3278,22 +3278,25 @@ class ResponseFuture(object):
         self._errbacks = []
         self._spec_execution_plan = speculative_execution_plan or self._spec_execution_plan
         self.attempted_hosts = []
+        self._timer_lock = Lock()
 
     def _start_timer(self):
-        if self._timer is None and self._timer is not _CANCELLED:
-            spec_delay = self._spec_execution_plan.next_execution(self._current_host)
-            if spec_delay >= 0:
-                if self._time_remaining is None or self._time_remaining > spec_delay:
-                    self._timer = self.session.cluster.connection_class.create_timer(spec_delay, self._on_speculative_execute)
-                    return
-            if self._time_remaining is not None:
-                self._timer = self.session.cluster.connection_class.create_timer(self._time_remaining, self._on_timeout)
+        with self._timer_lock:
+            if self._timer is None and self._timer is not _CANCELLED:
+                spec_delay = self._spec_execution_plan.next_execution(self._current_host)
+                if spec_delay >= 0:
+                    if self._time_remaining is None or self._time_remaining > spec_delay:
+                        self._timer = self.session.cluster.connection_class.create_timer(spec_delay, self._on_speculative_execute)
+                        return
+                if self._time_remaining is not None:
+                    self._timer = self.session.cluster.connection_class.create_timer(self._time_remaining, self._on_timeout)
 
     def _cancel_timer(self):
-        if self._timer is not None and self._timer is not _CANCELLED:
-            self._timer.cancel()
-        else:
-            self._timer = _CANCELLED
+        with self._timer_lock:
+            if self._timer is not None and self._timer is not _CANCELLED:
+                self._timer.cancel()
+            else:
+                self._timer = _CANCELLED
 
     def _on_timeout(self):
         errors = self._errors
@@ -3308,18 +3311,19 @@ class ResponseFuture(object):
         self._set_final_exception(OperationTimedOut(errors, self._current_host))
 
     def _on_speculative_execute(self):
-        if self._timer is _CANCELLED:
-            return
-        self._timer = None
-        if not self._event.is_set():
-            if self._time_remaining is not None:
-                elapsed = time.time() - self._start_time
-                self._time_remaining -= elapsed
-                if self._time_remaining <= 0:
-                    self._on_timeout()
-                    return
-            if not self.send_request(error_no_hosts=False):
-                self._start_timer()
+        with self._timer_lock:
+            if self._timer is _CANCELLED:
+                return
+            self._timer = None
+            if not self._event.is_set():
+                if self._time_remaining is not None:
+                    elapsed = time.time() - self._start_time
+                    self._time_remaining -= elapsed
+                    if self._time_remaining <= 0:
+                        self._on_timeout()
+                        return
+                if not self.send_request(error_no_hosts=False):
+                    self._start_timer()
 
 
     def _make_query_plan(self):


### PR DESCRIPTION
This change adds a sentinel to indicate when a `ResponseFuture`'s timer has been cancelled. This is similar to #685, but also uses a lock to eliminate race conditions. For instance, the lock prevents this series of events:

1. timer calls `_on_speculative_execute` on thread 1
2. `_set_final_result` cancels the timer on thread 2
3. `_on_speculative_execute` starts a new timer on thread 1

With these changes, I have not produced memory leaks with the script provided in [PYTHON-644](https://datastax-oss.atlassian.net/browse/PYTHON-644) when running it locally many times.

@aholmberg and I both suspect that there's a better solution than explicit locking, but I haven't figured it out yet.