### PR TITLE
remove uses of map that don't work in py3

### DIFF
--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -121,7 +121,9 @@ class LibevLoop(object):
 
         for conn in self._live_conns | self._new_conns | self._closed_conns:
             conn.close()
-            map(lambda w: w.stop(), (w for w in (conn._write_watcher, conn._read_watcher) if w))
+            for watcher in (conn._write_watcher, conn._read_watcher):
+                if watcher:
+                    watcher.stop()
 
         self.notify()  # wake the timer watcher
         log.debug("Waiting for event loop thread to join...")

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -108,8 +108,10 @@ class RoundRobinPolicyTest(unittest.TestCase):
                 self.assertEqual(sorted(qplan), hosts)
 
         threads = [Thread(target=check_query_plan) for i in range(4)]
-        map(lambda t: t.start(), threads)
-        map(lambda t: t.join(), threads)
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
 
     def test_thread_safety_during_modification(self):
         hosts = range(100)


### PR DESCRIPTION
[PYTHON-749](https://datastax-oss.atlassian.net/browse/PYTHON-749):

> There are a couple call sites for the `map` builtin that I believe weren't correctly converted for Python 3 -- they call `map` but don't consume the result. I... would like to see a test for the `LibevReactor` fail before we merge.