### PR TITLE
PYTHON-644 - Timer logic

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3608,6 +3608,7 @@ class ResponseFuture(object):
                 # we got some other kind of response message
                 msg = "Got unexpected message: %r" % (response,)
                 exc = ConnectionException(msg, host)
+                self._cancel_timer()
                 self._connection.defunct(exc)
                 self._set_final_exception(exc)
         except Exception as exc:

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3277,6 +3277,7 @@ class ResponseFuture(object):
         self._errbacks = []
         self._spec_execution_plan = speculative_execution_plan or self._spec_execution_plan
         self.attempted_hosts = []
+        self._start_timer()
 
     def _start_timer(self):
         if self._timer is None:
@@ -3331,11 +3332,6 @@ class ResponseFuture(object):
             req_id = self._query(host)
             if req_id is not None:
                 self._req_id = req_id
-
-                # timer is only started here, after we have at least one message queued
-                # this is done to avoid overrun of timers with unfettered client requests
-                # in the case of full disconnect, where no hosts will be available
-                self._start_timer()
                 return True
             if self.timeout is not None and time.time() - self._start_time > self.timeout:
                 self._on_timeout()
@@ -3454,7 +3450,7 @@ class ResponseFuture(object):
         self._event.clear()
         self._final_result = _NOT_SET
         self._final_exception = None
-        self._timer = None  # clear cancelled timer; new one will be set when request is queued
+        self._start_timer()
         self.send_request()
 
     def _reprepare(self, prepare_message, host, connection, pool):

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -184,7 +184,7 @@ class ExecutionProfileTest(unittest.TestCase):
         self._verify_response_future_profile(rf, expected_profile)
 
     def test_default_profile(self):
-        non_default_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(5)])
+        non_default_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(3)])
         cluster = Cluster(execution_profiles={'non-default': non_default_profile})
         session = Session(cluster, hosts=[])
 
@@ -218,7 +218,7 @@ class ExecutionProfileTest(unittest.TestCase):
         self._verify_response_future_profile(rf, expected_profile)
 
     def test_statement_params_override_profile(self):
-        non_default_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(5)])
+        non_default_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(3)])
         cluster = Cluster(execution_profiles={'non-default': non_default_profile})
         session = Session(cluster, hosts=[])
 
@@ -284,7 +284,7 @@ class ExecutionProfileTest(unittest.TestCase):
 
     def test_profile_name_value(self):
 
-        internalized_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(5)])
+        internalized_profile = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(3)])
         cluster = Cluster(execution_profiles={'by-name': internalized_profile})
         session = Session(cluster, hosts=[])
         self.assertEqual(cluster._config_mode, _ConfigMode.PROFILES)
@@ -292,7 +292,7 @@ class ExecutionProfileTest(unittest.TestCase):
         rf = session.execute_async("query", execution_profile='by-name')
         self._verify_response_future_profile(rf, internalized_profile)
 
-        by_value = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(5)])
+        by_value = ExecutionProfile(RoundRobinPolicy(), *[object() for _ in range(3)])
         rf = session.execute_async("query", execution_profile=by_value)
         self._verify_response_future_profile(rf, by_value)
 


### PR DESCRIPTION
First commit reverts part of the fix for [PYTHON-367](https://datastax-oss.atlassian.net/browse/PYTHON-367) (#379) that put `_start_timer` calls in code that could be called from secondary threads. This caused a race between timer cancellation and that `_start_timer` call.

The second commit adds a `_cancel_timer` call before defuncting connections if the `ResponseFuture` isn't going to retry the request. Commit message explaining this reproduced below:

>This allows us to revert some of the fix to PYTHON-367 without the timer
heap growing out of control as described on that ticket. We cancel
before defuncting to ensure that the timer doesn't hang around while
running callbacks. Between this change and the delegation of callbacks
to a secondary thread (see commit 5192302, part of the original
PYTHON-367 fix), this commit should not cause a regression on
PYTHON-367.

>Note that we don't cancel timers before defuncting and retrying -- we're
not done with the logical request and still want that timer to fire.

>Now that timers are started on ResponseFuture initialization, we
actually use the value of timeout in the tests, so we no longer pass
that argument, allowing the test to use the default value.