### PR TITLE
PYTHON-692, Allow hosts=None for register_connection

### DIFF
--- a/cassandra/cqlengine/connection.py
+++ b/cassandra/cqlengine/connection.py
@@ -171,12 +171,7 @@ def register_connection(name, hosts=None, consistency=None, lazy_connect=False,
     if name in _connections:
         log.warning("Registering connection '{0}' when it already exists.".format(name))
 
-    hosts_xor_session_passed = (hosts is None) ^ (session is None)
-    if not hosts_xor_session_passed:
-        raise CQLEngineException(
-            "Must pass exactly one of 'hosts' or 'session' arguments"
-        )
-    elif session is not None:
+    if session is not None:
         invalid_config_args = (consistency is not None or
                                lazy_connect is not False or
                                retry_connect is not False or
@@ -187,7 +182,7 @@ def register_connection(name, hosts=None, consistency=None, lazy_connect=False,
             )
         conn = Connection.from_session(name, session=session)
         conn.setup_session()
-    elif hosts is not None:
+    else:  # use hosts argument
         conn = Connection(
             name, hosts=hosts,
             consistency=consistency, lazy_connect=lazy_connect,

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -98,6 +98,8 @@ class ConnectionTest(BaseCassEngTestCase):
 
     def test_connection_setup_with_setup(self):
         connection.setup(hosts=None, default_keyspace=None)
+        self.assertIsNotNone(connection.get_connection("default").cluster.metadata.get_host("127.0.0.1"))
 
     def test_connection_setup_with_default(self):
         connection.default()
+        self.assertIsNotNone(connection.get_connection("default").cluster.metadata.get_host("127.0.0.1"))

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -95,3 +95,9 @@ class ConnectionTest(BaseCassEngTestCase):
         connection.set_session(self.session2)
         self.assertEqual(1, TestConnectModel.objects.count())
         self.assertEqual(TestConnectModel.objects.first(), TCM2)
+
+    def test_connection_setup_with_setup(self):
+        connection.setup(hosts=None, default_keyspace=None)
+
+    def test_connection_setup_with_default(self):
+        connection.default()


### PR DESCRIPTION
Turns out that allowing `hosts=None` is not only ok, but required for `connection.setup(hosts=None, ...)` and `connection.default` to continue working. This adds integration tests for those functions and fixes the regression.

I think maybe these integration tests could be unit tests, so don't merge just yet.