### PR TITLE
Change protocol to allow sending key space independent of query string (CASSANDRA-10145)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,11 +1,14 @@
 3.12.0
 ======
 
+Features
+--------
+* Send keyspace in QUERY, PREPARE, and BATCH messages (PYTHON-678)
+
 Bug Fixes
 ---------
 * Both _set_final_exception/result called for the same ResponseFuture (PYTHON-630)
 * Use of DCAwareRoundRobinPolicy raises NoHostAvailable exception (PYTHON-781)
-
 
 3.11.0
 ======

--- a/build.yaml
+++ b/build.yaml
@@ -121,9 +121,9 @@ build:
       # Run the unit tests, this is not done in travis because
       # it takes too much time for the whole matrix to build with cython
       if [[ $CYTHON == 'CYTHON' ]]; then
-        EVENT_LOOP_MANAGER=$EVENT_LOOP_MANAGER VERIFY_CYTHON=1 nosetests -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=cqle_results.xml tests/unit/ || true
-        MONKEY_PATCH_LOOP=1 EVENT_LOOP_MANAGER=$EVENT_LOOP_MANAGER VERIFY_CYTHON=1 nosetests -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=cqle_results.xml tests/unit/io/test_eventletreactor.py || true
-        MONKEY_PATCH_LOOP=1 EVENT_LOOP_MANAGER=$EVENT_LOOP_MANAGER VERIFY_CYTHON=1 nosetests -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=cqle_results.xml tests/unit/io/test_geventreactor.py || true
+        EVENT_LOOP_MANAGER=$EVENT_LOOP_MANAGER VERIFY_CYTHON=1 nosetests -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=unit_results.xml tests/unit/ || true
+        MONKEY_PATCH_LOOP=1 EVENT_LOOP_MANAGER=$EVENT_LOOP_MANAGER VERIFY_CYTHON=1 nosetests -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=unit_eventlet_results.xml tests/unit/io/test_eventletreactor.py || true
+        MONKEY_PATCH_LOOP=1 EVENT_LOOP_MANAGER=$EVENT_LOOP_MANAGER VERIFY_CYTHON=1 nosetests -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=unit_gevent_results.xml tests/unit/io/test_geventreactor.py || true
 
       fi
 

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -204,6 +204,10 @@ class ProtocolVersion(object):
     def uses_error_code_map(cls, version):
         return version >= cls.V5
 
+    @classmethod
+    def uses_keyspace_flag(cls, version):
+        return version >= cls.V5
+
 
 class SchemaChangeType(object):
     DROPPED = 'DROPPED'

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -508,6 +508,7 @@ _WITH_PAGING_STATE_FLAG = 0x08
 _WITH_SERIAL_CONSISTENCY_FLAG = 0x10
 _PROTOCOL_TIMESTAMP = 0x20
 _WITH_KEYSPACE_FLAG = 0x80
+_PREPARED_WITH_KEYSPACE_FLAG = 0x01
 
 
 class QueryMessage(_MessageType):
@@ -791,7 +792,7 @@ class PrepareMessage(_MessageType):
 
         if self.keyspace is not None:
             if ProtocolVersion.uses_keyspace_flag(protocol_version):
-                flags |= _WITH_KEYSPACE_FLAG
+                flags |= _PREPARED_WITH_KEYSPACE_FLAG
             else:
                 raise UnsupportedOperation(
                     "Keyspaces may only be set on queries with protocol version "

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -507,6 +507,7 @@ _PAGE_SIZE_FLAG = 0x04
 _WITH_PAGING_STATE_FLAG = 0x08
 _WITH_SERIAL_CONSISTENCY_FLAG = 0x10
 _PROTOCOL_TIMESTAMP = 0x20
+_WITH_KEYSPACE_FLAG = 0x80
 
 
 class QueryMessage(_MessageType):
@@ -514,13 +515,14 @@ class QueryMessage(_MessageType):
     name = 'QUERY'
 
     def __init__(self, query, consistency_level, serial_consistency_level=None,
-                 fetch_size=None, paging_state=None, timestamp=None):
+                 fetch_size=None, paging_state=None, timestamp=None, keyspace=None):
         self.query = query
         self.consistency_level = consistency_level
         self.serial_consistency_level = serial_consistency_level
         self.fetch_size = fetch_size
         self.paging_state = paging_state
         self.timestamp = timestamp
