### PR TITLE
request_ids may not be returned to the pool (PYTHON-739)

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -436,9 +436,10 @@ class Connection(object):
         try:
             return self.request_ids.popleft()
         except IndexError:
-            self.highest_request_id += 1
+            new_request_id = self.highest_request_id + 1
             # in_flight checks should guarantee this
             assert self.highest_request_id <= self.max_request_id
+            self.highest_request_id = new_request_id
             return self.highest_request_id
 
     def handle_pushed(self, response):


### PR DESCRIPTION
Fixes [PYTHON-739](https://datastax-oss.atlassian.net/browse/PYTHON-739).

Like the comment says, `this is bad`. However, I think a big overhaul to the "ref-counting" code here is not in order yet.

This doesn't change the code [where `highest_request_id` can be incremented, but no new id issued](https://github.com/datastax/python-driver/blob/f60bdc38c4a3faba276864fb9d44e22a5816650f/cassandra/connection.py#L432). I believe this is ok, as `highest_request_id` doesn't track the same kind of crucial state that `in_flight` can.
