### PR TITLE
PYTHON-463 PYTHON-945 PYTHON-947: ResultSet refactoring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,12 +3,14 @@
 
 Features
 --------
+* Add one() function to the ResultSet API (PYTHON-947)
 * cqlengine: asynchronous execution support (PYTHON-605)
 * cqlengine: Makes Model._table_name_ case sensitive (PYTHON-855)
 * cqlengine: LIKE filter operator (PYTHON-512)
 
 Bug Fixes
 ---------
+* Calling next() on a ResultSet throws an exception (PYTHON-463)
 * Support retry_policy in PreparedStatement (PYTHON-861)
 * cqlengine: Remove cassandra.cqlengine.query.BatchType in favor of cassandra.query.BatchType (PYTHON-888)
 
@@ -18,6 +20,7 @@ Other
 * PreparedStatement.column_metadata should be renamed to bind_metadata (PYTHON-884)
 * Remove Cluster.set_meta_refresh_enabled (PYTHON-890)
 * Remove legacy execution parameters (PYTHON-876)
+* Remove basic equality and indexing support of ResultSet (PYTHON-945)
 * cqlengine: disallow Counter create, save operations (PYTHON-497)
 * cqlengine: remove the negative indices slicing support in ModelQuerySet (PYTHON-875)
 * cqlengine: Remove Model.__default_ttl__ (PYTHON-889)

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -896,7 +896,7 @@ class Cluster(object):
 
             # results will include Address instances
             results = session.execute("SELECT * FROM users")
-            row = results[0]
+            row = results.one()
             print row.id, row.location.street, row.location.zipcode
 
         """
@@ -3768,20 +3768,44 @@ class QueryExhausted(Exception):
     pass
 
 
+class ResultSetIterator(object):
+    """ResultSet iterator that handle pagination transparently"""
+
+    def __init__(self, result_set):
+        self._result_set = result_set
+
+    def __iter__(self):
+        if self._result_set._page_iter is None:
+            self._result_set._page_iter = iter(self._result_set.current_rows)
+        return self
+
+    def next(self):
+        try:
+            return next(self._result_set._page_iter)
+        except StopIteration:
+            if not self._result_set.has_more_pages:
+                self._result_set._current_rows = []
+                raise
+
+        self._result_set.fetch_next_page()
+        self._result_set._page_iter = iter(self._result_set._current_rows)
+
+        return next(self._result_set._page_iter)
+
+    __next__ = next
+
+
 class ResultSet(object):
     """
-    An iterator over the rows from a query result. Also supplies basic equality
-    and indexing methods for backward-compatability. These methods materialize
-    the entire result set (loading all pages), and should only be used if the
-    total result size is understood. Warnings are emitted when paged results
-    are materialized in this fashion.
-
-    You can treat this as a normal iterator over rows::
+    The result of a query. You can access rows using an iterator::
 
         >>> from cassandra.query import SimpleStatement
         >>> statement = SimpleStatement("SELECT * FROM users", fetch_size=10)
         >>> for user_row in session.execute(statement):
         ...     process_user(user_row)
+
+        # or for a single row with
+        >>> row = session.execute(statement).one()
 
     Whenever there are no more rows in the current page, the next page will
     be fetched transparently.  However, note that it *is* possible for
@@ -3795,7 +3819,6 @@ class ResultSet(object):
         self.column_types = response_future._col_types
         self._set_current_rows(initial_response)
         self._page_iter = None
-        self._list_mode = False
 
     @property
     def has_more_pages(self):
@@ -3812,27 +3835,17 @@ class ResultSet(object):
         """
         return self._current_rows or []
 
+    def one(self):
+        """
+        Return a single row of the results or None if empty. This is basically
+        a shortcut to `result_set.current_rows[0]` and should only be used when
+        you know a query returns a single row. Consider using an iterator if the
+        ResultSet contains more than one row.
+        """
+        return self._current_rows[0] if self._current_rows else None
+
     def __iter__(self):
-        if self._list_mode:
-            return iter(self._current_rows)
-        self._page_iter = iter(self._current_rows)
-        return self
-
-    def next(self):
-        try:
-            return next(self._page_iter)
-        except StopIteration:
-            if not self.response_future.has_more_pages:
-                if not self._list_mode:
-                    self._current_rows = []
-                raise
-
-        self.fetch_next_page()
-        self._page_iter = iter(self._current_rows)
-
-        return next(self._page_iter)
-
-    __next__ = next
+        return iter(ResultSetIterator(self))
 
     def fetch_next_page(self):
         """
@@ -3856,28 +3869,6 @@ class ResultSet(object):
             self._current_rows = result
         except TypeError:
             self._current_rows = [result] if result else []
-
-    def _fetch_all(self):
-        self._current_rows = list(self)
-        self._page_iter = None
-
-    def _enter_list_mode(self, operator):
-        if self._list_mode:
-            return
-        if self._page_iter:
-            raise RuntimeError("Cannot use %s when results have been iterated." % operator)
-        if self.response_future.has_more_pages:
-            log.warning("Using %s on paged results causes entire result set to be materialized.", operator)
-        self._fetch_all()  # done regardless of paging status in case the row factory produces a generator
-        self._list_mode = True
-
-    def __eq__(self, other):
-        self._enter_list_mode("equality operator")
-        return self._current_rows == other
-
-    def __getitem__(self, i):
-        self._enter_list_mode("index operator")
-        return self._current_rows[i]
 
     def __nonzero__(self):
         return bool(self._current_rows)

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -944,7 +944,7 @@ class QueryTrace(object):
                 SimpleStatement(self._SELECT_SESSIONS_FORMAT, consistency_level=query_cl), (self.trace_id,), time_spent, max_wait)
 
             # PYTHON-730: There is race condition that the duration mutation is written before started_at the for fast queries
-            is_complete = session_results and session_results[0].duration is not None and session_results[0].started_at is not None
+            is_complete = session_results and session_results.one().duration is not None and session_results.one().started_at is not None
             if not session_results or (wait_for_complete and not is_complete):
                 time.sleep(self._BASE_RETRY_SLEEP * (2 ** attempt))
                 attempt += 1
@@ -954,7 +954,7 @@ class QueryTrace(object):
             else:
                 log.debug("Fetching parital trace info for trace ID: %s", self.trace_id)
 
-            session_row = session_results[0]
+            session_row = session_results.one()
             self.request_type = session_row.request
             self.duration = timedelta(microseconds=session_row.duration) if is_complete else None
             self.started_at = session_row.started_at

--- a/docs/execution_profiles.rst
+++ b/docs/execution_profiles.rst
@@ -35,7 +35,7 @@ Default
     session = cluster.connect()
     local_query = 'SELECT rpc_address FROM system.local'
     for _ in cluster.metadata.all_hosts():
-        print session.execute(local_query)[0]
+        print session.execute(local_query).one()
 
 
 .. parsed-literal::
@@ -61,7 +61,7 @@ Initializing cluster with profiles
     profiles = {'node1': node1_profile, 'node2': node2_profile}
     session = Cluster(execution_profiles=profiles).connect()
     for _ in cluster.metadata.all_hosts():
-        print session.execute(local_query, execution_profile='node1')[0]
+        print session.execute(local_query, execution_profile='node1').one()
 
 
 .. parsed-literal::
@@ -73,7 +73,7 @@ Initializing cluster with profiles
 .. code:: python
 
     for _ in cluster.metadata.all_hosts():
-        print session.execute(local_query, execution_profile='node2')[0]
+        print session.execute(local_query, execution_profile='node2').one()
 
 
 .. parsed-literal::
@@ -85,7 +85,7 @@ Initializing cluster with profiles
 .. code:: python
 
     for _ in cluster.metadata.all_hosts():
-        print session.execute(local_query)[0]
+        print session.execute(local_query).one()
 
 
 .. parsed-literal::
@@ -115,7 +115,7 @@ New profiles can be added constructing from scratch, or deriving from default:
     cluster.add_execution_profile(node1_profile, locked_execution)
     
     for _ in cluster.metadata.all_hosts():
-        print session.execute(local_query, execution_profile=node1_profile)[0]
+        print session.execute(local_query, execution_profile=node1_profile).one()
 
 
 .. parsed-literal::
@@ -136,8 +136,8 @@ We also have the ability to pass profile instances to be used for execution, but
     
     tmp = session.execution_profile_clone_update('node1', request_timeout=100, row_factory=tuple_factory)
 
-    print session.execute(local_query, execution_profile=tmp)[0]
-    print session.execute(local_query, execution_profile='node1')[0]
+    print session.execute(local_query, execution_profile=tmp).one()
+    print session.execute(local_query, execution_profile='node1').one()
 
 .. parsed-literal::
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -28,7 +28,7 @@ To avoid this, make sure to create sessions per process, after the fork. Using u
 
     @app.route('/')
     def server_version():
-        row = session.execute(prepared, ('local',))[0]
+        row = session.execute(prepared, ('local',)).one()
         return row.release_version
 
 uWSGI provides a ``postfork`` hook you can use to create sessions and prepared statements after the child process forks.

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -272,7 +272,7 @@ For example:
 
     try:
         rows = future.result()
-        user = rows[0]
+        user = rows.one()
         print user.name, user.age
     except ReadTimeout:
         log.exception("Query timed out:")