+        self.keyspace = keyspace
         self._query_params = None  # only used internally. May be set to a list of native-encoded values to have them sent with the request.
 
     def send_body(self, f, protocol_version):
@@ -558,6 +560,14 @@ class QueryMessage(_MessageType):
         if self.timestamp is not None:
             flags |= _PROTOCOL_TIMESTAMP
 
+        if self.keyspace is not None:
+            if ProtocolVersion.uses_keyspace_flag(protocol_version):
+                flags |= _WITH_KEYSPACE_FLAG
+            else:
+                raise UnsupportedOperation(
+                    "Keyspaces may only be set on queries with protocol version "
+                    "5 or higher. Consider setting Cluster.protocol_version to 5.")
+
         if ProtocolVersion.uses_int_query_flags(protocol_version):
             write_uint(f, flags)
         else:
@@ -576,6 +586,8 @@ class QueryMessage(_MessageType):
             write_consistency_level(f, self.serial_consistency_level)
         if self.timestamp is not None:
             write_long(f, self.timestamp)
+        if self.keyspace is not None:
+            write_string(f, self.keyspace)
 
 
 CUSTOM_TYPE = object()
@@ -768,14 +780,38 @@ class PrepareMessage(_MessageType):
     opcode = 0x09
     name = 'PREPARE'
 
-    def __init__(self, query):
+    def __init__(self, query, keyspace=None):
         self.query = query
+        self.keyspace = keyspace
 
     def send_body(self, f, protocol_version):
         write_longstring(f, self.query)
+
+        flags = 0x00
+
+        if self.keyspace is not None:
+            if ProtocolVersion.uses_keyspace_flag(protocol_version):
+                flags |= _WITH_KEYSPACE_FLAG
+            else:
+                raise UnsupportedOperation(
+                    "Keyspaces may only be set on queries with protocol version "
+                    "5 or higher. Consider setting Cluster.protocol_version to 5.")
+
         if ProtocolVersion.uses_prepare_flags(protocol_version):
-            # Write the flags byte; with 0 value for now, but this should change in PYTHON-678
-            write_uint(f, 0)
+            write_uint(f, flags)
+        else:
+            # checks above should prevent this, but just to be safe...
+            if flags:
+                raise UnsupportedOperation(
+                    "Attempted to set flags with value {flags:0=#8x} on"
+                    "protocol version {pv}, which doesn't support flags"
+                    "in prepared statements."
+                    "Consider setting Cluster.protocol_version to 5."
+                    "".format(flags=flags, pv=protocol_version))
+
+        if ProtocolVersion.uses_keyspace_flag(protocol_version):
+            if self.keyspace:
+                write_string(f, self.keyspace)
 
 
 class ExecuteMessage(_MessageType):
@@ -852,12 +888,14 @@ class BatchMessage(_MessageType):
     name = 'BATCH'
 
     def __init__(self, batch_type, queries, consistency_level,
-                 serial_consistency_level=None, timestamp=None):
+                 serial_consistency_level=None, timestamp=None,
+                 keyspace=None):
         self.batch_type = batch_type
         self.queries = queries
         self.consistency_level = consistency_level
         self.serial_consistency_level = serial_consistency_level
         self.timestamp = timestamp
+        self.keyspace = keyspace
 
     def send_body(self, f, protocol_version):
         write_byte(f, self.batch_type.value)
@@ -881,6 +919,13 @@ class BatchMessage(_MessageType):
                 flags |= _WITH_SERIAL_CONSISTENCY_FLAG
             if self.timestamp is not None:
                 flags |= _PROTOCOL_TIMESTAMP
+            if self.keyspace:
+                if ProtocolVersion.uses_keyspace_flag(protocol_version):
+                    flags |= _WITH_KEYSPACE_FLAG
+                else:
+                    raise UnsupportedOperation(
+                        "Keyspaces may only be set on queries with protocol version "
+                        "5 or higher. Consider setting Cluster.protocol_version to 5.")
 
             if ProtocolVersion.uses_int_query_flags(protocol_version):
                 write_int(f, flags)
@@ -891,6 +936,10 @@ class BatchMessage(_MessageType):
                 write_consistency_level(f, self.serial_consistency_level)
             if self.timestamp is not None:
                 write_long(f, self.timestamp)
