### PR TITLE
Python host filter policy PYTHON-761

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
 Features
 --------
 * Add idle_heartbeat_timeout cluster option to tune how long to wait for heartbeat responses. (PYTHON-762)
+* Add HostFilterPolicy (PYTHON-761)
 
 Bug Fixes
 ---------
@@ -18,6 +19,10 @@ Other
 -----
 * Bump Cython dependency version to 0.25.2 (PYTHON-754)
 * Fix DeprecationWarning when using lz4 (PYTHON-769)
+
+Other
+-----
+* Deprecate WhiteListRoundRobinPolicy (PYTHON-759)
 
 3.10.0
 ======

--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -619,6 +619,7 @@ class WriteType(object):
     A lighweight-transaction write, such as "DELETE ... IF EXISTS".
     """
 
+
 WriteType.name_to_value = {
     'SIMPLE': WriteType.SIMPLE,
     'BATCH': WriteType.BATCH,

--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -17,6 +17,7 @@ import logging
 from random import randint, shuffle
 from threading import Lock
 import socket
+from warnings import warn
 
 from cassandra import ConsistencyLevel, OperationTimedOut
 
@@ -396,6 +397,10 @@ class TokenAwarePolicy(LoadBalancingPolicy):
 
 class WhiteListRoundRobinPolicy(RoundRobinPolicy):
     """
+    |wlrrp| **is deprecated. It will be removed in 4.0.** It can effectively be
+    reimplemented using :class:`.HostFilterPolicy`. For more information, see
+    PYTHON-758_.
+
     A subclass of :class:`.RoundRobinPolicy` which evenly
     distributes queries across all nodes in the cluster,
     regardless of what datacenter the nodes may be in, but
@@ -405,12 +410,25 @@ class WhiteListRoundRobinPolicy(RoundRobinPolicy):
     https://datastax-oss.atlassian.net/browse/JAVA-145
     Where connection errors occur when connection
     attempts are made to private IP addresses remotely