@@ -290,7 +290,7 @@ This works well for executing many queries concurrently:
     # wait for them to complete and use the results
     for future in futures:
         rows = future.result()
-        print rows[0].name
+        print rows.one().name
 
 Alternatively, instead of calling :meth:`~.ResponseFuture.result()`,
 you can attach callback and errback functions through the
@@ -303,7 +303,7 @@ that:
 .. code-block:: python
 
     def handle_success(rows):
-        user = rows[0]
+        user = rows.one()
         try:
             process_user(user.name, user.age, user.id)
         except Exception:
@@ -389,8 +389,8 @@ prepared statement:
     user_lookup_stmt.consistency_level = ConsistencyLevel.QUORUM
 
     # these will both use QUORUM
-    user1 = session.execute(user_lookup_stmt, [user_id1])[0]
-    user2 = session.execute(user_lookup_stmt, [user_id2])[0]
+    user1 = session.execute(user_lookup_stmt, [user_id1]).one()
+    user2 = session.execute(user_lookup_stmt, [user_id2]).one()
 
 The second option is to create a :class:`~.BoundStatement` from the
 :class:`~.PreparedStatement` and binding parameters and set a consistency

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -23,6 +23,39 @@ Upgrading to 4.0
   - Session.default_serial_consistency_level
   - Session.row_factory
 
+ResultSet
+~~~~~~~~~
+
+* :class:`~.ResultSet` *next* method has been removed. Use an iterator 
+  to consume the results.
+
+  .. code-block:: python
+
+    rs = session.execute("select * from cars")
+    for car in rs:
+        # ...
+  
+    # or
+    car = next(iter(rs))
+
+* Basic equality and indexing support of the :class:`~.ResultSet` class have been removed.
+  In previous versions, these were preserved for backward compatibility. Since a 
+  ResultSet is not final until all pages are fetched, you should materialize the 
+  results first if you want to compare or access an element by index.
+
+  .. code-block:: python
+
+    list(result_set1) == list(result_set2)  # materialize then comparison 
+    results = list(result_set1)
+    results[3]                              # results is just a python list
+
+* With :class:`~.ResultSet` indexing support removed, you have to use 
+  :meth:`~.ResultSet.one()` to get a single row.
+
+  .. code-block:: python
+
+    row = session.execute("select * from cars where id=42").one()
+
 Upgrading to 3.0
 ----------------
 Version 3.0 of the DataStax Python driver for Apache Cassandra

--- a/docs/user_defined_types.rst
+++ b/docs/user_defined_types.rst
@@ -38,7 +38,7 @@ instance through :meth:`.Cluster.register_user_type`:
 
     # results will include Address instances
     results = session.execute("SELECT * FROM users")
-    row = results[0]
+    row = results.one()
     print row.id, row.location.street, row.location.zipcode
 
 Using UDTs Without Registering Them
@@ -77,7 +77,7 @@ for the UDT:
     # when we query data, UDT columns that don't have a class registered
     # will be returned as namedtuples:
     results = session.execute("SELECT * FROM users")
-    first_row = results[0]
+    first_row = results.one()
     address = first_row.location
     print address  # prints "Address(street='123 Main St.', zipcode=78723)"
     street = address.street

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -73,7 +73,7 @@ def get_server_versions():
 
     c = Cluster()
     s = c.connect()
-    row = s.execute('SELECT cql_version, release_version FROM system.local')[0]
+    row = s.execute('SELECT cql_version, release_version FROM system.local').one()
 
     cass_version = _tuple_version(row.release_version)
     cql_version = _tuple_version(row.cql_version)

--- a/tests/integration/cqlengine/statements/test_base_statement.py
+++ b/tests/integration/cqlengine/statements/test_base_statement.py
@@ -66,7 +66,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
     def _verify_statement(self, original):
         st = SelectStatement(self.table_name)
         result = execute(st)
-        response = result[0]
+        response = result.one()
 
         for assignment in original.assignments:
             self.assertEqual(response[assignment.field], assignment.value)
@@ -135,7 +135,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
                          'SELECT * FROM {} WHERE "text" LIKE %(0)s'.format(self.table_name))
 
         result = execute(ss)
-        self.assertEqual(result[0]["text"], self.text)
+        self.assertEqual(result.one()["text"], self.text)
 
         q = TestQueryUpdateModel.objects.filter(text__like=like_clause).allow_filtering()
         self.assertEqual(q[0].text, self.text)

--- a/tests/integration/cqlengine/test_ttl.py
+++ b/tests/integration/cqlengine/test_ttl.py
@@ -161,7 +161,7 @@ class TTLDefaultTest(BaseDefaultTTLTest):
         except InvalidRequest:
             default_ttl = session.execute("SELECT default_time_to_live FROM system.schema_columnfamilies "
                                           "WHERE keyspace_name = 'cqlengine_test' AND columnfamily_name = '{0}'".format(table_name))
-        return default_ttl[0]['default_time_to_live']
+        return default_ttl.one()['default_time_to_live']
 
     def test_default_ttl_not_set(self):
         session = get_session()

--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -496,7 +496,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         self.assertIn(results.response_future.attempted_hosts[0],
                       cluster.metadata.get_replicas(keyspace, bound.routing_key))
 
-        self.assertTrue(results[0].i)
+        self.assertTrue(results.one().i)
 
         cluster.shutdown()
 
@@ -533,8 +533,8 @@ class LoadBalancingPolicyTests(unittest.TestCase):
 
         p = session.prepare("SELECT * FROM system.local WHERE key=?")
         # this would blow up prior to 61b4fad
-        r = session.execute(p, ('local',))
-        self.assertEqual(r[0].key, 'local')
+        r = session.execute(p, ('local',)).one()
+        self.assertEqual(r.key, 'local')
 
         cluster.shutdown()
 

--- a/tests/integration/standard/test_concurrent.py
+++ b/tests/integration/standard/test_concurrent.py
@@ -99,6 +99,7 @@ class ClusterTests(unittest.TestCase):
             parameters = [(i, ) for i in range(num_statements)]
 
             results = self.execute_concurrent_helper(self.session, list(zip(statements, parameters)))
+            results = [(s, list(r)) for s, r in results]
             self.assertEqual(num_statements, len(results))
             self.assertEqual([(True, [(i,)]) for i in range(num_statements)], results)
 
@@ -122,8 +123,9 @@ class ClusterTests(unittest.TestCase):
             parameters = [(i, ) for i in range(num_statements)]
 
             results = self.execute_concurrent_args_helper(self.session, statement, parameters)
+            results = [(s, list(r)) for s, r in results]
             self.assertEqual(num_statements, len(results))
