### PR TITLE
Allow for counter columns be static. Fixed in C* 2.0.7

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -485,12 +485,14 @@ class Counter(Integer):
 
     def __init__(self,
                  index=False,
+                 static=False,
                  db_field=None,
                  required=False):
         super(Counter, self).__init__(
             primary_key=False,
             partition_key=False,
             index=index,
+            static=static,
             db_field=db_field,
             default=0,
             required=required,


### PR DESCRIPTION
[CASSANDRA-6827](https://issues.apache.org/jira/browse/CASSANDRA-6827) issue was resolver.
So we can enable static counters in ORM.

Tested manually on existing project.