### PR TITLE
Added fix for gevent and eventlet

### DIFF
--- a/cassandra/io/eventletreactor.py
+++ b/cassandra/io/eventletreactor.py
@@ -138,7 +138,7 @@ class EventletConnection(Connection):
                 self.defunct(err)
                 return  # leave the read loop
 
-            if self._iobuf.tell():
+            if buf and self._iobuf.tell():
                 self.process_io_buffer()
             else:
                 log.debug("Connection %s closed by server", self)

--- a/cassandra/io/geventreactor.py
+++ b/cassandra/io/geventreactor.py
@@ -125,7 +125,7 @@ class GeventConnection(Connection):
                 self.defunct(err)
                 return  # leave the read loop
 
-            if self._iobuf.tell():
+            if buf and self._iobuf.tell():
                 self.process_io_buffer()
             else:
                 log.debug("Connection %s closed by server", self)


### PR DESCRIPTION
Addresses a bug (found by Jaume) in how the `EventletConnection` handles empty strings coming back from its socket.