### PR TITLE
PYTHON-950: Remove cqlengine QuerySet indexing support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Other
 * cqlengine: disallow Counter create, save operations (PYTHON-497)
 * cqlengine: remove the negative indices slicing support in ModelQuerySet (PYTHON-875)
 * cqlengine: Remove Model.__default_ttl__ (PYTHON-889)
+* cqlengine: Remove cqlengine QuerySet indexing support (PYTHON-950)
 
 3.12.0
 ======

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -734,8 +734,8 @@ class AbstractQuerySet(object):
             # Check that the resultset only contains one element, avoiding sending a COUNT query
             try:
                 it = iter(self)
-                for _ in range(2):
-                    next(it)
+                next(it)
+                next(it)  # if this works.. there are more than one row in the results.
                 raise self.model.MultipleObjectsReturned('Multiple objects found')
             except StopIteration:
                 pass

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -733,14 +733,16 @@ class AbstractQuerySet(object):
         def check_multiple_object(_):
             # Check that the resultset only contains one element, avoiding sending a COUNT query
             try:
-                self[1]
+                it = iter(self)
+                for _ in range(2):
+                    next(it)
                 raise self.model.MultipleObjectsReturned('Multiple objects found')
-            except IndexError:
+            except StopIteration:
                 pass
 
             try:
-                obj = self[0]
-            except IndexError:
+                obj = next(iter(self))
+            except StopIteration:
                 raise self.model.DoesNotExist
 
             return obj

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -548,42 +548,6 @@ class AbstractQuerySet(object):
 
             idx += 1
 
