### PR TITLE
let users specify Cython version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -388,7 +388,11 @@ def run_setup(extensions):
         # 1.) build_ext eats errors at compile time, letting the install complete while producing useful feedback
         # 2.) there could be a case where the python environment has cython installed but the system doesn't have build tools
         if pre_build_check():
-            kw['setup_requires'] = ['Cython>=0.20,<0.25']
+            cython_dep = 'Cython>=0.20,<0.25'
+            user_specified_cython_version = os.environ.get('CASS_DRIVER_ALLOWED_CYTHON_VERSION')
+            if user_specified_cython_version is not None:
+                cython_dep = 'Cython==%s' % (user_specified_cython_version,)
+            kw['setup_requires'] = [cython_dep]
         else:
             sys.stderr.write("Bypassing Cython setup requirement\n")
 


### PR DESCRIPTION
Adds a `CASS_DRIVER_ALLOWED_CYTHON_VERSION` "escape hatch" env var that allows users to specify what version of Cython to use.

You can verify this behavior by installing the driver in an environment without Cython installed, then opening the installed driver with

```
view `python -c 'from cassandra import cluster ; print cluster.__file__'`
```

and searching for `cython`. If you install without `CASS_DRIVER_ALLOWED_CYTHON_VERSION`, the driver is installed with `0.24.1`. If you install with `CASS_DRIVER_ALLOWED_CYTHON_VERSION=0.25.2`, the driver is installed with `0.25.2`. (This holds even when you've installed `Cython==0.25.2` in the environment you're installing the driver.)