### PR TITLE
initialize libevreactor for cluster unit tests

### DIFF
--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -28,6 +28,15 @@ from cassandra.query import SimpleStatement, named_tuple_factory, tuple_factory
 from cassandra.pool import Host
 from tests.unit.utils import mock_session_pools
 
+try:
+    from dse.io.libevreactor import LibevConnection
+except ImportError:
+    LibevConnection = None  # noqa
+
+def setUp():
+    LibevConnection.initialize_reactor()
+
+
 class ExceptionTypeTest(unittest.TestCase):
 
     def test_exception_types(self):

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -29,7 +29,7 @@ from cassandra.pool import Host
 from tests.unit.utils import mock_session_pools
 
 try:
-    from dse.io.libevreactor import LibevConnection
+    from cassandra.io.libevreactor import LibevConnection
 except ImportError:
     LibevConnection = None  # noqa
 


### PR DESCRIPTION
```
These tests weren't failing on CI, because CI runs all the unit tests
together, and LibevConnection.initialize_reactor is called in the setup
for other tests, in particular tests.unit.io.test_libev{reactor,timer}.
```

@bjmb could you give this a quick review please?