+
+    .. |wlrrp| raw:: html
+
+       <b><code>WhiteListRoundRobinPolicy</code></b>
+
+    .. _PYTHON-758: https://datastax-oss.atlassian.net/browse/PYTHON-758
+
     """
     def __init__(self, hosts):
         """
         The `hosts` parameter should be a sequence of hosts to permit
         connections to.
         """
+        msg = ('WhiteListRoundRobinPolicy is deprecated. '
+               'It will be removed in 4.0. '
+               'It can effectively be reimplemented using HostFilterPolicy.')
+        warn(msg, DeprecationWarning)
+        # DeprecationWarnings are silent by default so we also log the message
+        log.warning(msg)
 
         self._allowed_hosts = hosts
         self._allowed_hosts_resolved = [endpoint[4][0] for a in self._allowed_hosts
@@ -439,6 +457,116 @@ class WhiteListRoundRobinPolicy(RoundRobinPolicy):
     def on_add(self, host):
         if host.address in self._allowed_hosts_resolved:
             RoundRobinPolicy.on_add(self, host)
+
+
+class HostFilterPolicy(LoadBalancingPolicy):
+    """
+    A :class:`.LoadBalancingPolicy` subclass configured with a child policy,
+    and a single-argument predicate. This policy defers to the child policy for
+    hosts where ``predicate(host)`` is truthy. Hosts for which
+    ``predicate(host)`` is falsey will be considered :attr:`.IGNORED`, and will
+    not be used in a query plan.
+
+    This can be used in the cases where you need a whitelist or blacklist
+    policy, e.g. to prepare for decommissioning nodes or for testing:
+
+    .. code-block:: python
+
+        def address_is_ignored(host):
+            return host.address in [ignored_address0, ignored_address1]
+
+        blacklist_filter_policy = HostFilterPolicy(
+            child_policy=RoundRobinPolicy(),
+            predicate=address_is_ignored
+        )
+
+        cluster = Cluster(
+            primary_host,
+            load_balancing_policy=blacklist_filter_policy,
+        )
+
+    Please note that whitelist and blacklist policies are not recommended for
+    general, day-to-day use. You probably want something like
+    :class:`.DCAwareRoundRobinPolicy`, which prefers a local DC but has
+    fallbacks, over a brute-force method like whitelisting or blacklisting.
+    """
+
+    def __init__(self, child_policy, predicate):
+        """
+        :param child_policy: an instantiated :class:`.LoadBalancingPolicy`
+                             that this one will defer to.
+        :param predicate: a one-parameter function that takes a :class:`.Host`.
+                          If it returns a falsey value, the :class:`.Host` will
+                          be :attr:`.IGNORED` and not returned in query plans.
+        """
+        super(HostFilterPolicy, self).__init__()
+        self._child_policy = child_policy
+        self._predicate = predicate
+
+    def on_up(self, host, *args, **kwargs):
+        if self.predicate(host):
+            return self._child_policy.on_up(host, *args, **kwargs)
+
+    def on_down(self, host, *args, **kwargs):
+        if self.predicate(host):
+            return self._child_policy.on_down(host, *args, **kwargs)
+
+    def on_add(self, host, *args, **kwargs):
+        if self.predicate(host):
+            return self._child_policy.on_add(host, *args, **kwargs)
+
+    def on_remove(self, host, *args, **kwargs):
+        if self.predicate(host):
+            return self._child_policy.on_remove(host, *args, **kwargs)
+
+    @property
+    def predicate(self):
+        """
+        A predicate, set on object initialization, that takes a :class:`.Host`
+        and returns a value. If the value is falsy, the :class:`.Host` is
+        :class:`~HostDistance.IGNORED`. If the value is truthy,
+        :class:`.HostFilterPolicy` defers to the child policy to determine the
+        host's distance.
+
+        This is a read-only value set in ``__init__``, implemented as a
+        ``property``.
+        """
+        return self._predicate
+
+    def distance(self, host):
+        """
+        Checks if ``predicate(host)``, then returns
+        :attr:`~HostDistance.IGNORED` if falsey, and defers to the child policy
+        otherwise.
+        """
+        if self.predicate(host):
+            return self._child_policy.distance(host)
+        else:
+            return HostDistance.IGNORED
+
+    def populate(self, cluster, hosts):
+        self._child_policy.populate(
+            cluster=cluster,
+            hosts=[h for h in hosts if self.predicate(h)]
+        )
+
+    def make_query_plan(self, working_keyspace=None, query=None):
+        """
+        Defers to the child policy's
+        :meth:`.LoadBalancingPolicy.make_query_plan`. Since host changes (up,
+        down, addition, and removal) have not been propagated to the child
+        policy, the child policy will only ever return policies for which
+        :meth:`.predicate(host)` was truthy when that change occurred.
+        """
+        child_qp = self._child_policy.make_query_plan(
+            working_keyspace=working_keyspace, query=query
+        )
+        for host in child_qp:
+            if self.predicate(host):
+                yield host
+
+    def check_supported(self):
+        return self._child_policy.check_supported()
 
 
 class ConvictionPolicy(object):

--- a/docs/api/cassandra/policies.rst
+++ b/docs/api/cassandra/policies.rst
@@ -24,6 +24,14 @@ Load Balancing
 .. autoclass:: TokenAwarePolicy
    :members:
 
+.. autoclass:: HostFilterPolicy
+
+   # we document these methods manually so we can specify a param to predicate
+
+   .. automethod:: predicate(host)
+   .. automethod:: distance
+   .. automethod:: make_query_plan
+
 Translating Server Node Addresses
 ---------------------------------
 

--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import struct, time, logging, sys, traceback
+import logging
+import struct
+import sys
+import traceback
 
 from cassandra import ConsistencyLevel, Unavailable, OperationTimedOut, ReadTimeout, ReadFailure, \
     WriteTimeout, WriteFailure
-from cassandra.cluster import Cluster, NoHostAvailable, ExecutionProfile
+from cassandra.cluster import Cluster, NoHostAvailable
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.metadata import murmur3
 from cassandra.policies import (RoundRobinPolicy, DCAwareRoundRobinPolicy,
@@ -40,7 +43,7 @@ log = logging.getLogger(__name__)
 class LoadBalancingPolicyTests(unittest.TestCase):
 
     def setUp(self):
-        remove_cluster() # clear ahead of test so it doesn't use one left in unknown state
+        remove_cluster()  # clear ahead of test so it doesn't use one left in unknown state
         self.coordinator_stats = CoordinatorStats()
         self.prepared = None
         self.probe_cluster = None
@@ -105,7 +108,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
             query_string = 'SELECT * FROM %s.cf WHERE k = ?' % keyspace
             if not self.prepared or self.prepared.query_string != query_string:
                 self.prepared = session.prepare(query_string)
-                self.prepared.consistency_level=consistency_level
+                self.prepared.consistency_level = consistency_level
             for i in range(count):
                 tries = 0
                 while True:
@@ -508,7 +511,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
 
         self.coordinator_stats.reset_counts()
         stop(2)
-        self._wait_for_nodes_down([2],cluster)
+        self._wait_for_nodes_down([2], cluster)
 
         self._query(session, keyspace)
 

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -421,7 +421,6 @@ class DCAwareRoundRobinPolicyTest(unittest.TestCase):
         policy.on_up(hosts[2])
         policy.on_up(hosts[3])
 
-
         another_host = Host(5, SimpleConvictionPolicy)
         another_host.set_location_info("dc3", "rack1")
         new_host.set_location_info("dc3", "rack1")
@@ -755,7 +754,7 @@ class TokenAwarePolicyTest(unittest.TestCase):
         @test_category policy
         """
         self._assert_shuffle(keyspace=None, routing_key='routing_key')
