### PR TITLE
PYTHON-506: Remove two-phase query when deleting values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features
 * cqlengine: asynchronous execution support (PYTHON-605)
 * cqlengine: disallow Counter create, save operations (PYTHON-497)
 * cqlengine: Makes Model._table_name_ case sensitive (PYTHON-855)
+* cqlengine: Remove two-phase query when deleting values (PYTHON-506)
 
 
 Other

--- a/tests/integration/cqlengine/query/test_updates.py
+++ b/tests/integration/cqlengine/query/test_updates.py
@@ -106,7 +106,7 @@ class QueryUpdateTests(BaseCassEngTestCase):
             self.assertEqual(row.count, i)
             self.assertEqual(row.text, None if i == 3 else str(i))
 
-    @execute_count(9)
+    @execute_count(8)
     def test_mixed_value_and_null_update(self):
         """ tests that updating a columns value, and removing another works properly """
         partition = uuid4()

--- a/tests/integration/cqlengine/statements/test_assignment_clauses.py
+++ b/tests/integration/cqlengine/statements/test_assignment_clauses.py
@@ -49,21 +49,22 @@ class SetUpdateClauseTests(unittest.TestCase):
         self.assertEqual(ctx, {'0': set((1, 2))})
 
     def test_null_update(self):
-        """ tests setting a set to None creates an empty update statement """
+        """ tests setting a set to None creates an update statement """
         c = SetUpdateClause('s', None, previous=set((1, 2)))
         c._analyze()
         c.set_context_id(0)
 
+        self.assertTrue(c._is_assignment)
         self.assertIsNone(c._assignments)
         self.assertIsNone(c._additions)
         self.assertIsNone(c._removals)
 
-        self.assertEqual(c.get_context_size(), 0)
-        self.assertEqual(str(c), '')
+        self.assertEqual(c.get_context_size(), 1)
+        self.assertEqual(str(c), '"s" = %(0)s')
 
         ctx = {}
         c.update_context(ctx)
-        self.assertEqual(ctx, {})
+        self.assertEqual(ctx, {'0': None})
 
     def test_no_update(self):
         """ tests an unchanged value creates an empty update statement """
@@ -166,6 +167,23 @@ class ListUpdateClauseTests(unittest.TestCase):
         ctx = {}
         c.update_context(ctx)
         self.assertEqual(ctx, {'0': [1, 2, 3]})
+
+    def test_update_to_none(self):
+        c = ListUpdateClause('s', None, previous=[1, 2, 3])
+        c._analyze()
+        c.set_context_id(0)
+
+        self.assertTrue(c._is_assignment)
+        self.assertIsNone(c._assignments)
+        self.assertIsNone(c._append)
+        self.assertIsNone(c._prepend)
+
+        self.assertEqual(c.get_context_size(), 1)
+        self.assertEqual(str(c), '"s" = %(0)s')
+
+        ctx = {}
+        c.update_context(ctx)
+        self.assertEqual(ctx, {'0': None})
 
     def test_update_from_empty(self):
         c = ListUpdateClause('s', [1, 2, 3], previous=[])

--- a/tests/integration/cqlengine/statements/test_update_statement.py
+++ b/tests/integration/cqlengine/statements/test_update_statement.py
@@ -69,6 +69,11 @@ class UpdateStatementTests(unittest.TestCase):
         us.add_update(Set(Text, db_field='a'), set((1,)), 'add')
         self.assertEqual(six.text_type(us), 'UPDATE table SET "a" = "a" + %(0)s')
 
+    def test_update_set_with_none(self):
+        us = UpdateStatement('table')
+        us.add_update(Set(Text, db_field='a'), None)
+        self.assertTrue(us.assignments)
+
     def test_update_empty_set_add_does_not_assign(self):
         us = UpdateStatement('table')
         us.add_update(Set(Text, db_field='a'), set(), 'add')
@@ -78,6 +83,11 @@ class UpdateStatementTests(unittest.TestCase):
         us = UpdateStatement('table')
         us.add_update(Set(Text, db_field='a'), set(), 'remove')
         self.assertFalse(us.assignments)
+
+    def test_update_list_with_none(self):
+        us = UpdateStatement('table')
+        us.add_update(List(Text, db_field='a'), None, previous=[1])
+        self.assertTrue(us.assignments)
 
     def test_update_list_prepend_with_empty_list(self):
         us = UpdateStatement('table')


### PR DESCRIPTION
This PR now let None pass along the UPDATE statements. Map key deletions is a bit different.. so some code has been preserve to avoid the creation of tombstone on every update.