### PR TITLE
request_ids may not be returned to the pool (PYTHON-739) (replaces #784)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Bug Fixes
 * Driver takes several minutes to remove a bad host from session (PYTHON-762)
 * Installation doesn't always fall back to no cython in Windows (PYTHON-763)
 * Avoid to replace a connection that is supposed to shutdown (PYTHON-772)
+* request_ids may not be returned to the pool (PYTHON-739)
 
 Other
 -----

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -436,9 +436,10 @@ class Connection(object):
         try:
             return self.request_ids.popleft()
         except IndexError:
-            self.highest_request_id += 1
+            new_request_id = self.highest_request_id + 1
             # in_flight checks should guarantee this
             assert self.highest_request_id <= self.max_request_id
+            self.highest_request_id = new_request_id
             return self.highest_request_id
 
     def handle_pushed(self, response):


### PR DESCRIPTION
#784 should have been on a `python-*` branch to run the integration tests.