### PR TITLE
PYTHON-862: use self.create_timer instead of AsyncoreConnection.creat…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Features
 
 Bug Fixes
 ---------
+* AttributeError: 'NoneType' object has no attribute 'add_timer' (PYTHON-862)
 * Support retry_policy in PreparedStatement (PYTHON-861)
 * __del__ method in Session is throwing an exception (PYTHON-813)
 

--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -370,7 +370,7 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
         self._readable = False
 
         # We don't have to wait for this to be closed, we can just schedule it
-        AsyncoreConnection.create_timer(0, partial(asyncore.dispatcher.close, self))
+        self.create_timer(0, partial(asyncore.dispatcher.close, self))
 
         log.debug("Closed socket to %s", self.host)
 

--- a/tests/integration/simulacron/test_connection.py
+++ b/tests/integration/simulacron/test_connection.py
@@ -27,6 +27,7 @@ from cassandra import OperationTimedOut
 from cassandra.cluster import (EXEC_PROFILE_DEFAULT, Cluster, ExecutionProfile,
                                _Scheduler, NoHostAvailable)
 from cassandra.policies import HostStateListener, RoundRobinPolicy
+from cassandra.io.asyncorereactor import AsyncoreConnection
 from tests.integration import (CASSANDRA_VERSION, PROTOCOL_VERSION,
                                requiressimulacron)
 from tests.integration.util import assert_quiescent_pool_state
@@ -328,3 +329,13 @@ class ConnectionTests(SimulacronBase):
 
         self.assertEqual(listener.hosts_marked_down, [])
         assert_quiescent_pool_state(self, cluster)
+
+    def test_can_shutdown_asyncoreconnection_subclass(self):
+        start_and_prime_singledc()
+        class ExtendedConnection(AsyncoreConnection):
+            pass
+
+        cluster = Cluster(contact_points=["127.0.0.2"],
+                          connection_class=ExtendedConnection)
+        cluster.connect()
+        cluster.shutdown()


### PR DESCRIPTION
…e_timer