### PR TITLE
PYTHON-794: add VIEW and CDC writetypes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Features
 --------
 * Send keyspace in QUERY, PREPARE, and BATCH messages (PYTHON-678)
 * Add IPv4Address/IPv6Address support for inet types (PYTHON-751)
+* WriteType.CDC and VIEW missing (PYTHON-794)
 
 Bug Fixes
 ---------

--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -731,6 +731,18 @@ class WriteType(object):
     A lighweight-transaction write, such as "DELETE ... IF EXISTS".
     """
 
+    VIEW = 6
+    """
+    This WriteType is only seen in results for requests that were unable to
+    complete MV operations.
+    """
+
+    CDC = 7
+    """
+    This WriteType is only seen in results for requests that were unable to
+    complete CDC operations.
+    """
+
 
 WriteType.name_to_value = {
     'SIMPLE': WriteType.SIMPLE,
@@ -738,7 +750,9 @@ WriteType.name_to_value = {
     'UNLOGGED_BATCH': WriteType.UNLOGGED_BATCH,
     'COUNTER': WriteType.COUNTER,
     'BATCH_LOG': WriteType.BATCH_LOG,
-    'CAS': WriteType.CAS
+    'CAS': WriteType.CAS,
+    'VIEW': WriteType.VIEW,
+    'CDC': WriteType.CDC
 }
 
 


### PR DESCRIPTION
[PYTHON-794](https://datastax-oss.atlassian.net/browse/PYTHON-794)

Had to do a little digging to find the writetypes, but I only found them in the documented cases. I can go dig the code back up if requested.