-            self.assertEqual([(True, [(i,)]) for i in range(num_statements)], results)
+            self.assertEqual([(True, [(i,)]) for i in range(num_statements)], list(results))
 
     def test_execute_concurrent_with_args_generator(self):
         """
@@ -162,7 +164,7 @@ class ClusterTests(unittest.TestCase):
             parameters = [(i, ) for i in range(num_statements)]
 
             results = self.execute_concurrent_args_helper(self.session, statement, parameters, results_generator=True)
-
+            results = iter([(s, list(r)) for s, r in results])
             for i in range(num_statements):
                 result = next(results)
                 self.assertEqual((True, [(i,)]), result)

--- a/tests/integration/standard/test_concurrent.py
+++ b/tests/integration/standard/test_concurrent.py
@@ -98,8 +98,9 @@ class ClusterTests(unittest.TestCase):
             statements = cycle((statement, ))
             parameters = [(i, ) for i in range(num_statements)]
 
-            results = self.execute_concurrent_helper(self.session, list(zip(statements, parameters)))
-            results = [(s, list(r)) for s, r in results]
+            results = [(s, list(r)) for s, r in
+                       self.execute_concurrent_helper(self.session,
+                                                      list(zip(statements, parameters)))]
             self.assertEqual(num_statements, len(results))
             self.assertEqual([(True, [(i,)]) for i in range(num_statements)], results)
 
@@ -122,8 +123,10 @@ class ClusterTests(unittest.TestCase):
                 consistency_level=ConsistencyLevel.QUORUM)
             parameters = [(i, ) for i in range(num_statements)]
 
-            results = self.execute_concurrent_args_helper(self.session, statement, parameters)
-            results = [(s, list(r)) for s, r in results]
+            results = [(s, list(r)) for s, r in
+                       self.execute_concurrent_args_helper(self.session,
+                                                           statement,
+                                                           parameters)]
             self.assertEqual(num_statements, len(results))
             self.assertEqual([(True, [(i,)]) for i in range(num_statements)], list(results))
 
@@ -163,8 +166,13 @@ class ClusterTests(unittest.TestCase):
                 consistency_level=ConsistencyLevel.QUORUM)
             parameters = [(i, ) for i in range(num_statements)]
 
-            results = self.execute_concurrent_args_helper(self.session, statement, parameters, results_generator=True)
-            results = iter([(s, list(r)) for s, r in results])
+            results = iter(
+                [(s, list(r)) for s, r in
+                 self.execute_concurrent_args_helper(self.session,
+                                                     statement,
+                                                     parameters,
+                                                     results_generator=True)]
+            )
             for i in range(num_statements):
                 result = next(results)
                 self.assertEqual((True, [(i,)]), result)

--- a/tests/integration/standard/test_custom_protocol_handler.py
+++ b/tests/integration/standard/test_custom_protocol_handler.py
@@ -70,22 +70,22 @@ class CustomProtocolHandlerTest(unittest.TestCase):
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)})
         session = cluster.connect(keyspace="custserdes")
 
-        result = session.execute("SELECT schema_version FROM system.local")
-        uuid_type = result[0][0]
+        result = session.execute("SELECT schema_version FROM system.local").one()
+        uuid_type = result[0]
         self.assertEqual(type(uuid_type), uuid.UUID)
 
         # use our custom protocol handlder
 
         session.client_protocol_handler = CustomTestRawRowType
-        result_set = session.execute("SELECT schema_version FROM system.local")
-        raw_value = result_set[0][0]
+        result = session.execute("SELECT schema_version FROM system.local").one()
+        raw_value = result[0]
         self.assertTrue(isinstance(raw_value, binary_type))
         self.assertEqual(len(raw_value), 16)
 
         # Ensure that we get normal uuid back when we re-connect
         session.client_protocol_handler = ProtocolHandler
-        result_set = session.execute("SELECT schema_version FROM system.local")
-        uuid_type = result_set[0][0]
+        result = session.execute("SELECT schema_version FROM system.local").one()
+        uuid_type = result[0]
         self.assertEqual(type(uuid_type), uuid.UUID)
         cluster.shutdown()
 
@@ -114,7 +114,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
 
         # verify data
         params = get_all_primitive_params(0)
-        results = session.execute("SELECT {0} FROM alltypes WHERE primkey=0".format(columns_string))[0]
+        results = session.execute("SELECT {0} FROM alltypes WHERE primkey=0".format(columns_string)).one()
         for expected, actual in zip(params, results):
             self.assertEqual(actual, expected)
         # Ensure we have covered the various primitive types

--- a/tests/integration/standard/test_cython_protocol_handlers.py
+++ b/tests/integration/standard/test_cython_protocol_handlers.py
@@ -87,7 +87,7 @@ class CythonProtocolHandlerTest(unittest.TestCase):
         # arrays = { 'a': arr1, 'b': arr2, ... }
         result = get_data(NumpyProtocolHandler)
         self.assertFalse(result.has_more_pages)
-        self._verify_numpy_page(result[0])
+        self._verify_numpy_page(result.one())
 
     @numpytest
     def test_numpy_results_paged(self):
@@ -228,14 +228,14 @@ class NumpyNullTest(BasicSharedKeyspaceUnitTestCase):
         table = "%s.%s" % (self.keyspace_name, self.function_table_name)
         create_table_with_all_types(table, s, 10)
 
-        begin_unset = max(s.execute('select primkey from %s' % (table,))[0]['primkey']) + 1
+        begin_unset = max(s.execute('select primkey from %s' % (table,)).one()['primkey']) + 1
         keys_null = range(begin_unset, begin_unset + 10)
 
         # scatter some emptry rows in here
         insert = "insert into %s (primkey) values (%%s)" % (table,)
         execute_concurrent_with_args(s, insert, ((k,) for k in keys_null))
 
-        result = s.execute("select * from %s" % (table,))[0]
+        result = s.execute("select * from %s" % (table,)).one()
 
         from numpy.ma import masked, MaskedArray
         result_keys = result.pop('primkey')

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -128,8 +128,8 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         query = "SELECT * FROM system.local"
         no_schema_rs = no_schema_session.execute(query)
         no_token_rs = no_token_session.execute(query)
-        self.assertIsNotNone(no_schema_rs[0])
-        self.assertIsNotNone(no_token_rs[0])
+        self.assertIsNotNone(no_schema_rs.one())
+        self.assertIsNotNone(no_token_rs.one())
         no_schema.shutdown()
         no_token.shutdown()
 
@@ -1856,14 +1856,14 @@ class AggregateMetadata(FunctionTest):
         for init_cond in (-1, 0, 1):
             cql_init = encoder.cql_encode_all_types(init_cond)
             with self.VerifiedAggregate(self, **self.make_aggregate_kwargs('sum_int', 'int', init_cond=cql_init)) as va:
-                sum_res = s.execute("SELECT %s(v) AS sum FROM t" % va.function_kwargs['name'])[0].sum
+                sum_res = s.execute("SELECT %s(v) AS sum FROM t" % va.function_kwargs['name']).one().sum
                 self.assertEqual(sum_res, int(init_cond) + sum(expected_values))
 
         # list<text>
         for init_cond in ([], ['1', '2']):
             cql_init = encoder.cql_encode_all_types(init_cond)
             with self.VerifiedAggregate(self, **self.make_aggregate_kwargs('extend_list', 'list<text>', init_cond=cql_init)) as va:
-                list_res = s.execute("SELECT %s(v) AS list_res FROM t" % va.function_kwargs['name'])[0].list_res
+                list_res = s.execute("SELECT %s(v) AS list_res FROM t" % va.function_kwargs['name']).one().list_res
                 self.assertListEqual(list_res[:len(init_cond)], init_cond)
                 self.assertEqual(set(i for i in list_res[len(init_cond):]),
                                  set(str(i) for i in expected_values))
@@ -1874,7 +1874,7 @@ class AggregateMetadata(FunctionTest):
         for init_cond in ({}, {1: 2, 3: 4}, {5: 5}):
             cql_init = encoder.cql_encode_all_types(init_cond)
             with self.VerifiedAggregate(self, **self.make_aggregate_kwargs('update_map', 'map<int, int>', init_cond=cql_init)) as va:
-                map_res = s.execute("SELECT %s(v) AS map_res FROM t" % va.function_kwargs['name'])[0].map_res
+                map_res = s.execute("SELECT %s(v) AS map_res FROM t" % va.function_kwargs['name']).one().map_res
                 self.assertDictContainsSubset(expected_map_values, map_res)
                 init_not_updated = dict((k, init_cond[k]) for k in set(init_cond) - expected_key_set)
                 self.assertDictContainsSubset(init_not_updated, map_res)

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -260,7 +260,7 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
     def _is_trace_present(self, trace_id):
         select_statement = SimpleStatement("SElECT duration FROM system_traces.sessions WHERE session_id = {0}".format(trace_id), consistency_level=ConsistencyLevel.ALL)
         ssrs = self.session.execute(select_statement)
-        if not len(ssrs.current_rows) or ssrs[0].duration is None:
+        if not len(ssrs.current_rows) or ssrs.one().duration is None:
             return False
         return True
 
@@ -328,7 +328,7 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
         self.session.execute(insert_query)
         results = self.session.execute(json_query)
         self.assertEqual(results.column_names, ["[json]"])
-        self.assertEqual(results[0][0], '{"k": 1, "v": 1}')
+        self.assertEqual(results.one()[0], '{"k": 1, "v": 1}')
 
 
 class PreparedStatementTests(unittest.TestCase):
@@ -453,9 +453,9 @@ class PreparedStatementMetdataTest(unittest.TestCase):
             future = session.execute_async(select_statement)
             results = future.result()
             if base_line is None:
-                base_line = results[0]._asdict().keys()
+                base_line = results.one()._asdict().keys()
             else:
-                self.assertEqual(base_line, results[0]._asdict().keys())
+                self.assertEqual(base_line, results.one()._asdict().keys())
             cluster.shutdown()
 
 
@@ -522,7 +522,7 @@ class PreparedStatementArgTest(unittest.TestCase):
         session.execute(batch_statement)
         select_results = session.execute(SimpleStatement("SELECT * FROM %s WHERE k = 1" % table,
                                                          consistency_level=ConsistencyLevel.ALL))
-        first_row = select_results[0][:2]
+        first_row = select_results.one()[:2]
         self.assertEqual((1, 2), first_row)
 
     def test_prepare_batch_statement_after_alter(self):
@@ -750,7 +750,7 @@ class SerialConsistencyTests(unittest.TestCase):
         result = future.result()
         self.assertEqual(future.message.serial_consistency_level, ConsistencyLevel.SERIAL)
         self.assertTrue(result)
-        self.assertFalse(result[0].applied)
+        self.assertFalse(result.one().applied)
 
         statement = SimpleStatement(
             "UPDATE test3rf.test SET v=1 WHERE k=0 IF v=0",
@@ -760,7 +760,7 @@ class SerialConsistencyTests(unittest.TestCase):
         result = future.result()
         self.assertEqual(future.message.serial_consistency_level, ConsistencyLevel.LOCAL_SERIAL)
         self.assertTrue(result)
-        self.assertTrue(result[0].applied)
+        self.assertTrue(result.one().applied)
 
     def test_conditional_update_with_prepared_statements(self):
         self.session.execute("INSERT INTO test3rf.test (k, v) VALUES (0, 0)")
@@ -772,7 +772,7 @@ class SerialConsistencyTests(unittest.TestCase):
         result = future.result()
         self.assertEqual(future.message.serial_consistency_level, ConsistencyLevel.SERIAL)
         self.assertTrue(result)
-        self.assertFalse(result[0].applied)
+        self.assertFalse(result.one().applied)
 
         statement = self.session.prepare(
             "UPDATE test3rf.test SET v=1 WHERE k=0 IF v=0")
@@ -782,7 +782,7 @@ class SerialConsistencyTests(unittest.TestCase):
         result = future.result()
         self.assertEqual(future.message.serial_consistency_level, ConsistencyLevel.LOCAL_SERIAL)
         self.assertTrue(result)
-        self.assertTrue(result[0].applied)
+        self.assertTrue(result.one().applied)
 
     def test_conditional_update_with_batch_statements(self):
         self.session.execute("INSERT INTO test3rf.test (k, v) VALUES (0, 0)")
@@ -793,7 +793,7 @@ class SerialConsistencyTests(unittest.TestCase):
         result = future.result()
         self.assertEqual(future.message.serial_consistency_level, ConsistencyLevel.SERIAL)
         self.assertTrue(result)
-        self.assertFalse(result[0].applied)
+        self.assertFalse(result.one().applied)
 
         statement = BatchStatement(serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL)
         statement.add("UPDATE test3rf.test SET v=1 WHERE k=0 IF v=0")
@@ -802,7 +802,7 @@ class SerialConsistencyTests(unittest.TestCase):
         result = future.result()
         self.assertEqual(future.message.serial_consistency_level, ConsistencyLevel.LOCAL_SERIAL)
         self.assertTrue(result)
-        self.assertTrue(result[0].applied)
+        self.assertTrue(result.one().applied)
 
     def test_bad_consistency_level(self):
         statement = SimpleStatement("foo")
@@ -1050,18 +1050,18 @@ class MaterializedViewQueryTest(BasicSharedKeyspaceUnitTestCase):
         # Test simple statement and alltime high filtering
         query_statement = SimpleStatement("SELECT * FROM {0}.alltimehigh WHERE game='Coup'".format(self.keyspace_name),
                                           consistency_level=ConsistencyLevel.QUORUM)
-        results = self.session.execute(query_statement)
-        self.assertEqual(results[0].game, 'Coup')
-        self.assertEqual(results[0].year, 2015)
-        self.assertEqual(results[0].month, 5)
-        self.assertEqual(results[0].day, 1)
-        self.assertEqual(results[0].score, 4000)
-        self.assertEqual(results[0].user, "pcmanus")
+        result = self.session.execute(query_statement).one()
+        self.assertEqual(result.game, 'Coup')
+        self.assertEqual(result.year, 2015)
+        self.assertEqual(result.month, 5)
+        self.assertEqual(result.day, 1)
+        self.assertEqual(result.score, 4000)
+        self.assertEqual(result.user, "pcmanus")
 
         # Test prepared statement and daily high filtering
         prepared_query = self.session.prepare("SELECT * FROM {0}.dailyhigh WHERE game=? AND year=? AND month=? and day=?".format(self.keyspace_name))
         bound_query = prepared_query.bind(("Coup", 2015, 6, 2))
-        results = self.session.execute(bound_query)
+        results = list(self.session.execute(bound_query))
         self.assertEqual(results[0].game, 'Coup')
         self.assertEqual(results[0].year, 2015)
         self.assertEqual(results[0].month, 6)
@@ -1079,7 +1079,7 @@ class MaterializedViewQueryTest(BasicSharedKeyspaceUnitTestCase):
         # Test montly high range queries
         prepared_query = self.session.prepare("SELECT * FROM {0}.monthlyhigh WHERE game=? AND year=? AND month=? and score >= ? and score <= ?".format(self.keyspace_name))
         bound_query = prepared_query.bind(("Coup", 2015, 6, 2500, 3500))
-        results = self.session.execute(bound_query)
+        results = list(self.session.execute(bound_query))
         self.assertEqual(results[0].game, 'Coup')
         self.assertEqual(results[0].year, 2015)
         self.assertEqual(results[0].month, 6)
@@ -1104,7 +1104,7 @@ class MaterializedViewQueryTest(BasicSharedKeyspaceUnitTestCase):
         # Test filtered user high scores
         query_statement = SimpleStatement("SELECT * FROM {0}.filtereduserhigh WHERE game='Chess'".format(self.keyspace_name),
                                           consistency_level=ConsistencyLevel.QUORUM)
-        results = self.session.execute(query_statement)
+        results = list(self.session.execute(query_statement))
         self.assertEqual(results[0].game, 'Chess')
         self.assertEqual(results[0].year, 2015)
         self.assertEqual(results[0].month, 6)
@@ -1283,12 +1283,12 @@ class SimpleWithKeyspaceTests(QueryKeyspaceTests, unittest.TestCase):
     def _check_set_keyspace_in_statement(self, session):
         simple_stmt = SimpleStatement("SELECT * from {}".format(self.table_name), keyspace=self.ks_name)
         results = session.execute(simple_stmt)
-        self.assertEqual(results[0], (1, 1))
+        self.assertEqual(results.one(), (1, 1))
 
         simple_stmt = SimpleStatement("SELECT * from {}".format(self.table_name))
         simple_stmt.keyspace = self.ks_name
         results = session.execute(simple_stmt)
-        self.assertEqual(results[0], (1, 1))
+        self.assertEqual(results.one(), (1, 1))
 
 
 @greaterthanorequalcass40
@@ -1342,14 +1342,14 @@ class PreparedWithKeyspaceTests(BaseKeyspaceTests, unittest.TestCase):
         prepared_statement = self.session.prepare(query, keyspace=self.ks_name)
 
         results = self.session.execute(prepared_statement, (1, ))
-        self.assertEqual(results[0], (1, 1))
+        self.assertEqual(results.one(), (1, 1))
 
         prepared_statement_alternative = self.session.prepare(query, keyspace=self.alternative_ks)
 
         self.assertNotEqual(prepared_statement.query_id, prepared_statement_alternative.query_id)
 
         results = self.session.execute(prepared_statement_alternative, (2,))
-        self.assertEqual(results[0], (2, 2))
+        self.assertEqual(results.one(), (2, 2))
 
     def test_reprepare_after_host_is_down(self):
         """
