### PR TITLE
fix hang on exit

### DIFF
--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import atexit
+# import atexit
 from collections import deque
 from functools import partial
 import logging
@@ -200,7 +200,11 @@ class AsyncoreLoop(object):
             dispatcher = _BusyWaitDispatcher()
         self._loop_dispatcher = dispatcher
 
-        atexit.register(partial(_cleanup, weakref.ref(self)))
+        # XXX this can cause AsynccoreConnection in flight to never complete
+        #     this is seen when the loop exits from a shutdown, an underlying
+        #     AsynccoreConnection completes auth successfully then blocks on
+        #     a keyspace query. At this point the program is hung during atexit.
+        # atexit.register(partial(_cleanup, weakref.ref(self)))
 
     def maybe_start(self):
         should_start = False


### PR DESCRIPTION
When using a cluster of 3 cassandra nodes, after I connect and perform a few actions with the client, the code will hang on exit due to an apparent deadlock. I see that one of the three server connections has just processed authentication complete just after the asynccore loop has exited due to the atexit code. It then hangs waiting on keyspace. When removing the atexit code from the asyncore loop it never does this. It does much more occasionally pause and then timeout a connection, after which the code properly exits.

So this is not a perfect fix but it does avoid the deadlock in exchange for an occasional short pause and timeout during atexit.