### PR TITLE
PYTHON-947: Add one() function to the ResultSet API 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 3.14.0
 ======
 
+Features
+--------
+* Add one() function to the ResultSet API (PYTHON-947)
+
 Other
 -----
 * Fix Broken Links in Docs (PYTHON-916)

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4230,6 +4230,15 @@ class ResultSet(object):
         """
         return self._current_rows or []
 
+    def one(self):
+        """
+        Return a single row of the results or None if empty. This is basically
+        a shortcut to `result_set.current_rows[0]` and should only be used when
+        you know a query returns a single row. Consider using an iterator if the
+        ResultSet contains more than one row.
+        """
+        return self._current_rows[0] if self._current_rows else None
+
     def __iter__(self):
         if self._list_mode:
             return iter(self._current_rows)
@@ -4294,6 +4303,9 @@ class ResultSet(object):
         return self._current_rows == other
 
     def __getitem__(self, i):
+        if i is 0:
+            warn("ResultSet indexing support will be removed in 4.0. Consider using "
+                 "ResultSet.one() to get a single row.", DeprecationWarning)
         self._enter_list_mode("index operator")
         return self._current_rows[i]
 

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -4303,7 +4303,7 @@ class ResultSet(object):
         return self._current_rows == other
 
     def __getitem__(self, i):
-        if i is 0:
+        if i == 0:
             warn("ResultSet indexing support will be removed in 4.0. Consider using "
                  "ResultSet.one() to get a single row.", DeprecationWarning)
         self._enter_list_mode("index operator")

--- a/tests/unit/test_resultset.py
+++ b/tests/unit/test_resultset.py
@@ -187,3 +187,10 @@ class ResultSetTests(unittest.TestCase):
         for applied in (True, False):
             rs = ResultSet(Mock(row_factory=row_factory), [{'[applied]': applied}])
             self.assertEqual(rs.was_applied, applied)
+
+    def test_one(self):
+        # no pages
+        first, second = Mock(), Mock()
+        rs = ResultSet(Mock(has_more_pages=False), [first, second])
+
+        self.assertEqual(rs.one(), first)

--- a/tests/unit/test_resultset.py
+++ b/tests/unit/test_resultset.py
@@ -194,3 +194,20 @@ class ResultSetTests(unittest.TestCase):
         rs = ResultSet(Mock(has_more_pages=False), [first, second])
 
         self.assertEqual(rs.one(), first)
+
+    def test_indexing_deprecation(self):
+        import warnings
+
+        first, second = Mock(), Mock()
+        rs = ResultSet(Mock(has_more_pages=False), [first, second])
+        self.assertEqual(rs[0], first)
+
+        with warnings.catch_warnings(record=True) as ws:
+            # catch_warnings restores original filter on close
+            warnings.simplefilter('always')
+            rs[0]
+        self.assertEqual(len(ws), 1)
+        index_warning = ws[0]
+        self.assertIs(index_warning.category, DeprecationWarning)
+        self.assertIn('indexing support will be removed in 4.0',
+                      str(index_warning.message))


### PR DESCRIPTION
PR for master (3.14)