@@ -1380,10 +1380,10 @@ class PreparedWithKeyspaceTests(BaseKeyspaceTests, unittest.TestCase):
         time.sleep(5)
         self.assertEqual(1, mock_handler.get_message_count('debug', 'Preparing all known prepared statements'))
         results = self.session.execute(prepared_statement, (1,), execution_profile="only_first")
-        self.assertEqual(results[0], (1, ))
+        self.assertEqual(results.one(), (1, ))
 
         results = self.session.execute(prepared_statement_alternative, (2,), execution_profile="only_first")
-        self.assertEqual(results[0], (2, ))
+        self.assertEqual(results.one(), (2, ))
 
     def test_prepared_not_found(self):
         """
@@ -1407,7 +1407,7 @@ class PreparedWithKeyspaceTests(BaseKeyspaceTests, unittest.TestCase):
 
         for _ in range(10):
             results = session.execute(prepared_statement, (1, ))
-            self.assertEqual(results[0], (1,))
+            self.assertEqual(results.one(), (1,))
 
     def test_prepared_in_query_keyspace(self):
         """
@@ -1426,12 +1426,12 @@ class PreparedWithKeyspaceTests(BaseKeyspaceTests, unittest.TestCase):
         query = "SELECT k from {}.{} WHERE k = ?".format(self.ks_name, self.table_name)
         prepared_statement = session.prepare(query)
         results = session.execute(prepared_statement, (1,))
-        self.assertEqual(results[0], (1,))
+        self.assertEqual(results.one(), (1,))
 
         query = "SELECT k from {}.{} WHERE k = ?".format(self.alternative_ks, self.table_name)
         prepared_statement = session.prepare(query)
         results = session.execute(prepared_statement, (2,))