- 
+
     def test_no_shuffle_if_given_no_routing_key(self):
         """
         Test to validate the hosts are not shuffled when no routing_key is provided
@@ -766,7 +765,7 @@ class TokenAwarePolicyTest(unittest.TestCase):
         @test_category policy
         """
         self._assert_shuffle(keyspace='keyspace', routing_key=None)
- 
+
     @patch('cassandra.policies.shuffle')
     def _assert_shuffle(self, patched_shuffle, keyspace, routing_key):
         hosts = [Host(str(i), SimpleConvictionPolicy) for i in range(4)]
@@ -884,7 +883,7 @@ class ExponentialReconnectionPolicyTest(unittest.TestCase):
         self.assertRaises(ValueError, ExponentialReconnectionPolicy, -1, 0)
         self.assertRaises(ValueError, ExponentialReconnectionPolicy, 0, -1)
         self.assertRaises(ValueError, ExponentialReconnectionPolicy, 9000, 1)
-        self.assertRaises(ValueError, ExponentialReconnectionPolicy, 1, 2,-1)
+        self.assertRaises(ValueError, ExponentialReconnectionPolicy, 1, 2, -1)
 
     def test_schedule_no_max(self):
         base_delay = 2.0
@@ -1235,8 +1234,7 @@ class WhiteListRoundRobinPolicyTest(unittest.TestCase):
 class AddressTranslatorTest(unittest.TestCase):
 
     def test_identity_translator(self):
-        it = IdentityTranslator()
-        addr = '127.0.0.1'
+        IdentityTranslator()
 
     @patch('socket.getfqdn', return_value='localhost')
     def test_ec2_multi_region_translator(self, *_):


### PR DESCRIPTION
I need to write more documentation before we merge, but I wanted to get discussion going on API choices.

I chose to model the API here almost exactly off the [Java driver implementation](https://github.com/datastax/java-driver/blob/3.x/driver-core/src/main/java/com/datastax/driver/core/policies/HostFilterPolicy.java). The two relevant choices here:

- the predicate is immutable, and
- host-filtering takes place at policy-population time, not at query-planning time.

Does anyone have strong feelings either way about those? Changing either of these is totally doable, but would add more complexity and make the class harder to test.