### PR TITLE
PYTHON-730 Resulset.get_query_trace returns empty trace sometimes

### DIFF
--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -925,6 +925,7 @@ class QueryTrace(object):
             session_results = self._execute(
                 SimpleStatement(self._SELECT_SESSIONS_FORMAT, consistency_level=query_cl), (self.trace_id,), time_spent, max_wait)
 
+            # PYTHON-730: There is race condition that the duration mutation is written before started_at the for fast queries
             is_complete = session_results and session_results[0].duration is not None and session_results[0].started_at is not None
             if not session_results or (wait_for_complete and not is_complete):
                 time.sleep(self._BASE_RETRY_SLEEP * (2 ** attempt))

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -925,7 +925,7 @@ class QueryTrace(object):
             session_results = self._execute(
                 SimpleStatement(self._SELECT_SESSIONS_FORMAT, consistency_level=query_cl), (self.trace_id,), time_spent, max_wait)
 
-            is_complete = session_results and session_results[0].duration is not None
+            is_complete = session_results and session_results[0].duration is not None and session_results[0].started_at is not None
             if not session_results or (wait_for_complete and not is_complete):
                 time.sleep(self._BASE_RETRY_SLEEP * (2 ** attempt))
                 attempt += 1


### PR DESCRIPTION
Make sure all trace mutations are written before considering a trace as complete.