-        self.assertEqual(results[0], (2,))
+        self.assertEqual(results.one(), (2,))
 
     def test_prepared_in_query_keyspace_and_explicit(self):
         """
@@ -1448,9 +1448,9 @@ class PreparedWithKeyspaceTests(BaseKeyspaceTests, unittest.TestCase):
         query = "SELECT k from {}.{} WHERE k = ?".format(self.ks_name, self.table_name)
         prepared_statement = self.session.prepare(query, keyspace="system")
         results = self.session.execute(prepared_statement, (1,))
-        self.assertEqual(results[0], (1,))
+        self.assertEqual(results.one(), (1,))
 
         query = "SELECT k from {}.{} WHERE k = ?".format(self.ks_name, self.table_name)
         prepared_statement = self.session.prepare(query, keyspace=self.alternative_ks)
         results = self.session.execute(prepared_statement, (1,))
-        self.assertEqual(results[0], (1,))
+        self.assertEqual(results.one(), (1,))

--- a/tests/integration/standard/test_routing.py
+++ b/tests/integration/standard/test_routing.py
@@ -53,7 +53,7 @@ class RoutingTests(unittest.TestCase):
 
         my_token = s.cluster.metadata.token_map.token_class.from_key(bound.routing_key)
 
-        cass_token = s.execute(select, key_values)[0][0]
+        cass_token = s.execute(select, key_values).one()[0]
         token = s.cluster.metadata.token_map.token_class(cass_token)
         self.assertEqual(my_token, token)
 

--- a/tests/integration/standard/test_row_factories.py
+++ b/tests/integration/standard/test_row_factories.py
@@ -69,7 +69,7 @@ class NameTupleFactory(BasicSharedKeyspaceUnitTestCase):
 
         query = "SELECT v1 AS duplicate, v2 AS duplicate, v3 AS duplicate from {0}.{1}".format(self.ks_name, self.function_table_name)
         rs = self.session.execute(query)
-        row = rs[0]
+        row = rs.one()
         self.assertTrue(hasattr(row, 'duplicate'))
         self.assertTrue(hasattr(row, 'duplicate_'))
         self.assertTrue(hasattr(row, 'duplicate__'))
@@ -96,6 +96,7 @@ class RowFactoryTests(BasicSharedKeyspaceUnitTestCaseWFunctionTable):
     def test_tuple_factory(self):
         result = self._results_from_row_factory(tuple_factory)
         self.assertIsInstance(result, ResultSet)
+        result = list(result)
         self.assertIsInstance(result[0], tuple)
 
         for row in result:
@@ -122,6 +123,7 @@ class RowFactoryTests(BasicSharedKeyspaceUnitTestCaseWFunctionTable):
     def _test_dict_factory(self, row_factory, row_type):
         result = self._results_from_row_factory(row_factory)
         self.assertIsInstance(result, ResultSet)
+        result = list(result)
         self.assertIsInstance(result[0], row_type)
 
         for row in result:

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -80,7 +80,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         else:
             s.execute(query, params)
 
-        results = s.execute("SELECT * FROM blobstring")[0]
+        results = s.execute("SELECT * FROM blobstring").one()
         for expected, actual in zip(params, results):
             self.assertEqual(expected, actual)
 
@@ -95,7 +95,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         params = ['key1', bytearray(b'blob1')]
         s.execute("INSERT INTO blobbytes (a, b) VALUES (%s, %s)", params)
 
-        results = s.execute("SELECT * FROM blobbytes")[0]
+        results = s.execute("SELECT * FROM blobbytes").one()
         for expected, actual in zip(params, results):
             self.assertEqual(expected, actual)
 
@@ -122,7 +122,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
             params = ['key1', bytearray(b'blob1')]
             s.execute("INSERT INTO blobbytes2 (a, b) VALUES (%s, %s)", params)
 
-            results = s.execute("SELECT * FROM blobbytes2")[0]
+            results = s.execute("SELECT * FROM blobbytes2").one()
             for expected, actual in zip(params, results):
                 self.assertEqual(expected, actual)
         finally:
@@ -157,7 +157,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.execute("INSERT INTO alltypes ({0}) VALUES ({1})".format(columns_string, placeholders), params)
 
         # verify data
-        results = s.execute("SELECT {0} FROM alltypes WHERE zz=0".format(columns_string))[0]
+        results = s.execute("SELECT {0} FROM alltypes WHERE zz=0".format(columns_string)).one()
         for expected, actual in zip(params, results):
             self.assertEqual(actual, expected)
 
@@ -174,7 +174,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
                 s.execute("INSERT INTO alltypes ({0}) VALUES ({1})".format(single_columns_string, placeholders),
                           single_params)
                 # verify data
-                result = s.execute("SELECT {0} FROM alltypes WHERE zz=%s".format(single_columns_string), (key,))[0][1]
+                result = s.execute("SELECT {0} FROM alltypes WHERE zz=%s".format(single_columns_string), (key,)).one()[1]
                 compare_value = data_sample
                 if six.PY3:
                     import ipaddress
@@ -189,20 +189,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.execute(insert.bind(params))
 
         # verify data
-        results = s.execute("SELECT {0} FROM alltypes WHERE zz=0".format(columns_string))[0]
+        results = s.execute("SELECT {0} FROM alltypes WHERE zz=0".format(columns_string)).one()
         for expected, actual in zip(params, results):
             self.assertEqual(actual, expected)
 
         # verify data with prepared statement query
         select = s.prepare("SELECT {0} FROM alltypes WHERE zz=?".format(columns_string))
-        results = s.execute(select.bind([0]))[0]
+        results = s.execute(select.bind([0])).one()
         for expected, actual in zip(params, results):
             self.assertEqual(actual, expected)
 
         # verify data with with prepared statement, use dictionary with no explicit columns
         select = s.prepare("SELECT * FROM alltypes")
         results = s.execute(select,
-            execution_profile=s.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, row_factory=ordered_dict_factory))[0]
+            execution_profile=s.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, row_factory=ordered_dict_factory)).one()
 
         for expected, actual in zip(params, results.values()):
             self.assertEqual(actual, expected)
@@ -251,7 +251,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.execute("INSERT INTO allcoltypes ({0}) VALUES ({1})".format(columns_string, placeholders), params)
 
         # verify data
-        results = s.execute("SELECT {0} FROM allcoltypes WHERE zz=0".format(columns_string))[0]
+        results = s.execute("SELECT {0} FROM allcoltypes WHERE zz=0".format(columns_string)).one()
         for expected, actual in zip(params, results):
             self.assertEqual(actual, expected)
 
@@ -267,20 +267,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.execute(insert.bind(params))
 
         # verify data
-        results = s.execute("SELECT {0} FROM allcoltypes WHERE zz=0".format(columns_string))[0]
+        results = s.execute("SELECT {0} FROM allcoltypes WHERE zz=0".format(columns_string)).one()
         for expected, actual in zip(params, results):
             self.assertEqual(actual, expected)
 
         # verify data with prepared statement query
         select = s.prepare("SELECT {0} FROM allcoltypes WHERE zz=?".format(columns_string))
-        results = s.execute(select.bind([0]))[0]
+        results = s.execute(select.bind([0])).one()
         for expected, actual in zip(params, results):
             self.assertEqual(actual, expected)
 
         # verify data with with prepared statement, use dictionary with no explicit columns
         select = s.prepare("SELECT * FROM allcoltypes")
         results = s.execute(select,
-            execution_profile=s.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, row_factory=ordered_dict_factory))[0]
+            execution_profile=s.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, row_factory=ordered_dict_factory)).one()
 
         for expected, actual in zip(params, results.values()):
             self.assertEqual(actual, expected)
@@ -316,12 +316,12 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         # verify all types initially null with simple statement
         columns_string = ','.join(col_names)
         s.execute("INSERT INTO all_empty (zz) VALUES (2)")
-        results = s.execute("SELECT {0} FROM all_empty WHERE zz=2".format(columns_string))[0]
+        results = s.execute("SELECT {0} FROM all_empty WHERE zz=2".format(columns_string)).one()
         self.assertTrue(all(x is None for x in results))
 
         # verify all types initially null with prepared statement
         select = s.prepare("SELECT {0} FROM all_empty WHERE zz=?".format(columns_string))
-        results = s.execute(select.bind([2]))[0]
+        results = s.execute(select.bind([2])).one()
         self.assertTrue(all(x is None for x in results))
 
         # insert empty strings for string-like fields
@@ -331,12 +331,12 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.execute("INSERT INTO all_empty (zz, {0}) VALUES (3, {1})".format(columns_string, placeholders), expected_values.values())
 
         # verify string types empty with simple statement
-        results = s.execute("SELECT {0} FROM all_empty WHERE zz=3".format(columns_string))[0]
+        results = s.execute("SELECT {0} FROM all_empty WHERE zz=3".format(columns_string)).one()
         for expected, actual in zip(expected_values.values(), results):
             self.assertEqual(actual, expected)
 
         # verify string types empty with prepared statement
-        results = s.execute(s.prepare("SELECT {0} FROM all_empty WHERE zz=?".format(columns_string)), [3])[0]
+        results = s.execute(s.prepare("SELECT {0} FROM all_empty WHERE zz=?".format(columns_string)), [3]).one()
         for expected, actual in zip(expected_values.values(), results):
             self.assertEqual(actual, expected)
 
@@ -368,13 +368,13 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
 
         # check via simple statement
         query = "SELECT {0} FROM all_empty WHERE zz=5".format(columns_string)
-        results = s.execute(query)[0]
+        results = s.execute(query).one()
         for col in results:
             self.assertEqual(None, col)
 
         # check via prepared statement
         select = s.prepare("SELECT {0} FROM all_empty WHERE zz=?".format(columns_string))
-        results = s.execute(select.bind([5]))[0]
+        results = s.execute(select.bind([5])).one()
         for col in results:
             self.assertEqual(None, col)
 
@@ -385,11 +385,11 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         insert = s.prepare("INSERT INTO all_empty (zz, {0}) VALUES (5, {1})".format(columns_string, placeholders))
         s.execute(insert, null_values)
 
-        results = s.execute(query)[0]
+        results = s.execute(query).one()
         for col in results:
             self.assertEqual(None, col)
 
-        results = s.execute(select.bind([5]))[0]
+        results = s.execute(select.bind([5])).one()
         for col in results:
             self.assertEqual(None, col)
 
@@ -403,7 +403,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         execute_until_pass(s, "INSERT INTO empty_values (a, b) VALUES ('a', blobAsInt(0x))")
         try:
             Int32Type.support_empty_values = True
-            results = execute_until_pass(s, "SELECT b FROM empty_values WHERE a='a'")[0]
+            results = execute_until_pass(s, "SELECT b FROM empty_values WHERE a='a'").one()
             self.assertIs(EMPTY, results.b)
         finally:
             Int32Type.support_empty_values = False
@@ -428,13 +428,13 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
 
         # test non-prepared statement
         s.execute("INSERT INTO tz_aware (a, b) VALUES ('key1', %s)", [dt])
-        result = s.execute("SELECT b FROM tz_aware WHERE a='key1'")[0].b
+        result = s.execute("SELECT b FROM tz_aware WHERE a='key1'").one().b
         self.assertEqual(dt.utctimetuple(), result.utctimetuple())
 
         # test prepared statement
         insert = s.prepare("INSERT INTO tz_aware (a, b) VALUES ('key2', ?)")
         s.execute(insert.bind([dt]))
-        result = s.execute("SELECT b FROM tz_aware WHERE a='key2'")[0].b
+        result = s.execute("SELECT b FROM tz_aware WHERE a='key2'").one().b
         self.assertEqual(dt.utctimetuple(), result.utctimetuple())
 
     def test_can_insert_tuples(self):
@@ -456,20 +456,20 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         # test non-prepared statement
         complete = ('foo', 123, True)
         s.execute("INSERT INTO tuple_type (a, b) VALUES (0, %s)", parameters=(complete,))
-        result = s.execute("SELECT b FROM tuple_type WHERE a=0")[0]
+        result = s.execute("SELECT b FROM tuple_type WHERE a=0").one()
         self.assertEqual(complete, result.b)
 
         partial = ('bar', 456)
         partial_result = partial + (None,)
         s.execute("INSERT INTO tuple_type (a, b) VALUES (1, %s)", parameters=(partial,))
-        result = s.execute("SELECT b FROM tuple_type WHERE a=1")[0]
+        result = s.execute("SELECT b FROM tuple_type WHERE a=1").one()
         self.assertEqual(partial_result, result.b)
 
         # test single value tuples
         subpartial = ('zoo',)
         subpartial_result = subpartial + (None, None)
         s.execute("INSERT INTO tuple_type (a, b) VALUES (2, %s)", parameters=(subpartial,))
-        result = s.execute("SELECT b FROM tuple_type WHERE a=2")[0]
+        result = s.execute("SELECT b FROM tuple_type WHERE a=2").one()
         self.assertEqual(subpartial_result, result.b)
 
         # test prepared statement
@@ -482,9 +482,9 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         self.assertRaises(ValueError, s.execute, prepared, parameters=(0, (1, 2, 3, 4, 5, 6)))
 
         prepared = s.prepare("SELECT b FROM tuple_type WHERE a=?")
-        self.assertEqual(complete, s.execute(prepared, (3,))[0].b)
-        self.assertEqual(partial_result, s.execute(prepared, (4,))[0].b)
-        self.assertEqual(subpartial_result, s.execute(prepared, (5,))[0].b)
+        self.assertEqual(complete, s.execute(prepared, (3,)).one().b)
+        self.assertEqual(partial_result, s.execute(prepared, (4,)).one().b)
+        self.assertEqual(subpartial_result, s.execute(prepared, (5,)).one().b)
 
         c.shutdown()
 
@@ -524,7 +524,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
 
             s.execute("INSERT INTO tuple_lengths (k, v_%s) VALUES (0, %s)", (i, created_tuple))
 
-            result = s.execute("SELECT v_%s FROM tuple_lengths WHERE k=0", (i,))[0]
+            result = s.execute("SELECT v_%s FROM tuple_lengths WHERE k=0", (i,)).one()
             self.assertEqual(tuple(created_tuple), result['v_%s' % i])
         c.shutdown()
 
@@ -552,7 +552,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
             values.append(get_sample(data_type))
             expected = tuple(values + [None] * (type_count - len(values)))
             s.execute("INSERT INTO tuple_primitive (k, v) VALUES (%s, %s)", (i, tuple(values)))
-            result = s.execute("SELECT v FROM tuple_primitive WHERE k=%s", (i,))[0]
+            result = s.execute("SELECT v FROM tuple_primitive WHERE k=%s", (i,)).one()
             self.assertEqual(result.v, expected)
         c.shutdown()
 
@@ -607,7 +607,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
             created_tuple = tuple([[get_sample(datatype)]])
             s.execute("INSERT INTO tuple_non_primative (k, v_%s) VALUES (0, %s)", (i, created_tuple))
 
-            result = s.execute("SELECT v_%s FROM tuple_non_primative WHERE k=0", (i,))[0]
+            result = s.execute("SELECT v_%s FROM tuple_non_primative WHERE k=0", (i,)).one()
             self.assertEqual(created_tuple, result['v_%s' % i])
             i += 1
 
@@ -616,7 +616,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
             created_tuple = tuple([sortedset([get_sample(datatype)])])
             s.execute("INSERT INTO tuple_non_primative (k, v_%s) VALUES (0, %s)", (i, created_tuple))
 
-            result = s.execute("SELECT v_%s FROM tuple_non_primative WHERE k=0", (i,))[0]
+            result = s.execute("SELECT v_%s FROM tuple_non_primative WHERE k=0", (i,)).one()
             self.assertEqual(created_tuple, result['v_%s' % i])
             i += 1
 
@@ -630,7 +630,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
 
             s.execute("INSERT INTO tuple_non_primative (k, v_%s) VALUES (0, %s)", (i, created_tuple))
 
-            result = s.execute("SELECT v_%s FROM tuple_non_primative WHERE k=0", (i,))[0]
+            result = s.execute("SELECT v_%s FROM tuple_non_primative WHERE k=0", (i,)).one()
             self.assertEqual(created_tuple, result['v_%s' % i])
             i += 1
         c.shutdown()
@@ -691,7 +691,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
             s.execute("INSERT INTO nested_tuples (k, v_%s) VALUES (%s, %s)", (i, i, created_tuple))
 
             # verify tuple was written and read correctly
-            result = s.execute("SELECT v_%s FROM nested_tuples WHERE k=%s", (i, i))[0]
+            result = s.execute("SELECT v_%s FROM nested_tuples WHERE k=%s", (i, i)).one()
             self.assertEqual(created_tuple, result['v_%s' % i])
         c.shutdown()
 
@@ -711,16 +711,16 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         s.execute(insert, [(None, None, None, None)])
 
         result = s.execute("SELECT * FROM tuples_nulls WHERE k=0")
-        self.assertEqual((None, None, None, None), result[0].t)
+        self.assertEqual((None, None, None, None), result.one().t)
 
         read = s.prepare("SELECT * FROM tuples_nulls WHERE k=0")
-        self.assertEqual((None, None, None, None), s.execute(read)[0].t)
+        self.assertEqual((None, None, None, None), s.execute(read).one().t)
 
         # also test empty strings where compatible
         s.execute(insert, [('', None, None, b'')])
         result = s.execute("SELECT * FROM tuples_nulls WHERE k=0")
-        self.assertEqual(('', None, None, b''), result[0].t)
-        self.assertEqual(('', None, None, b''), s.execute(read)[0].t)
+        self.assertEqual(('', None, None, b''), result.one().t)
+        self.assertEqual(('', None, None, b''), s.execute(read).one().t)
 
     def test_can_insert_unicode_query_string(self):
         """
