### PR TITLE
KEEP_TEST_CLUSTER env var

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -113,6 +113,8 @@ def _tuple_version(version_string):
 
 
 USE_CASS_EXTERNAL = bool(os.getenv('USE_CASS_EXTERNAL', False))
+KEEP_TEST_CLUSTER = bool(os.getenv('KEEP_TEST_CLUSTER', False))
+
 
 # If set to to true this will force the Cython tests to run regardless of whether they are installed
 cython_env = os.getenv('VERIFY_CYTHON', "False")
@@ -309,7 +311,7 @@ def use_single_node(start=True, workloads=[]):
 
 
 def remove_cluster():
-    if USE_CASS_EXTERNAL:
+    if USE_CASS_EXTERNAL or KEEP_TEST_CLUSTER:
         return
 
     global CCM_CLUSTER
@@ -416,7 +418,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=[]):
 
 
 def teardown_package():
-    if USE_CASS_EXTERNAL:
+    if USE_CASS_EXTERNAL or KEEP_TEST_CLUSTER:
         return
     # when multiple modules are run explicitly, this runs between them
     # need to make sure CCM_CLUSTER is properly cleared for that case


### PR DESCRIPTION
I had to jump through some hoops to keep a cluster around and examine `debug.log`. This simplifies that, adding a `KEEP_TEST_CLUSTER` env var.

@bjmb This is low-priority/non-urgent. When you get a chance, could you have a look?