### PR TITLE
Alternative solution for PYTHON-836

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Features
 * Include hash of result set metadata in prepared stmt id (PYTHON-808)
 * Add NO_COMPACT startup option (PYTHON-839)
 * Add new exception type for CDC (PYTHON-837)
+* Allow 0ms in ConstantSpeculativeExecutionPolicy (PYTHON-836)
 
 Bug Fixes
 ---------

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3521,6 +3521,18 @@ class ResponseFuture(object):
     def _on_speculative_execute(self):
         self._timer = None
         if not self._event.is_set():
+
+            # PYTHON-836, the speculative queries must be after
+            # the query is sent from the main thread, otherwise the
+            # query from the main thread may raise NoHostAvailable
+            # if the _query_plan has been exhausted by the specualtive queries.
+            # This also prevents a race condition accessing the iterator.
+            # We reschedule this call until the main thread has succeeded
+            # making a query
+            if not self.attempted_hosts:
+                self._timer = self.session.cluster.connection_class.create_timer(0.01, self._on_speculative_execute)
+                return
+
             if self._time_remaining is not None:
                 if self._time_remaining <= 0:
                     self._on_timeout()
@@ -3534,10 +3546,6 @@ class ResponseFuture(object):
         # calls to send_request (which retries may do) will resume where
         # they last left off
         self.query_plan = iter(self._load_balancer.make_query_plan(self.session.keyspace, self.query))
-        # Make iterator thread safe when there can be a speculative delay since it could
-        # from different threads
-        if isinstance(self._spec_execution_plan, NoSpeculativeExecutionPlan):
-            self.query_plan = _threadsafe_iter(self.query_plan)
 
     def send_request(self, error_no_hosts=True):
         """ Internal """
@@ -4310,16 +4318,3 @@ class ResultSet(object):
         avoid sending this to untrusted parties.
         """
         return self.response_future._paging_state
-
-
-class _threadsafe_iter(six.Iterator):
-    def __init__(self, it):
-        self.it = it
-        self.lock = Lock()
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        with self.lock:
-            return next(self.it)


### PR DESCRIPTION
This is a different solution https://github.com/datastax/python-driver/pull/873 and one that hopefully works better. The problem with the previous one was that for example if we are connected to one host cluster and the scheduled speculative execution happens before the regular attempt from the main thread (this is likely to happen since it's scheduled in `0` seconds). The `_query_plan` from `ResponseFuture` will have already been exhausted by the speculative executions and the attempt from the main thread will fail with `NoHostAvailable`.
In this PR `_on_speculative_execute` schedules itself again if the attempt from the main thread hasn't yet happened