@@ -744,13 +744,13 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
 
         # CompositeType string literals are split on ':' chars
         s.execute("INSERT INTO composites (a, b) VALUES (0, 'abc:123')")
-        result = s.execute("SELECT * FROM composites WHERE a = 0")[0]
+        result = s.execute("SELECT * FROM composites WHERE a = 0").one()
         self.assertEqual(0, result.a)
         self.assertEqual(('abc', 123), result.b)
 
         # CompositeType values can omit elements at the end
         s.execute("INSERT INTO composites (a, b) VALUES (0, 'abc')")
-        result = s.execute("SELECT * FROM composites WHERE a = 0")[0]
+        result = s.execute("SELECT * FROM composites WHERE a = 0").one()
         self.assertEqual(0, result.a)
         self.assertEqual(('abc',), result.b)
 
@@ -776,7 +776,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         def verify_insert_select(ins_statement, sel_statement):
             execute_concurrent_with_args(s, ins_statement, ((f, f) for f in items))
             for f in items:
-                row = s.execute(sel_statement, (f,))[0]
+                row = s.execute(sel_statement, (f,)).one()
                 if math.isnan(f):
                     self.assertTrue(math.isnan(row.f))
                     self.assertTrue(math.isnan(row.d))
@@ -810,7 +810,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         try:
             self.session.execute("INSERT INTO {0} (dc) VALUES (-1.08430792318105707)".format(self.function_table_name))
             results = self.session.execute("SELECT * FROM {0}".format(self.function_table_name))
-            self.assertTrue(str(results[0].dc) == '-1.08430792318105707')
+            self.assertTrue(str(results.one().dc) == '-1.08430792318105707')
         finally:
             self.session.execute("DROP TABLE {0}".format(self.function_table_name))
 
@@ -853,7 +853,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
                 self.session.execute(prepared, (1, Duration(month_day_value, month_day_value, nanosecond_value)))
                 results = self.session.execute("SELECT * FROM duration_smoke")
 
-                v = results[0][1]
+                v = results.one()[1]
                 self.assertEqual(Duration(month_day_value, month_day_value, nanosecond_value), v,
                                  "Error encoding value {0},{0},{1}".format(month_day_value, nanosecond_value))
 
@@ -910,16 +910,16 @@ class TypeTestsProtocol(BasicSharedKeyspaceUnitTestCase):
     def read_inserts_at_level(self, proto_ver):
         session = Cluster(protocol_version=proto_ver).connect(self.keyspace_name)
         try:
-            results = session.execute('select * from t')[0]
+            results = session.execute('select * from t').one()
             self.assertEqual("[SortedSet([1, 2]), SortedSet([3, 5])]", str(results.v))
 