+
+            if ProtocolVersion.uses_keyspace_flag(protocol_version):
+                if self.keyspace is not None:
+                    write_string(f, self.keyspace)
 
 
 known_event_types = frozenset((

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -182,8 +182,19 @@ def set_default_cass_ip():
         Cluster.__init__.__func__.__defaults__ = tuple(defaults)
 
 
-def get_default_protocol():
+def set_default_beta_flag_true():
+    defaults = list(Cluster.__init__.__defaults__)
+    defaults = defaults[:-3] + [True] + defaults[-2:]
+    try:
+        Cluster.__init__.__defaults__ = tuple(defaults)
+    except:
+        Cluster.__init__.__func__.__defaults__ = tuple(defaults)
 
+
+def get_default_protocol():
+    if Version(CASSANDRA_VERSION) >= Version('4.0'):
+        set_default_beta_flag_true()
+        return 5
     if Version(CASSANDRA_VERSION) >= Version('2.2'):
         return 4
     elif Version(CASSANDRA_VERSION) >= Version('2.1'):
@@ -261,6 +272,7 @@ greaterthanorequalcass30 = unittest.skipUnless(CASSANDRA_VERSION >= '3.0', 'Cass
 greaterthanorequalcass36 = unittest.skipUnless(CASSANDRA_VERSION >= '3.6', 'Cassandra version 3.6 or greater required')
 greaterthanorequalcass3_10 = unittest.skipUnless(CASSANDRA_VERSION >= '3.10', 'Cassandra version 3.10 or greater required')
 greaterthanorequalcass3_11 = unittest.skipUnless(CASSANDRA_VERSION >= '3.11', 'Cassandra version 3.10 or greater required')
+greaterthanorequalcass40 = unittest.skipUnless(CASSANDRA_VERSION >= '4.0', 'Cassandra version 4.0 or greater required')
 lessthancass30 = unittest.skipUnless(CASSANDRA_VERSION < '3.0', 'Cassandra version less then 3.0 required')
 dseonly = unittest.skipUnless(DSE_VERSION, "Test is only applicalbe to DSE clusters")
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
@@ -690,7 +702,7 @@ class BasicSharedKeyspaceUnitTestCase(BasicKeyspaceUnitTestCase):
 class BasicSharedKeyspaceUnitTestCaseRF1(BasicSharedKeyspaceUnitTestCase):
     """
     This is basic unit test case that can be leveraged to scope a keyspace to a specific test class.
-    creates a keyspace named after the testclass with a rf of 1, and a table named after the class
+    creates a keyspace named after the testclass with a rf of 1
     """
     @classmethod
     def setUpClass(self):

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -24,25 +24,28 @@ from cassandra import ProtocolVersion
 from cassandra import ConsistencyLevel, Unavailable, InvalidRequest, cluster
 from cassandra.query import (PreparedStatement, BoundStatement, SimpleStatement,
                              BatchStatement, BatchType, dict_factory, TraceUnavailable)
-from cassandra.cluster import Cluster, NoHostAvailable
-from cassandra.policies import HostDistance, RoundRobinPolicy
+from cassandra.cluster import Cluster, NoHostAvailable, ExecutionProfile
+from cassandra.policies import HostDistance, RoundRobinPolicy, WhiteListRoundRobinPolicy
 from tests.integration import use_singledc, PROTOCOL_VERSION, BasicSharedKeyspaceUnitTestCase, get_server_versions, \
-    greaterthanprotocolv3, MockLoggingHandler, get_supported_protocol_versions, local, get_cluster, setup_keyspace
+    greaterthanprotocolv3, MockLoggingHandler, get_supported_protocol_versions, local, get_cluster, setup_keyspace, \
+    USE_CASS_EXTERNAL, greaterthanorequalcass40
 from tests import notwindows
-from tests.integration import greaterthanorequalcass30
+from tests.integration import greaterthanorequalcass30, get_node
 
 import time
 import re
 
 def setup_module():
-    use_singledc(start=False)
-    ccm_cluster = get_cluster()
-    ccm_cluster.clear()
-    # This is necessary because test_too_many_statements may
-    # timeout otherwise
-    config_options = {'write_request_timeout_in_ms': '20000'}
-    ccm_cluster.set_configuration_options(config_options)
-    ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+    if not USE_CASS_EXTERNAL:
+        use_singledc(start=False)
+        ccm_cluster = get_cluster()
+        ccm_cluster.clear()
+        # This is necessary because test_too_many_statements may
+        # timeout otherwise
+        config_options = {'write_request_timeout_in_ms': '20000'}
+        ccm_cluster.set_configuration_options(config_options)
+        ccm_cluster.start(wait_for_binary_proto=True, wait_other_notice=True)
+
     setup_keyspace()
     global CASS_SERVER_VERSION
     CASS_SERVER_VERSION = get_server_versions()[0]
@@ -1175,3 +1178,304 @@ class UnicodeQueryTest(BasicSharedKeyspaceUnitTestCase):
         self.session.execute(bound)
 
 
+class BaseKeyspaceTests():
+    @classmethod
+    def setUpClass(cls):
+        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.session = cls.cluster.connect(wait_for_all_pools=True)
+        cls.ks_name = cls.__name__.lower()
+
+        cls.alternative_ks = "alternative_keyspace"
+        cls.table_name = "table_query_keyspace_tests"
+
+        ddl = """CREATE KEYSPACE {0} WITH replication =
+                        {{'class': 'SimpleStrategy',
+                        'replication_factor': '{1}'}}""".format(cls.ks_name, 1)
+        cls.session.execute(ddl)
+
+        ddl = """CREATE KEYSPACE {0} WITH replication =
+                                {{'class': 'SimpleStrategy',
+                                'replication_factor': '{1}'}}""".format(cls.alternative_ks, 1)
+        cls.session.execute(ddl)
+
+        ddl = '''
+                CREATE TABLE {0}.{1} (
+                    k int PRIMARY KEY,
+                    v int )'''.format(cls.ks_name, cls.table_name)
+        cls.session.execute(ddl)
+        ddl = '''
+                CREATE TABLE {0}.{1} (
+                    k int PRIMARY KEY,
+                    v int )'''.format(cls.alternative_ks, cls.table_name)
+        cls.session.execute(ddl)
+
+        cls.session.execute("INSERT INTO {}.{} (k, v) VALUES (1, 1)".format(cls.ks_name, cls.table_name))
+        cls.session.execute("INSERT INTO {}.{} (k, v) VALUES (2, 2)".format(cls.alternative_ks, cls.table_name))
+
+    @classmethod
+    def tearDownClass(cls):
+        ddl = "DROP KEYSPACE {}".format(cls.alternative_ks)
+        cls.session.execute(ddl)
+        ddl = "DROP KEYSPACE {}".format(cls.ks_name)
+        cls.session.execute(ddl)
+        cls.cluster.shutdown()
+
+class QueryKeyspaceTests(BaseKeyspaceTests):
+
+    def test_setting_keyspace(self):
+        """
+        Test the basic functionality of PYTHON-678, the keyspace can be set
+        independently of the query and read the results
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the query is executed and the results retrieved
+
+        @test_category query
+        """
+        self._check_set_keyspace_in_statement(self.session)
+
+    def test_setting_keyspace_and_session(self):
+        """
+        Test we can still send the keyspace independently even the session
+        connects to a keyspace when it's created
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the query is executed and the results retrieved
+
+        @test_category query
+        """
+        cluster = Cluster(protocol_version=ProtocolVersion.V5, allow_beta_protocol_version=True)
+        session = cluster.connect(self.alternative_ks)
+        self.addCleanup(cluster.shutdown)
+
+        self._check_set_keyspace_in_statement(session)
+
+    def test_setting_keyspace_and_session_after_created(self):
+        """
+        Test we can still send the keyspace independently even the session
+        connects to a different keyspace after being created
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the query is executed and the results retrieved
+
+        @test_category query
+        """
+        cluster = Cluster(protocol_version=ProtocolVersion.V5, allow_beta_protocol_version=True)
+        session = cluster.connect()
+        self.addCleanup(cluster.shutdown)
+
+        session.set_keyspace(self.alternative_ks)
+        self._check_set_keyspace_in_statement(session)
+
+    def test_setting_keyspace_and_same_session(self):
+        """
+        Test we can still send the keyspace independently even if the session
+        is connected to the sent keyspace
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the query is executed and the results retrieved
+
+        @test_category query
+        """
+        cluster = Cluster(protocol_version=ProtocolVersion.V5, allow_beta_protocol_version=True)
+        session = cluster.connect(self.ks_name)
+        self.addCleanup(cluster.shutdown)
+
+        self._check_set_keyspace_in_statement(session)
+
+
+@greaterthanorequalcass40
+class SimpleWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
+    @unittest.skip
+    def test_lower_protocol(self):
+        cluster = Cluster(protocol_version=ProtocolVersion.V4)
+        session = cluster.connect(self.ks_name)
+        self.addCleanup(cluster.shutdown)
+
+        simple_stmt = SimpleStatement("SELECT * from {}".format(self.table_name), keyspace=self.ks_name)
+        # This raises cassandra.cluster.NoHostAvailable: ('Unable to complete the operation against
+        # any hosts', {<Host: 127.0.0.3 datacenter1>: UnsupportedOperation('Keyspaces may only be
+        # set on queries with protocol version 5 or higher. Consider setting Cluster.protocol_version to 5.',),
+        # <Host: 127.0.0.2 datacenter1>: ConnectionException('Host has been marked down or removed',),
+        # <Host: 127.0.0.1 datacenter1>: ConnectionException('Host has been marked down or removed',)})
+        with self.assertRaises(NoHostAvailable):
+            session.execute(simple_stmt)
+            
+    def _check_set_keyspace_in_statement(self, session):
+        simple_stmt = SimpleStatement("SELECT * from {}".format(self.table_name), keyspace=self.ks_name)
+        results = session.execute(simple_stmt)
+        self.assertEqual(results[0], (1, 1))
+
+        simple_stmt = SimpleStatement("SELECT * from {}".format(self.table_name))
+        simple_stmt.keyspace = self.ks_name
+        results = session.execute(simple_stmt)
+        self.assertEqual(results[0], (1, 1))
+
+
+@greaterthanorequalcass40
+class BatchWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
+    def _check_set_keyspace_in_statement(self, session):
+        batch_stmt = BatchStatement()
+        for i in range(10):
+            batch_stmt.add("INSERT INTO {} (k, v) VALUES (%s, %s)".format(self.table_name), (i, i))
+
+        batch_stmt.keyspace = self.ks_name
+        session.execute(batch_stmt)
+        self.confirm_results()
+
+    def confirm_results(self):
+        keys = set()
+        values = set()
+        # Assuming the test data is inserted at default CL.ONE, we need ALL here to guarantee we see
+        # everything inserted
+        results = self.session.execute(SimpleStatement("SELECT * FROM {}.{}".format(self.ks_name, self.table_name),
+                                                       consistency_level=ConsistencyLevel.ALL))
+        for result in results:
+            keys.add(result.k)
+            values.add(result.v)
+
+        self.assertEqual(set(range(10)), keys, msg=results)
+        self.assertEqual(set(range(10)), values, msg=results)
+
+
+@greaterthanorequalcass40
+class PreparedWithKeyspaceTests(BaseKeyspaceTests, unittest.TestCase):
+
+    def setUp(self):
+        self.cluster = Cluster(protocol_version=PROTOCOL_VERSION, allow_beta_protocol_version=True)
+        self.session = self.cluster.connect()
+
+    def tearDown(self):
+        self.cluster.shutdown()
+
+    def test_prepared_with_keyspace_explicit(self):
+        """
+        Test the basic functionality of PYTHON-678, the keyspace can be set
+        independently of the query and read the results
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the query is executed and the results retrieved
+
+        @test_category query
+        """
+        query = "SELECT * from {} WHERE k = ?".format(self.table_name)
+        prepared_statement = self.session.prepare(query, keyspace=self.ks_name)
+
+        results = self.session.execute(prepared_statement, (1, ))
+        self.assertEqual(results[0], (1, 1))
+
+        prepared_statement_alternative = self.session.prepare(query, keyspace=self.alternative_ks)
+
+        self.assertNotEqual(prepared_statement.query_id, prepared_statement_alternative.query_id)
+
+        results = self.session.execute(prepared_statement_alternative, (2,))
+        self.assertEqual(results[0], (2, 2))
+
+    def test_reprepare_after_host_is_down(self):
+        """
+        Test that Cluster._prepare_all_queries is called and the
+        when a node comes up and the queries succeed later
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the query is executed and the results retrieved
+
+        @test_category query
+        """
+        mock_handler = MockLoggingHandler()
+        logger = logging.getLogger(cluster.__name__)
+        logger.addHandler(mock_handler)
+        get_node(1).stop(wait=True, gently=True, wait_other_notice=True)
+
+        only_first = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy(["127.0.0.1"]))
+        self.cluster.add_execution_profile("only_first", only_first)
+
+        query = "SELECT v from {} WHERE k = ?".format(self.table_name)
+        prepared_statement = self.session.prepare(query, keyspace=self.ks_name)
+        prepared_statement_alternative = self.session.prepare(query, keyspace=self.alternative_ks)
+
+        get_node(1).start(wait_for_binary_proto=True, wait_other_notice=True)
+
+        # We wait for cluster._prepare_all_queries to be called
+        time.sleep(5)
+        self.assertEqual(1, mock_handler.get_message_count('debug', 'Preparing all known prepared statements'))
+        results = self.session.execute(prepared_statement, (1,), execution_profile="only_first")
+        self.assertEqual(results[0], (1, ))
+
+        results = self.session.execute(prepared_statement_alternative, (2,), execution_profile="only_first")
+        self.assertEqual(results[0], (2, ))
+
+    def test_prepared_not_found(self):
+        """
+        Test to if a query fails on a node that didn't have
+        the query prepared, it is re-prepared as expected and then
+        the query is executed
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the query is executed and the results retrieved
+
+        @test_category query
+        """
+        cluster = Cluster(protocol_version=PROTOCOL_VERSION, allow_beta_protocol_version=True)
+        session = self.cluster.connect("system")
+        self.addCleanup(cluster.shutdown)
+
+        cluster.prepare_on_all_hosts = False
+        query = "SELECT k from {} WHERE k = ?".format(self.table_name)
+        prepared_statement = session.prepare(query, keyspace=self.ks_name)
+
+        for _ in range(10):
+            results = session.execute(prepared_statement, (1, ))
+            self.assertEqual(results[0], (1,))
+
+    def test_prepared_in_query_keyspace(self):
+        """
+        Test to the the keyspace can be set in the query
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the results are retrieved correctly
+
+        @test_category query
+        """
+        cluster = Cluster(protocol_version=PROTOCOL_VERSION, allow_beta_protocol_version=True)
+        session = self.cluster.connect()
+        self.addCleanup(cluster.shutdown)
+
+        query = "SELECT k from {}.{} WHERE k = ?".format(self.ks_name, self.table_name)
+        prepared_statement = session.prepare(query)
+        results = session.execute(prepared_statement, (1,))
+        self.assertEqual(results[0], (1,))
+
+        query = "SELECT k from {}.{} WHERE k = ?".format(self.alternative_ks, self.table_name)
+        prepared_statement = session.prepare(query)
+        results = session.execute(prepared_statement, (2,))
+        self.assertEqual(results[0], (2,))
+
+    def test_prepared_in_query_keyspace_and_explicit(self):
+        """
+        Test to the the keyspace set explicitly is ignored if it is
+        specified as well in the query
+
+        @since 3.12
+        @jira_ticket PYTHON-678
+        @expected_result the keyspace set explicitly is ignored and
+        the results are retrieved correctly
+
+        @test_category query
+        """
+        query = "SELECT k from {}.{} WHERE k = ?".format(self.ks_name, self.table_name)
+        prepared_statement = self.session.prepare(query, keyspace="system")
+        results = self.session.execute(prepared_statement, (1,))
+        self.assertEqual(results[0], (1,))
+
+        query = "SELECT k from {}.{} WHERE k = ?".format(self.ks_name, self.table_name)
+        prepared_statement = self.session.prepare(query, keyspace=self.alternative_ks)
+        results = self.session.execute(prepared_statement, (1,))
+        self.assertEqual(results[0], (1,))

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -98,9 +98,9 @@ class MessageTest(unittest.TestCase):
             if ProtocolVersion.uses_keyspace_flag(version):
                 message.send_body(io, version)
                 self._check_calls(io, [
-                    ('\x00\x00\x00\x01',),
-                    ('a',),
-                    ('\x00\x00\x00\x80',),
+                    (b'\x00\x00\x00\x01',),
+                    (b'a',),
+                    (b'\x00\x00\x00\x01',),
                     (b'\x00\x02',),
                     (b'ks',),
                 ])
@@ -158,13 +158,13 @@ class MessageTest(unittest.TestCase):
         )
         batch.send_body(io, protocol_version=5)
         self._check_calls(io,
-            (('\x00',), ('\x00\x03',), ('\x00',),
-             ('\x00\x00\x00\x06',), ('stmt a',),
-             ('\x00\x01',), ('\x00\x00\x00\x07',), ('param a',),
-             ('\x00',), ('\x00\x00\x00\x06',), ('stmt b',),
-             ('\x00\x01',), ('\x00\x00\x00\x07',), ('param b',),
-             ('\x00',), ('\x00\x00\x00\x06',), ('stmt c',),
-             ('\x00\x01',), ('\x00\x00\x00\x07',), ('param c',),
-             ('\x00\x03',),
-             ('\x00\x00\x00\x80',), ('\x00\x02',), ('ks',))
+            ((b'\x00',), (b'\x00\x03',), (b'\x00',),
+             (b'\x00\x00\x00\x06',), (b'stmt a',),
+             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param a',),
+             (b'\x00',), (b'\x00\x00\x00\x06',), (b'stmt b',),
+             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param b',),
+             (b'\x00',), (b'\x00\x00\x00\x06',), (b'stmt c',),
+             (b'\x00\x01',), (b'\x00\x00\x00\x07',), ('param c',),
+             (b'\x00\x03',),
+             (b'\x00\x00\x00\x80',), (b'\x00\x02',), (b'ks',))
         )

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -23,19 +23,19 @@ class MessageTest(unittest.TestCase):
         message = PrepareMessage("a")
         io = Mock()
 
-        message.send_body(io,4)
+        message.send_body(io, 4)
         self._check_calls(io, [(b'\x00\x00\x00\x01',), (b'a',)])
 
         io.reset_mock()
-        message.send_body(io,5)
+        message.send_body(io, 5)
 
         self._check_calls(io, [(b'\x00\x00\x00\x01',), (b'a',), (b'\x00\x00\x00\x00',)])
 
     def test_execute_message(self):
-        message = ExecuteMessage('1',[],4)
+        message = ExecuteMessage('1', [], 4)
         io = Mock()
 
-        message.send_body(io,4)
+        message.send_body(io, 4)
         self._check_calls(io, [(b'\x00\x01',), (b'1',), (b'\x00\x04',), (b'\x01',), (b'\x00\x00',)])
 
         io.reset_mock()

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -1,12 +1,13 @@
-
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest # noqa
 
 from mock import Mock
-from cassandra import ProtocolVersion
-from cassandra.protocol import PrepareMessage, QueryMessage, ExecuteMessage
+from cassandra import ProtocolVersion, UnsupportedOperation
+from cassandra.protocol import (PrepareMessage, QueryMessage, ExecuteMessage,
+                                BatchMessage)
+from cassandra.query import SimpleStatement, BatchType
 
 class MessageTest(unittest.TestCase):
 
@@ -53,20 +54,21 @@ class MessageTest(unittest.TestCase):
 
         @test_category connection
         """
-        message = QueryMessage("a",3)
+        message = QueryMessage("a", 3)
         io = Mock()
-        
-        message.send_body(io,4)
+
+        message.send_body(io, 4)
         self._check_calls(io, [(b'\x00\x00\x00\x01',), (b'a',), (b'\x00\x03',), (b'\x00',)])
 
         io.reset_mock()
-        message.send_body(io,5)
+        message.send_body(io, 5)
         self._check_calls(io, [(b'\x00\x00\x00\x01',), (b'a',), (b'\x00\x03',), (b'\x00\x00\x00\x00',)])
 
     def _check_calls(self, io, expected):
-        self.assertEqual(len(io.write.mock_calls), len(expected))
-        for call, expect in zip(io.write.mock_calls, expected):
-            self.assertEqual(call[1], expect)
+        self.assertEqual(
+            tuple(c[1] for c in io.write.mock_calls),
+            tuple(expected)
+        )
 
     def test_prepare_flag(self):
         """
@@ -83,9 +85,86 @@ class MessageTest(unittest.TestCase):
         for version in ProtocolVersion.SUPPORTED_VERSIONS:
             message.send_body(io, version)
             if ProtocolVersion.uses_prepare_flags(version):
-                # This should pass after PYTHON-696
                 self.assertEqual(len(io.write.mock_calls), 3)
-                # self.assertEqual(uint32_unpack(io.write.mock_calls[2][1][0]) & _WITH_SERIAL_CONSISTENCY_FLAG, 1)
             else:
                 self.assertEqual(len(io.write.mock_calls), 2)
             io.reset_mock()
+
+    def test_prepare_flag_with_keyspace(self):
+        message = PrepareMessage("a", keyspace='ks')
+        io = Mock()
+
+        for version in ProtocolVersion.SUPPORTED_VERSIONS:
+            if ProtocolVersion.uses_keyspace_flag(version):
+                message.send_body(io, version)
+                self._check_calls(io, [
+                    ('\x00\x00\x00\x01',),
+                    ('a',),
+                    ('\x00\x00\x00\x80',),
+                    (b'\x00\x02',),
+                    (b'ks',),
+                ])
+            else:
+                with self.assertRaises(UnsupportedOperation):
+                    message.send_body(io, version)
+            io.reset_mock()
+
+    def test_keyspace_flag_raises_before_v5(self):
+        keyspace_message = QueryMessage('a', consistency_level=3, keyspace='ks')
+        io = Mock(name='io')
+
+        with self.assertRaisesRegex(UnsupportedOperation, 'Keyspaces.*set'):
+            keyspace_message.send_body(io, protocol_version=4)
+        io.assert_not_called()
+
+    def test_keyspace_written_with_length(self):
+        io = Mock(name='io')
+        base_expected = [
+            (b'\x00\x00\x00\x01',),
+            (b'a',),
+            (b'\x00\x03',),
+            (b'\x00\x00\x00\x80',),  # options w/ keyspace flag
+        ]
+
+        QueryMessage('a', consistency_level=3, keyspace='ks').send_body(
+            io, protocol_version=5
+        )
+        self._check_calls(io, base_expected + [
+            (b'\x00\x02',),  # length of keyspace string
+            (b'ks',),
+        ])
+
+        io.reset_mock()
+
+        QueryMessage('a', consistency_level=3, keyspace='keyspace').send_body(
+            io, protocol_version=5
+        )
+        self._check_calls(io, base_expected + [
+            (b'\x00\x08',),  # length of keyspace string
+            (b'keyspace',),
+        ])
+
+    def test_batch_message_with_keyspace(self):
+        self.maxDiff = None
+        io = Mock(name='io')
+        batch = BatchMessage(
+            batch_type=BatchType.LOGGED,
+            queries=((False, 'stmt a', ('param a',)),
+                     (False, 'stmt b', ('param b',)),
+                     (False, 'stmt c', ('param c',))
+                     ),
+            consistency_level=3,
+            keyspace='ks'
+        )
+        batch.send_body(io, protocol_version=5)
+        self._check_calls(io,
+            (('\x00',), ('\x00\x03',), ('\x00',),
+             ('\x00\x00\x00\x06',), ('stmt a',),
+             ('\x00\x01',), ('\x00\x00\x00\x07',), ('param a',),
+             ('\x00',), ('\x00\x00\x00\x06',), ('stmt b',),
+             ('\x00\x01',), ('\x00\x00\x00\x07',), ('param b',),
+             ('\x00',), ('\x00\x00\x00\x06',), ('stmt c',),
+             ('\x00\x01',), ('\x00\x00\x00\x07',), ('param c',),
+             ('\x00\x03',),
+             ('\x00\x00\x00\x80',), ('\x00\x02',), ('ks',))
+        )

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -20,7 +20,7 @@ except ImportError:
 from mock import Mock, MagicMock, ANY
 
 from cassandra import ConsistencyLevel, Unavailable, SchemaTargetType, SchemaChangeType
-from cassandra.cluster import Session, ResponseFuture, NoHostAvailable
+from cassandra.cluster import Session, ResponseFuture, NoHostAvailable, ProtocolVersion
 from cassandra.connection import Connection, ConnectionException
 from cassandra.protocol import (ReadTimeoutErrorMessage, WriteTimeoutErrorMessage,
                                 UnavailableErrorMessage, ResultMessage, QueryMessage,
@@ -476,6 +476,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf = self.make_response_future(session)
         rf.send_request()
 
+        session.cluster.protocol_version = ProtocolVersion.V4
         session.cluster._prepared_statements = MagicMock(dict)
         prepared_statement = session.cluster._prepared_statements.__getitem__.return_value
         prepared_statement.query_string = "SELECT * FROM foobar"
@@ -500,6 +501,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf = self.make_response_future(session)
         rf.send_request()
 
+        session.cluster.protocol_version = ProtocolVersion.V4
         session.cluster._prepared_statements = MagicMock(dict)
         prepared_statement = session.cluster._prepared_statements.__getitem__.return_value
         prepared_statement.query_string = "SELECT * FROM foobar"


### PR DESCRIPTION
This deals with [PYTHON-678](https://datastax-oss.atlassian.net/browse/PYTHON-678)/[PYTHON-804](https://datastax-oss.atlassian.net/browse/PYTHON-804).

I honestly don't know what the user API looks like for this, so I don't have integration tests yet. I'll consult with folks tomorrow.