### PR TITLE
733: race condition between start_fetching_next_page and add_callback

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3881,6 +3881,9 @@ class ResponseFuture(object):
         """
         run_now = False
         with self._callback_lock:
+            # Always add fn to self._callbacks, even when we're about to
+            # execute it, to prevent races with functions like
+            # start_fetching_next_page that reset _final_result
             self._callbacks.append((fn, args, kwargs))
             if self._final_result is not _NOT_SET:
                 run_now = True
@@ -3896,6 +3899,9 @@ class ResponseFuture(object):
         """
         run_now = False
         with self._callback_lock:
+            # Always add fn to self._errbacks, even when we're about to execute
+            # it, to prevent races with functions like start_fetching_next_page
+            # that reset _final_exception
             self._errbacks.append((fn, args, kwargs))
             if self._final_exception:
                 run_now = True

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3881,10 +3881,9 @@ class ResponseFuture(object):
         """
         run_now = False
         with self._callback_lock:
+            self._callbacks.append((fn, args, kwargs))
             if self._final_result is not _NOT_SET:
                 run_now = True
-            else:
-                self._callbacks.append((fn, args, kwargs))
         if run_now:
             fn(self._final_result, *args, **kwargs)
         return self
@@ -3897,10 +3896,9 @@ class ResponseFuture(object):
         """
         run_now = False
         with self._callback_lock:
+            self._errbacks.append((fn, args, kwargs))
             if self._final_exception:
                 run_now = True
-            else:
-                self._errbacks.append((fn, args, kwargs))
         if run_now:
             fn(self._final_exception, *args, **kwargs)
         return self


### PR DESCRIPTION
PYTHON-733

Adam figured this one out -- if I understand correctly, there's a race between `add_callback`, which uses `_final_result` to determine if callbacks should be called or not, and `start_fetching_next_page`, which resets it.

Adam was able to deterministically trigger the hang by inserting a sleep here:

https://gist.github.com/bjmb/41999db20794dfbac91bff6264f032ff#file-poc_event-py-L54

which led to `start_fetching_next_page` being called before `add_callback`. With this modification, the script hangs consistently before the changes in this PR and successfully runs after it.