### PR TITLE
Lock joining the libev event loop thread

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Bug Fixes
 * Use of DCAwareRoundRobinPolicy raises NoHostAvailable exception (PYTHON-781)
 * Not create two sessions by default in CQLEngine (PYTHON-814)
 * Bug when subclassing AyncoreConnection (PYTHON-827)
+* Rare exception when "sys.exit(0)" after query timeouts (PYTHON-752)
 
 3.11.0
 ======


### PR DESCRIPTION
I'd rather do this solution than add a lock around [this part](https://github.com/datastax/python-driver/blob/d3e960134f97198f244873aa1ce66078947c3a89/cassandra/io/libevreactor.py#L97) and the part where the thread is joined. It looks more simple to me.