### PR TITLE
fix ExponentialReconnectionPolicy may throw OverflowError problem

### DIFF
--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -556,8 +556,13 @@ class ExponentialReconnectionPolicy(ReconnectionPolicy):
 
     def new_schedule(self):
         i = 0
+        delay = self.base_delay
         while self.max_attempts is None or i < self.max_attempts:
-            yield min(self.base_delay * (2 ** i), self.max_delay)
+            if delay > self.max_delay:
+                yield self.max_delay
+            else: 
+                yield delay
+                delay = delay * 2
             i += 1
 
 

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -818,7 +818,7 @@ class ExponentialReconnectionPolicyTest(unittest.TestCase):
         self.assertRaises(ValueError, ExponentialReconnectionPolicy, 1, 2,-1)
 
     def test_schedule_no_max(self):
-        base_delay = 2
+        base_delay = 2.0
         max_delay = 100
         test_iter = 10000
         policy = ExponentialReconnectionPolicy(base_delay=base_delay, max_delay=max_delay, max_attempts=None)


### PR DESCRIPTION
self.base_delay * (2 ** i) may throw OverflowError  when self.base_delay is float and i>2000