### PR TITLE
aws lambda with cassandra python driver problem

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,8 @@ A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ a
 
 The driver supports Python 2.6, 2.7, 3.3, and 3.4.
 
+If you require compatibility with DataStax Enterprise, use the `DataStax Enterprise Python Driver <http://docs.datastax.com/en/developer/python-dse-driver/>`_.
+
 Feedback Requested
 ------------------
 **Help us focus our efforts!** Provide your input on the `Platform and Runtime Survey <https://docs.google.com/a/datastax.com/forms/d/10wkbKLqmqs91gvhFW5u43y60pg_geZDolVNrxfO5_48/viewform>`_ (we kept it short).
@@ -63,12 +65,9 @@ If you would like to contribute, please feel free to open a pull request.
 
 Getting Help
 ------------
-Your two best options for getting help with the driver are the
+Your best options for getting help with the driver are the
 `mailing list <https://groups.google.com/a/lists.datastax.com/forum/#!forum/python-driver-user>`_
-and the IRC channel.
-
-For IRC, use the #datastax-drivers channel on irc.freenode.net.  If you don't have an IRC client,
-you can use `freenode's web-based client <http://webchat.freenode.net/?channels=#datastax-drivers>`_.
+and the ``#datastax-drivers`` channel in the `DataStax Academy Slack <https://academy.datastax.com/slack>`_.
 
 License
 -------

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -366,6 +366,21 @@ class PreparedStatement(object):
 
     A :class:`.PreparedStatement` should be prepared only once. Re-preparing a statement
     may affect performance (as the operation requires a network roundtrip).
+
+    |prepared_stmt_head|: Do not use ``*`` in prepared statements if you might
+    change the schema of the table being queried. The driver and server each
+    maintain a map between metadata for a schema and statements that were
+    prepared against that schema. When a user changes a schema, e.g. by adding
+    or removing a column, the server invalidates its mappings involving that
+    schema. However, there is currently no way to propagate that invalidation
+    to drivers. Thus, after a schema change, the driver will incorrectly
+    interpret the results of ``SELECT *`` queries prepared before the schema
+    change. This is currently being addressed in `CASSANDRA-10786
+    <https://issues.apache.org/jira/browse/CASSANDRA-10786>`_.
+
+    .. |prepared_stmt_head| raw:: html
+
+       <b>A note about <code>*</code> in prepared statements</b>
     """
 
     column_metadata = None  #TODO: make this bind_metadata in next major

--- a/docs/dates_and_times.rst
+++ b/docs/dates_and_times.rst
@@ -7,7 +7,7 @@ reasoning behind it, and describe approaches to working with these types.
 timestamps (Cassandra DateType)
 -------------------------------
 
-Timestamps in Cassandra are timezone-naive timestamps encoded as microseconds since UNIX epoch. Clients working with
+Timestamps in Cassandra are timezone-naive timestamps encoded as millseconds since UNIX epoch. Clients working with
 timestamps in this database usually find it easiest to reason about them if they are always assumed to be UTC. To quote the
 pytz documentation, "The preferred way of dealing with times is to always work in UTC, converting to localtime only when
 generating output to be read by humans." The driver adheres to this tenant, and assumes UTC is always in the database. The
@@ -34,7 +34,7 @@ Note the second point above applies even to "local" times created using ``now()`
 These do not contain timezone information intrinsically, so they will be assumed to be UTC and not shifted. When generating
 timestamps in the application, it is clearer to use ``datetime.utcnow()`` to be explicit about it.
 
-If the input for a timestamp is numeric, it is assumed to be a epoch-relative microsecond timestamp, as specified in the
+If the input for a timestamp is numeric, it is assumed to be a epoch-relative millisecond timestamp, as specified in the
 CQL spec -- no scaling or conversion is done.
 
 Read Path

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,8 +74,7 @@ Visit the :doc:`FAQ section <faq>` in this documentation.
 
 Please send questions to the `mailing list <https://groups.google.com/a/lists.datastax.com/forum/#!forum/python-driver-user>`_.
 
-Alternatively, you can use IRC.  Connect to the #datastax-drivers channel on irc.freenode.net.
-If you don't have an IRC client, you can use `freenode's web-based client <http://webchat.freenode.net/?channels=#datastax-drivers>`_.
+Alternatively, you can use the `#datastax-drivers` channel in the DataStax Acadamy Slack to ask questions in real time.
 
 Reporting Issues
 ----------------


### PR DESCRIPTION
Unable to import module 'lambda_function': /var/task/cassandra/cluster.so: undefined symbol: PyFPE_jbuf
I am using aws lambda with
 python 3.6 and
 cassandra-driver 3.7.1
After some googling I found some answer with version incompatibility in cython for cassandra driver.Please help.