-            results = session.execute('select * from u')[0]
+            results = session.execute('select * from u').one()
             self.assertEqual("SortedSet([[1, 2], [3, 5]])", str(results.v))
 
-            results = session.execute('select * from v')[0]
+            results = session.execute('select * from v').one()
             self.assertEqual("{SortedSet([1, 2]): [1, 2, 3], SortedSet([3, 5]): [4, 5, 6]}", str(results.v))
 
-            results = session.execute('select * from w')[0]
+            results = session.execute('select * from w').one()
             self.assertEqual("typ(v0=OrderedMapSerializedKey([(1, [1, 2, 3]), (2, [4, 5, 6])]), v1=[7, 8, 9])", str(results.v))
 
         finally:

--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -69,7 +69,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         self.session.execute("INSERT INTO {0} (a, b) VALUES (%s, %s)".format(self.function_table_name), (0, User("Nebraska", True)))
         self.session.execute("UPDATE {0} SET b.has_corn = False where a = 0".format(self.function_table_name))
         result = self.session.execute("SELECT * FROM {0}".format(self.function_table_name))
-        self.assertFalse(result[0].b.has_corn)
+        self.assertFalse(result.one().b.has_corn)
         table_sql = self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].as_cql_query()
         self.assertNotIn("<frozen>", table_sql)
 
@@ -89,7 +89,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         s.execute("INSERT INTO mytable (a, b) VALUES (%s, %s)", (0, User(42, 'bob')))
         result = s.execute("SELECT b FROM mytable WHERE a=0")
-        row = result[0]
+        row = result.one()
         self.assertEqual(42, row.b.age)
         self.assertEqual('bob', row.b.name)
         self.assertTrue(type(row.b) is User)
@@ -108,7 +108,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         s.execute("INSERT INTO mytable (a, b) VALUES (%s, %s)", (0, User('Texas', True)))
         result = s.execute("SELECT b FROM mytable WHERE a=0")
-        row = result[0]
+        row = result.one()
         self.assertEqual('Texas', row.b.state)
         self.assertEqual(True, row.b.is_cool)
         self.assertTrue(type(row.b) is User)
@@ -156,7 +156,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         s.set_keyspace("udt_test_register_before_connecting")
         s.execute("INSERT INTO mytable (a, b) VALUES (%s, %s)", (0, User1(42, 'bob')))
         result = s.execute("SELECT b FROM mytable WHERE a=0")
-        row = result[0]
+        row = result.one()
         self.assertEqual(42, row.b.age)
         self.assertEqual('bob', row.b.name)
         self.assertTrue(type(row.b) is User1)
@@ -165,7 +165,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         s.set_keyspace("udt_test_register_before_connecting2")
         s.execute("INSERT INTO mytable (a, b) VALUES (%s, %s)", (0, User2('Texas', True)))
         result = s.execute("SELECT b FROM mytable WHERE a=0")
-        row = result[0]
+        row = result.one()
         self.assertEqual('Texas', row.b.state)
         self.assertEqual(True, row.b.is_cool)
         self.assertTrue(type(row.b) is User2)
@@ -192,7 +192,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         select = s.prepare("SELECT b FROM mytable WHERE a=?")
         result = s.execute(select, (0,))
-        row = result[0]
+        row = result.one()
         self.assertEqual(42, row.b.age)
         self.assertEqual('bob', row.b.name)
 
@@ -211,7 +211,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         select = s.prepare("SELECT b FROM mytable WHERE a=?")
         result = s.execute(select, (0,))
-        row = result[0]
+        row = result.one()
         self.assertEqual('Texas', row.b.state)
         self.assertEqual(True, row.b.is_cool)
 
@@ -238,7 +238,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         select = s.prepare("SELECT b FROM mytable WHERE a=?")
         result = s.execute(select, (0,))
-        row = result[0]
+        row = result.one()
         self.assertEqual(42, row.b.age)
         self.assertEqual('bob', row.b.name)
         self.assertTrue(type(row.b) is User)
@@ -260,7 +260,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         select = s.prepare("SELECT b FROM mytable WHERE a=?")
         result = s.execute(select, (0,))
-        row = result[0]
+        row = result.one()
         self.assertEqual('Texas', row.b.state)
         self.assertEqual(True, row.b.is_cool)
         self.assertTrue(type(row.b) is User)
@@ -287,15 +287,15 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         s.execute(insert, [User(None, None, None, None)])
 
         results = s.execute("SELECT b FROM mytable WHERE a=0")
-        self.assertEqual((None, None, None, None), results[0].b)
+        self.assertEqual((None, None, None, None), results.one().b)
 
         select = s.prepare("SELECT b FROM mytable WHERE a=0")
-        self.assertEqual((None, None, None, None), s.execute(select)[0].b)
+        self.assertEqual((None, None, None, None), s.execute(select).one().b)
 
         # also test empty strings
         s.execute(insert, [User('', None, None, six.binary_type())])
         results = s.execute("SELECT b FROM mytable WHERE a=0")
-        self.assertEqual(('', None, None, six.binary_type()), results[0].b)
+        self.assertEqual(('', None, None, six.binary_type()), results.one().b)
 
         c.shutdown()
 
@@ -334,7 +334,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
             s.execute("INSERT INTO mytable (k, v) VALUES (0, %s)", (created_udt,))
 
             # verify udt was written and read correctly, increase timeout to avoid the query failure on slow systems
-            result = s.execute("SELECT v FROM mytable WHERE k=0")[0]
+            result = s.execute("SELECT v FROM mytable WHERE k=0").one()
             self.assertEqual(created_udt, result.v)
 
         c.shutdown()
@@ -372,7 +372,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
             session.execute("INSERT INTO mytable (k, v_%s) VALUES (0, %s)", [i, udt])
 
             # verify udt was written and read correctly
-            result = session.execute("SELECT v_{0} FROM mytable WHERE k=0".format(i))[0]
+            result = session.execute("SELECT v_{0} FROM mytable WHERE k=0".format(i)).one()
             self.assertEqual(udt, result["v_{0}".format(i)])
 
             # write udt via prepared statement
@@ -380,7 +380,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
             session.execute(insert, [udt])
 
             # verify udt was written and read correctly
-            result = session.execute("SELECT v_{0} FROM mytable WHERE k=1".format(i))[0]
+            result = session.execute("SELECT v_{0} FROM mytable WHERE k=1".format(i)).one()
             self.assertEqual(udt, result["v_{0}".format(i)])
 
     def _cluster_default_dict_factory(self):
@@ -448,7 +448,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
                 s.execute(insert, [udt])
 
                 # verify udt was written and read correctly
-                result = s.execute("SELECT v_{0} FROM mytable WHERE k=0".format(i))[0]
+                result = s.execute("SELECT v_{0} FROM mytable WHERE k=0".format(i)).one()
                 self.assertEqual(udt, result["v_{0}".format(i)])
 
     def test_can_insert_nested_registered_udts_with_different_namedtuples(self):
@@ -539,7 +539,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         # retrieve and verify data
         results = s.execute("SELECT * FROM mytable")
 
-        row = results[0].b
+        row = results.one().b
         for expected, actual in zip(params, row):
             self.assertEqual(expected, actual)
 
@@ -597,7 +597,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         # retrieve and verify data
         results = s.execute("SELECT * FROM mytable")
 
-        row = results[0].b
+        row = results.one().b
         for expected, actual in zip(params, row):
             self.assertEqual(expected, actual)
 
@@ -606,7 +606,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
     def insert_select_column(self, session, table_name, column_name, value):
         insert = session.prepare("INSERT INTO %s (k, %s) VALUES (?, ?)" % (table_name, column_name))
         session.execute(insert, (0, value))
-        result = session.execute("SELECT %s FROM %s WHERE k=%%s" % (column_name, table_name), (0,))[0][0]
+        result = session.execute("SELECT %s FROM %s WHERE k=%%s" % (column_name, table_name), (0,)).one()[0]
         self.assertEqual(result, value)
 
     def test_can_insert_nested_collections(self):
@@ -673,7 +673,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         # table with types as map keys to make sure the tuple lookup works
         s.execute('CREATE TABLE %s (k int PRIMARY KEY, non_alphanum_type_map map<frozen<"%s">, int>, alphanum_type_map map<frozen<%s>, int>)' % (self.table_name, non_alphanum_name, type_name))
         s.execute('INSERT INTO %s (k, non_alphanum_type_map, alphanum_type_map) VALUES (%s, {{"%s": \'nonalphanum\'}: 0}, {{"%s": \'alphanum\'}: 1})' % (self.table_name, 0, non_alphanum_name, non_alphanum_name))
-        row = s.execute('SELECT * FROM %s' % (self.table_name,))[0]
+        row = s.execute('SELECT * FROM %s' % (self.table_name,)).one()
 
         k, v = row.non_alphanum_type_map.popitem()
         self.assertEqual(v, 0)
@@ -699,23 +699,23 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         s.cluster.register_user_type('udttests', type_name, dict)
 
-        val = s.execute('SELECT v FROM %s' % self.table_name)[0][0]
+        val = s.execute('SELECT v FROM %s' % self.table_name).one()[0]
         self.assertEqual(val['v0'], 1)
 
         # add field
         s.execute('ALTER TYPE %s ADD v1 text' % (type_name,))
