### PR TITLE
fixes for ExponentialReconnectionPolicy

### DIFF
--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -564,9 +564,17 @@ class ExponentialReconnectionPolicy(ReconnectionPolicy):
         self.max_attempts = max_attempts
 
     def new_schedule(self):
-        i = 0
+        i, overflowed = 0, False
         while self.max_attempts is None or i < self.max_attempts:
-            yield min(self.base_delay * (2 ** i), self.max_delay)
+            if overflowed:
+                yield self.max_delay
+            else:
+                try:
+                    yield min(self.base_delay * (2 ** i), self.max_delay)
+                except OverflowError:
+                    overflowed = True
+                    yield self.max_delay
+
             i += 1
 
 

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -885,8 +885,8 @@ class ExponentialReconnectionPolicyTest(unittest.TestCase):
         self.assertRaises(ValueError, ExponentialReconnectionPolicy, 1, 2,-1)
 
     def test_schedule_no_max(self):
-        base_delay = 2
-        max_delay = 100
+        base_delay = 2.0
+        max_delay = 100.0
         test_iter = 10000
         policy = ExponentialReconnectionPolicy(base_delay=base_delay, max_delay=max_delay, max_attempts=None)
         sched_slice = list(islice(policy.new_schedule(), 0, test_iter))
@@ -895,8 +895,8 @@ class ExponentialReconnectionPolicyTest(unittest.TestCase):
         self.assertEqual(len(sched_slice), test_iter)
 
     def test_schedule_with_max(self):
-        base_delay = 2
-        max_delay = 100
+        base_delay = 2.0
+        max_delay = 100.0
         max_attempts = 64
         policy = ExponentialReconnectionPolicy(base_delay=base_delay, max_delay=max_delay, max_attempts=max_attempts)
         schedule = list(policy.new_schedule())
@@ -908,6 +908,16 @@ class ExponentialReconnectionPolicyTest(unittest.TestCase):
                 self.assertEqual(delay, schedule[i - 1] * 2)
             else:
                 self.assertEqual(delay, max_delay)
+
+    def test_schedule_exactly_one_attempt(self):
+        base_delay = 2.0
+        max_delay = 100.0
+        max_attempts = 1
+        policy = ExponentialReconnectionPolicy(
+            base_delay=base_delay, max_delay=max_delay, max_attempts=max_attempts
+        )
+        self.assertEqual(len(list(policy.new_schedule())), 1)
+
 
 ONE = ConsistencyLevel.ONE
 


### PR DESCRIPTION
This does a couple things.

- It changes the tests for `ExponentialReconnectionPolicy` to use `float`s instead of `int`s. This is the documented type to use. This also triggers the failures seen in #700.
- It changes the logic in `ExponentialReconnectionPolicy` to handle cases like those in the tests where `float`s can overflow.

Would love to hear from @vipjml (person who filed #700) if you have a moment to have a look and confirm this also addresses the issue.