### PR TITLE
Added a more complete pre build check to setup.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Bug Fixes
 * is_idempotent flag is not propagated from PreparedStatement to BoundStatement (PYTHON-736)
 * Fix asyncore hang on exit (PYTHON-767)
 * Driver takes several minutes to remove a bad host from session (PYTHON-762)
+* Installation doesn't always fall back to no cython in Windows (PYTHON-763)
 
 Other
 -----

--- a/setup.py
+++ b/setup.py
@@ -348,6 +348,13 @@ def pre_build_check():
         compiler = new_compiler(compiler=be.compiler)
         customize_compiler(compiler)
 
+        try:
+            # We must be able to initialize the compiler if it has that method
+            if hasattr(compiler, "initialize"):
+                compiler.initialize()
+        except:
+            return False
+
         executables = []
         if compiler.compiler_type in ('unix', 'cygwin'):
             executables = [compiler.executables[exe][0] for exe in ('compiler_so', 'linker_so')]


### PR DESCRIPTION
The Windows compiler has the initialize method which is the one that raises an Exception when it doesn't find a valid C++ compiler.