### PR TITLE
PYTHON-853: delay timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Bug Fixes
 * Support retry_policy in PreparedStatement (PYTHON-861)
 * __del__ method in Session is throwing an exception (PYTHON-813)
 * LZ4 import issue with recent versions (PYTHON-897)
+* ResponseFuture._connection can be None when returning request_id (PYTHON-853)
 
 Other
 -----


### PR DESCRIPTION
Tries to solve the same issue as #857.

I'm a little wary of adding a new place where `._timer` is set, but I think we're OK:

```python
    def _on_speculative_execute(self):
        self._timer = None
        if not self._event.is_set():
            if self._time_remaining is not None:
                if self._time_remaining <= 0:
                    self._on_timeout()
                    return
            self.send_request(error_no_hosts=False)
            self._start_timer()
```

Here, if `_on_timeout` overwrites `._timer`, that's fine -- we know `._timer` is `None` anyway.

I was worried about deferring to the event loop and returning from `_on_timeout` without the work actually being done. However, _on_speculative_execute is only ever called from the event loop (see below) so I think it's ok to replace the timer and put the timeoout processing on the event loop, since nothing explicitly waits on the completion of `_on_speculative_execute`.


```python
    def _start_timer(self):
        if self._timer is None:
            spec_delay = self._spec_execution_plan.next_execution(self._current_host)
            if spec_delay >= 0:
                if self._time_remaining is None or self._time_remaining > spec_delay:
                    self._timer = self.session.cluster.connection_class.create_timer(spec_delay, self._on_speculative_execute)
                    return
            if self._time_remaining is not None:
                self._timer = self.session.cluster.connection_class.create_timer(self._time_remaining, self._on_timeout)
```

Here, we're definitely ok. If we ever replace `._timer`, it's at the end of the execution of the deferred `_on_timeout` or `_on_speculative_execute` call.

```python
    def send_request(self, error_no_hosts=True):
        """ Internal """
        # query_plan is an iterator, so this will resume where we last left
        # off if send_request() is called multiple times
        for host in self.query_plan:
            req_id = self._query(host)
            if req_id is not None:
                self._req_id = req_id
                return True
            if self.timeout is not None and time.time() - self._start_time > self.timeout:
                self._on_timeout()
                return True

        if error_no_hosts:
            self._set_final_exception(NoHostAvailable(
                "Unable to complete the operation against any hosts", self._errors))
        return False
```

I believe that we're ok here as well. Since the call ends after `_on_timeout` is called, we can't lose any timers -- `._timer` will only be set multiple times if `_on_timeout` reschedules itself multiple times, and that's fine.

I think this covers all the ways that `_on_timeout` is called -- it's always called by `_send_request`, sometimes via `_on_speculative_execute`. It also seems to cover all the ways that `._timer` can be set to a new value.

  