### PR TITLE
WARN on Cluster.__init__ w contact points & no lbp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Features
 * Send keyspace in QUERY, PREPARE, and BATCH messages (PYTHON-678)
 * Add IPv4Address/IPv6Address support for inet types (PYTHON-751)
 * WriteType.CDC and VIEW missing (PYTHON-794)
+* Warn on Cluster init if contact points are specified but LBP isn't (PYTHON-812)
 
 Bug Fixes
 ---------

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -312,6 +312,8 @@ class _ConfigMode(object):
     PROFILES = 2
 
 
+_UNSET_ARG = object()
+
 class Cluster(object):
     """
     The main class to use when interacting with a Cassandra cluster.
@@ -733,7 +735,7 @@ class Cluster(object):
     _listener_lock = None
 
     def __init__(self,
-                 contact_points=["127.0.0.1"],
+                 contact_points=_UNSET_ARG,
                  port=9042,
                  compression=True,
                  auth_provider=None,
@@ -770,7 +772,18 @@ class Cluster(object):
 
         Any of the mutable Cluster attributes may be set as keyword arguments to the constructor.
         """
+        if contact_points is not _UNSET_ARG and load_balancing_policy is None:
+            log.warn('Cluster.__init__ called with contact_points specified, '
+                     'but no load_balancing_policy. In the next major '
+                     'version, this will raise an error; please specify a '
+                     'load balancing policy. '
+                     '(contact_points = {cp}, lbp = {lbp}'
+                     ''.format(cp=contact_points, lbp=load_balancing_policy))
+
         if contact_points is not None:
+            if contact_points is _UNSET_ARG:
+                contact_points = ['127.0.0.1']
+
             if isinstance(contact_points, six.string_types):
                 raise TypeError("contact_points should not be a string, it should be a sequence (e.g. list) of strings")
 


### PR DESCRIPTION
[PYTHON-812](https://datastax-oss.atlassian.net/browse/PYTHON-812)

I think this is the right way to implement this -- we check if `contact_points` is unset, not if it's the default value. That way, if a user has some weird configuration where they want to connect to `localhost`, but also want a non-default LBP, they should still be able to specify it.