-    def __getitem__(self, s):
-        self._execute_query()
-
-        if isinstance(s, slice):
-            start = s.start if s.start else 0
-
-            # no support for negative indices
-            if start < 0 or (s.stop is not None and s.stop < 0):
-                raise ValueError("QuerySet slice indices must be positive")
-
-            try:
-                if s.stop:
-                    self._fill_result_cache_to_idx(s.stop)
-                else:
-                    self._fill_result_cache()
-            except StopIteration:
-                pass
-
-            return self._result_cache[start:s.stop:s.step]
-        else:
-            try:
-                s = int(s)
-            except (ValueError, TypeError):
-                raise TypeError('QuerySet indices must be integers')
-
-            # no support for negative indices
-            if s < 0:
-                raise ValueError("QuerySet indices must be positive")
-
-            try:
-                self._fill_result_cache_to_idx(s)
-            except StopIteration:
-                raise IndexError
-
-            return self._result_cache[s]
-
     def _get_result_constructor(self):
         """
         Returns a function that will be used to instantiate query results

--- a/docs/cqlengine/models.rst
+++ b/docs/cqlengine/models.rst
@@ -200,7 +200,7 @@ are only created, presisted, and queried via table Models. A short example to in
         addr = UserDefinedType(address)
 
     users.create(name="Joe", addr=address(street="Easy St.", zipcode=99999))
-    user = users.objects(name="Joe")[0]
+    user = users.objects(name="Joe").first()
     print user.name, user.addr
     # Joe address(street=u'Easy St.', zipcode=99999)
 

--- a/docs/cqlengine/queryset.rst
+++ b/docs/cqlengine/queryset.rst
@@ -78,30 +78,6 @@ Accessing objects in a QuerySet
                 #...do something to the car instance
                 pass
 
-    * list index
-        .. code-block:: python
-
-            q = Automobile.objects.all()
-            q[0] #returns the first result
-            q[1] #returns the second result
-
-        .. note::
-
-            * CQL does not support specifying a start position in it's queries. Therefore, accessing elements using array indexing will load every result up to the index value requested
-            * Using negative indices requires a "SELECT COUNT()" to be executed. This has a performance cost on large datasets.
-
-    * list slicing
-        .. code-block:: python
-
-            q = Automobile.objects.all()
-            q[1:] #returns all results except the first
-            q[1:9] #returns a slice of the results
-
-        .. note::
-
-            * CQL does not support specifying a start position in it's queries. Therefore, accessing elements using array slicing will load every result up to the index value requested
-            * Using negative indices requires a "SELECT COUNT()" to be executed. This has a performance cost on large datasets.
-
     * calling :attr:`get() <query.QuerySet.get>` on the queryset
         .. code-block:: python
 
@@ -257,7 +233,7 @@ Token Function
 
         query = Items.objects.all().limit(10)
 
-        first_page = list(query);
+        first_page = list(query)
         last = first_page[-1]
         next_page = list(query.filter(pk__token__gt=cqlengine.Token(last.pk)))
 
@@ -414,6 +390,6 @@ Named tables are a way of querying a table without creating an class.  They're u
         from cassandra.cqlengine.named import NamedTable
         user = NamedTable("cqlengine_test", "user")
         user.objects()
-        user.objects()[0]
+        user.objects().first()
 
         # {u'pk': 1, u't': datetime.datetime(2014, 6, 26, 17, 10, 31, 774000)}

--- a/docs/cqlengine/upgrade_guide.rst
+++ b/docs/cqlengine/upgrade_guide.rst
@@ -87,12 +87,30 @@ Upgrade Guide 3.x to 4.x
 
     Automobile.objects.all()[-10:]
 
-* Model.__default_ttl__ has been removed.
+* Model.__default_ttl__ has been removed. The default ttl should be set in the model __options__.
 
 * cassandra.cqlengine.query.BatchType has been removed. Use :class:`cassandra.query.BatchType`
   instead when specifying the batch type with cqlengine.
 
 * There is no more default limit on QuerySets (was 10000 before).
+
+* The QuerySet indexing support has been removed (e.g *Automobile.objects.all()[0]*). To access
+  objects in a queryset, you should use one of these:
+  
+  - An Iterator::
+
+      for car in Automobile.objects.all():
+          print(car.model)
+
+  - Materialize the results::
+
+      cars = list(Automobile.objects.all())  # This will fetch *all* rows from the server
+      car = cars[1:10]
+
+  - QuerySet.get() for a single row::
+
+      cars = Automobile.objects.filter(manufacturer=..., model=...)
+      car = cars.get()
 
 Upgrade Guide cqlengine to cassandra.cqlengine
 ==============================================

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -88,7 +88,7 @@ class TestDatetime(BaseCassEngTestCase):
         self.assertIsNone(dt2.created_at)
 
         dts = self.DatetimeTest.objects.filter(test_id=3).values_list('created_at')
-        self.assertIsNone(dts[0][0])
+        self.assertIsNone(dts.first()[0])
 
     def test_datetime_invalid(self):
         dt_value= 'INVALID'
@@ -281,7 +281,7 @@ class DataType():
         self.assertIsNone(dt2.class_param)
 
         dts = self.model_class.objects(test_id=1).values_list('class_param')
-        self.assertIsNone(dts[0][0])
+        self.assertIsNone(dts.first()[0])
 
 
 class TestDate(DataType, BaseCassEngTestCase):

--- a/tests/integration/cqlengine/model/test_model.py
+++ b/tests/integration/cqlengine/model/test_model.py
@@ -103,7 +103,7 @@ class TestModel(unittest.TestCase):
         sync_table(table)
 
         created = table.create(select=1, table='table')
-        selected = table.objects(select=1)[0]
+        selected = table.objects(select=1).first()
         self.assertEqual(created.select, selected.select)
         self.assertEqual(created.table, selected.table)
         self.assertEqual(created.where, selected.where)

--- a/tests/integration/cqlengine/model/test_model.py
+++ b/tests/integration/cqlengine/model/test_model.py
@@ -89,7 +89,7 @@ class TestModel(unittest.TestCase):
         sync_table(table)
 
         created = table.create(select=0, table='table')
-        selected = table.objects(select=0)[0]
+        selected = table.objects(select=0).first()
         self.assertEqual(created.select, selected.select)
         self.assertEqual(created.table, selected.table)
 

--- a/tests/integration/cqlengine/model/test_model_io.py
+++ b/tests/integration/cqlengine/model/test_model_io.py
@@ -656,8 +656,9 @@ class TestQueryQuoting(BaseCassEngTestCase):
         model2 = ReservedWordModel.filter(token='1')
 
         self.assertTrue(len(model2) == 1)
-        self.assertTrue(model1.token == model2[0].token)
-        self.assertTrue(model1.insert == model2[0].insert)
+        row = model2.first()
+        self.assertTrue(model1.token == row.token)
+        self.assertTrue(model1.insert == row.insert)
 
 
 class TestQueryModel(Model):

--- a/tests/integration/cqlengine/query/test_named.py
+++ b/tests/integration/cqlengine/query/test_named.py
@@ -367,11 +367,12 @@ class TestNamedWithMV(BasicSharedKeyspaceUnitTestCase):
 
         filtered_mv_monthly_objects = mv_monthly.objects.filter(game='Chess', year=2015, month=6)
         self.assertEqual(len(filtered_mv_monthly_objects), 1)
-        self.assertEqual(filtered_mv_monthly_objects[0]['score'], 3500)
-        self.assertEqual(filtered_mv_monthly_objects[0]['user'], 'jbellis')
+        row = filtered_mv_monthly_objects.first()
+        self.assertEqual(row['score'], 3500)
+        self.assertEqual(row['user'], 'jbellis')
         filtered_mv_alltime_objects = mv_all_time.objects.filter(game='Chess')
         self.assertEqual(len(filtered_mv_alltime_objects), 2)
-        self.assertEqual(filtered_mv_alltime_objects[0]['score'], 3500)
+        self.assertEqual(filtered_mv_alltime_objects.first()['score'], 3500)
 
     def check_table_size(self, table_name, key_space, expected_size):
         table = key_space.table(table_name)

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -637,78 +637,6 @@ class TestQuerySetOrdering(BaseQuerySetUsage):
         assert [r.three for r in results] == [1, 2, 3, 4, 5]
 
 
-class TestQuerySetSlicing(BaseQuerySetUsage):
-
-    @execute_count(1)
-    def test_out_of_range_index_raises_error(self):
-        q = TestModel.objects(test_id=0).order_by('attempt_id')
-        with self.assertRaises(IndexError):
-            q[10]
-
-    @execute_count(1)
-    def test_array_indexing_works_properly(self):
-        q = TestModel.objects(test_id=0).order_by('attempt_id')
-        expected_order = [0, 1, 2, 3]
-        for i in range(len(q)):
-            assert q[i].attempt_id == expected_order[i]
-
-    @execute_count(1)
-    def test_negative_indexing_raises_error(self):
-        q = TestModel.objects(test_id=0).order_by('attempt_id')
-        with self.assertRaises(ValueError):
-            q[-1].attempt_id
-
-    @execute_count(1)
-    def test_slicing_works_properly(self):
-        q = TestModel.objects(test_id=0).order_by('attempt_id')
-        expected_order = [0, 1, 2, 3]
-
-        for model, expect in zip(q[1:3], expected_order[1:3]):
-            self.assertEqual(model.attempt_id, expect)
-
-        for model, expect in zip(q[0:3:2], expected_order[0:3:2]):
-            self.assertEqual(model.attempt_id, expect)
-
-        for model, expect in zip(q[0:], expected_order):
-            self.assertEqual(model.attempt_id, expect)
-
-    @execute_count(4)
-    def test_negative_slicing_raises_error(self):
-
-        def assert_slicing(q):
-            with self.assertRaises(ValueError):
-                q[-1:]
-
-            with self.assertRaises(ValueError):
-                q[:-1]
-
-            with self.assertRaises(ValueError):
-                q[1:-1]
-
-            with self.assertRaises(ValueError):
-                q[-1:-1]
-
-            with self.assertRaises(ValueError):
-                q[-1:1]
-
-            with self.assertRaises(ValueError):
-                q[-1:4:2]
-
-            with self.assertRaises(ValueError):
-                q[4:-1:2]
-
-        q = TestModel.objects(test_id=0).order_by('attempt_id')
-        assert_slicing(q)
-
-        q = TestModel.objects(test_id=0)
-        assert_slicing(q)
-
-        q = TestModel.objects(test_id=0).filter(attempt_id=0)
-        assert_slicing(q)
-
-        # We should be able to do this
-        q = TestModel.get_all()[-1:]
-
 class TestQuerySetValidation(BaseQuerySetUsage):
 
     def test_primary_key_or_index_must_be_specified(self):
@@ -1071,7 +999,7 @@ class PageQueryTests(BaseCassEngTestCase):
 
         session = get_session()
         with mock.patch.object(session, 'default_fetch_size', 1):
-            results = PagingTest.objects()[:]
+            results = list(PagingTest.objects())[:]
 
         assert len(results) == 2
 

--- a/tests/integration/cqlengine/statements/test_base_statement.py
+++ b/tests/integration/cqlengine/statements/test_base_statement.py
@@ -138,7 +138,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
         self.assertEqual(result.one()["text"], self.text)
 
         q = TestQueryUpdateModel.objects.filter(text__like=like_clause).allow_filtering()
-        self.assertEqual(q[0].text, self.text)
+        self.assertEqual(q.first().text, self.text)
 
         q = TestQueryUpdateModel.objects.filter(text__like=like_clause)
         self.assertEqual(q[0].text, self.text)

--- a/tests/integration/cqlengine/statements/test_base_statement.py
+++ b/tests/integration/cqlengine/statements/test_base_statement.py
@@ -141,7 +141,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
         self.assertEqual(q.first().text, self.text)
 
         q = TestQueryUpdateModel.objects.filter(text__like=like_clause)
-        self.assertEqual(q[0].text, self.text)
+        self.assertEqual(q.first().text, self.text)
 
     def _insert_statement(self, partition, cluster):
         # Verifying insert statement

--- a/tests/integration/cqlengine/test_connections.py
+++ b/tests/integration/cqlengine/test_connections.py
@@ -583,19 +583,6 @@ class TestQuerySetCountSelectionAndIterationNoDefault(BaseConnectionTestNoDefaul
     pass
 
 
-class TestQuerySetSlicingNoDefault(BaseConnectionTestNoDefault, test_queryset.TestQuerySetSlicing):
-    """
-    Execute test_queryset.TestQuerySetOrdering using non default connection
-
-    @since 3.7
-    @jira_ticket PYTHON-613
-    @expected_result proper connection should be used
-
-    @test_category object_mapper
-    """
-    pass
-
-
 class TestQuerySetValidationNoDefault(BaseConnectionTestNoDefault, test_queryset.TestQuerySetValidation):
     """
     Execute test_queryset.TestQuerySetOrdering using non default connection


### PR DESCRIPTION
Something to keep in mind: I'm not exactly sure of the utility of `QuerySet.first()`. At first sight... this should be deleted since there is already a `.get()`. Will be Investigated in PYTHON-948.