### PR TITLE
Fix RuntimeError caused by change dict size during iteration

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2242,7 +2242,7 @@ class Session(object):
         Intended for internal use only.
         """
         futures = []
-        for host in self._pools.keys():
+        for host in tuple(self._pools.keys()):
             if host != excluded_host and host.is_up:
                 future = ResponseFuture(self, PrepareMessage(query=query), None, self.default_timeout)
 


### PR DESCRIPTION
> ERROR:cassandra.cluster:Error preparing query on all hosts: 
Traceback (most recent call last): 
  File "cassandra/cluster.py", line 2230, in cassandra.cluster.Session.prepare (cassandra/cluster.c:38698) 
  File "cassandra/cluster.py", line 2242, in cassandra.cluster.Session.prepare_on_all_hosts (cassandra/cluster.c:39022) 
RuntimeError: dictionary changed size during iteration