-        val = s.execute('SELECT v FROM %s' % self.table_name)[0][0]
+        val = s.execute('SELECT v FROM %s' % self.table_name).one()[0]
         self.assertEqual(val['v0'], 1)
         self.assertIsNone(val['v1'])
         s.execute("INSERT INTO %s (k, v) VALUES (0, {v0 : 2, v1 : 'sometext'})" % (self.table_name,))
-        val = s.execute('SELECT v FROM %s' % self.table_name)[0][0]
+        val = s.execute('SELECT v FROM %s' % self.table_name).one()[0]
         self.assertEqual(val['v0'], 2)
         self.assertEqual(val['v1'], 'sometext')
 
         # alter field type
         s.execute('ALTER TYPE %s ALTER v1 TYPE blob' % (type_name,))
         s.execute("INSERT INTO %s (k, v) VALUES (0, {v0 : 3, v1 : 0xdeadbeef})" % (self.table_name,))
-        val = s.execute('SELECT v FROM %s' % self.table_name)[0][0]
+        val = s.execute('SELECT v FROM %s' % self.table_name).one()[0]
         self.assertEqual(val['v0'], 3)
         self.assertEqual(val['v1'], six.b('\xde\xad\xbe\xef'))
 

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -74,7 +74,7 @@ class ResponseFutureTests(unittest.TestCase):
 
         rf._set_result(None, None, None, self.make_mock_response([{'col': 'val'}]))
         result = rf.result()
-        self.assertEqual(result, [{'col': 'val'}])
+        self.assertEqual(list(result), [{'col': 'val'}])
 
     def test_unknown_result_class(self):
         session = self.make_session()
@@ -305,7 +305,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf._set_result(None, None, None, self.make_mock_response([{'col': 'val'}]))
 
         result = rf.result()
-        self.assertEqual(result, [{'col': 'val'}])
+        self.assertEqual(list(result), [{'col': 'val'}])
 
     def test_timeout_getting_connection_from_pool(self):
         session = self.make_basic_session()
@@ -327,7 +327,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf.send_request()
 
         rf._set_result(None, None, None, self.make_mock_response([{'col': 'val'}]))
-        self.assertEqual(rf.result(), [{'col': 'val'}])
+        self.assertEqual(list(rf.result()), [{'col': 'val'}])
 
         # make sure the exception is recorded correctly
         self.assertEqual(rf._errors, {'ip1': exc})
@@ -346,7 +346,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf._set_result(None, None, None, self.make_mock_response(expected_result))
 
         result = rf.result()
-        self.assertEqual(result, expected_result)
+        self.assertEqual(list(result), expected_result)
 
         callback.assert_called_once_with(expected_result, arg, **kwargs)
 
@@ -395,7 +395,7 @@ class ResponseFutureTests(unittest.TestCase):
         rf._set_result(None, None, None, self.make_mock_response(expected_result))
 
         result = rf.result()
-        self.assertEqual(result, expected_result)
+        self.assertEqual(list(result), expected_result)
 
         callback.assert_called_once_with(expected_result, arg, **kwargs)
         callback2.assert_called_once_with(expected_result, arg2, **kwargs2)
@@ -465,7 +465,7 @@ class ResponseFutureTests(unittest.TestCase):
             errback=self.assertIsInstance, errback_args=(Exception,))
 
         rf._set_result(None, None, None, self.make_mock_response(expected_result))
-        self.assertEqual(rf.result(), expected_result)
+        self.assertEqual(list(rf.result()), expected_result)
 
         callback.assert_called_once_with(expected_result, arg, **kwargs)
 

--- a/tests/unit/test_resultset.py
+++ b/tests/unit/test_resultset.py
@@ -44,21 +44,21 @@ class ResultSetTests(unittest.TestCase):
     def test_list_non_paged(self):
         # list access on RS for backwards-compatibility
         expected = list(range(10))
-        rs = ResultSet(Mock(has_more_pages=False), expected)
+        rs = list(ResultSet(Mock(has_more_pages=False), expected))
         for i in range(10):
             self.assertEqual(rs[i], expected[i])
-        self.assertEqual(list(rs), expected)
+        self.assertEqual(rs, expected)
 
     def test_list_paged(self):
         # list access on RS for backwards-compatibility
         expected = list(range(10))
         response_future = Mock(has_more_pages=True)
         response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
-        rs = ResultSet(response_future, expected[:5])
+        rs = list(ResultSet(response_future, expected[:5]))
         # this is brittle, depends on internal impl details. Would like to find a better way
         type(response_future).has_more_pages = PropertyMock(side_effect=(True, True, True, False))  # First two True are consumed on check entering list mode
         self.assertEqual(rs[9], expected[9])
-        self.assertEqual(list(rs), expected)
+        self.assertEqual(rs, expected)
 
     def test_has_more_pages(self):
         response_future = Mock()
@@ -68,93 +68,29 @@ class ResultSetTests(unittest.TestCase):
         self.assertTrue(rs.has_more_pages)
         self.assertFalse(rs.has_more_pages)
 
-    def test_iterate_then_index(self):
-        # RuntimeError if indexing with no pages
-        expected = list(range(10))
-        rs = ResultSet(Mock(has_more_pages=False), expected)
-        itr = iter(rs)
-        # before consuming
-        with self.assertRaises(RuntimeError):
-            rs[0]
-        list(itr)
-        # after consuming
-        with self.assertRaises(RuntimeError):
-            rs[0]
-
-        self.assertFalse(rs)
-        self.assertFalse(list(rs))
-
-        # RuntimeError if indexing during or after pages
-        response_future = Mock(has_more_pages=True)
-        response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
-        rs = ResultSet(response_future, expected[:5])
-        type(response_future).has_more_pages = PropertyMock(side_effect=(True, False))
-        itr = iter(rs)
-        # before consuming
-        with self.assertRaises(RuntimeError):
-            rs[0]
-        for row in itr:
-            # while consuming
-            with self.assertRaises(RuntimeError):
-                rs[0]
-        # after consuming
-        with self.assertRaises(RuntimeError):
-            rs[0]
-        self.assertFalse(rs)
-        self.assertFalse(list(rs))
-
-    def test_index_list_mode(self):
-        # no pages
-        expected = list(range(10))
-        rs = ResultSet(Mock(has_more_pages=False), expected)
-
-        # index access before iteration causes list to be materialized
-        self.assertEqual(rs[0], expected[0])
-
-        # resusable iteration
-        self.assertListEqual(list(rs), expected)
-        self.assertListEqual(list(rs), expected)
-
-        self.assertTrue(rs)
-
-        # pages
-        response_future = Mock(has_more_pages=True)
-        response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
-        rs = ResultSet(response_future, expected[:5])
-        # this is brittle, depends on internal impl details. Would like to find a better way
-        type(response_future).has_more_pages = PropertyMock(side_effect=(True, True, True, False))  # First two True are consumed on check entering list mode
-        # index access before iteration causes list to be materialized
-        self.assertEqual(rs[0], expected[0])
-        self.assertEqual(rs[9], expected[9])
-        # resusable iteration
-        self.assertListEqual(list(rs), expected)
-        self.assertListEqual(list(rs), expected)
-
-        self.assertTrue(rs)
-
     def test_eq(self):
         # no pages
         expected = list(range(10))
-        rs = ResultSet(Mock(has_more_pages=False), expected)
+        rs = list(ResultSet(Mock(has_more_pages=False), expected))
 
         # eq before iteration causes list to be materialized
         self.assertEqual(rs, expected)
 
         # results can be iterated or indexed once we're materialized
-        self.assertListEqual(list(rs), expected)
+        self.assertListEqual(rs, expected)
         self.assertEqual(rs[9], expected[9])
         self.assertTrue(rs)
 
         # pages
         response_future = Mock(has_more_pages=True)
         response_future.result.side_effect = (ResultSet(Mock(), expected[-5:]), )  # ResultSet is iterable, so it must be protected in order to be returned whole by the Mock
-        rs = ResultSet(response_future, expected[:5])
+        rs = list(ResultSet(response_future, expected[:5]))
         type(response_future).has_more_pages = PropertyMock(side_effect=(True, True, True, False))
         # eq before iteration causes list to be materialized
         self.assertEqual(rs, expected)
 
         # results can be iterated or indexed once we're materialized
-        self.assertListEqual(list(rs), expected)
+        self.assertListEqual(rs, expected)
         self.assertEqual(rs[9], expected[9])
         self.assertTrue(rs)
 


### PR DESCRIPTION
This is not the final PR, but wanted a review to be sure we agree on the changes.

* ResultSet doesn't have iteration support, neither `next()`. We need to create one with `iter(rs)` or in a loop as usual.

* A ResultSetIterator has been created to separate the logic from the ResultSet itself.

* Basic equality and indexing have been removed. It was present only for backward-compatibility and was one of the reasons of the bad design and mixed behaviors of the ResultSet  (a warning will be added in 3.14).

* Related to the point above, the *list_mode* has been removed. If the user need to materialize all results, he should use `list(rs)`

* Although this is not a common practice, if a second (or more) iterator is created.. it will continue to consume the data at the ResultSet state where the previous one stopped.

* To get a single row of the resultset, we need to create an iterator and call next, or use `rs.current_rows[0]`. I am wondering if we should provide a shortcut like `rs.one()` for convenience (would use next internally). 
