### PR TITLE
PYTHON-623, Document cqlengine None semantics

### DIFF
--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -655,7 +655,8 @@ class BaseModel(object):
         """
         Create an instance of this model in the database.
 
-        Takes the model column values as keyword arguments.
+        Takes the model column values as keyword arguments. Setting a value to
+        `None` is equivalent to running a CQL `DELETE` on that column.
 
         Returns the instance.
         """
@@ -741,7 +742,8 @@ class BaseModel(object):
         Performs an update on the model instance. You can pass in values to set on the model
         for updating, or you can call without values to execute an update against any modified
         fields. If no fields on the model have been modified since loading, no query will be
-        performed. Model validation is performed normally.
+        performed. Model validation is performed normally. Setting a value to `None` is
+        equivalent to running a CQL `DELETE` on that column.
 
         It is possible to do a blind update, that is, to update a field without having first selected the object out of the database.
         See :ref:`Blind Updates <blind_updates>`

--- a/docs/cqlengine/faq.rst
+++ b/docs/cqlengine/faq.rst
@@ -48,3 +48,20 @@ resolve to the statement with the lastest timestamp.
     assert MyModel.objects(id=1).first().count == 3
     assert MyModel.objects(id=1).first().text  == '111'
 
+How can I delete individual values from a row?
+-------------------------------------------------
+
+When inserting with CQLEngine, ``None`` is equivalent to CQL ``NULL`` or to
+issuing a ``DELETE`` on that column. For example:
+
+.. code-block:: python
+
+    class MyModel(Model):
+        id    = columns.Integer(primary_key=True)
+        text  = columns.Text()
+
+    m = MyModel.create(id=1, text='We can delete this with None')
+    assert MyModel.objects(id=1).first().text is not None
+
+    m.update(text=None)
+    assert MyModel.objects(id=1).first().text is None

--- a/example_mapper.py
+++ b/example_mapper.py
@@ -78,6 +78,9 @@ def main():
     except LWTException:
         print "precondition not met"
 
+    log.info("### setting individual column to NULL by updating it to None")
+    nick.update(birth_year=None)
+
     # showing validation
     try:
         FamilyMembers.create(id=simmons.id, surname='Tweed', name='Shannon', birth_year=1957, sex='f')


### PR DESCRIPTION
Add docs in relevant places for `None` semantics.