### PR TITLE
Document long compile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Other
 * Refactor CASSANDRA_VERSION to a some kind of version object (PYTHON-915)
 * Warn users when using the deprecated Session.default_consistency_level (PYTHON-953)
 * Add DSE smoke test to OSS driver tests (PYTHON-894)
+* Document long compilation times and workarounds (PYTHON-868)
 
 3.13.0
 ======

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -230,10 +230,10 @@ class ExecutionProfile(object):
 
     Some example implementations:
 
-        - :func:`cassandra.query.tuple_factory` - return a result row as a tuple
-        - :func:`cassandra.query.named_tuple_factory` - return a result row as a named tuple
-        - :func:`cassandra.query.dict_factory` - return a result row as a dict
-        - :func:`cassandra.query.ordered_dict_factory` - return a result row as an OrderedDict
+    - :func:`cassandra.query.tuple_factory` - return a result row as a tuple
+    - :func:`cassandra.query.named_tuple_factory` - return a result row as a named tuple
+    - :func:`cassandra.query.dict_factory` - return a result row as a dict
+    - :func:`cassandra.query.ordered_dict_factory` - return a result row as an OrderedDict
     """
 
     speculative_execution_policy = None
@@ -1897,10 +1897,10 @@ class Session(object):
         returned row will be a named tuple.  You can alternatively
         use any of the following:
 
-          - :func:`cassandra.query.tuple_factory` - return a result row as a tuple
-          - :func:`cassandra.query.named_tuple_factory` - return a result row as a named tuple
-          - :func:`cassandra.query.dict_factory` - return a result row as a dict
-          - :func:`cassandra.query.ordered_dict_factory` - return a result row as an OrderedDict
+        - :func:`cassandra.query.tuple_factory` - return a result row as a tuple
+        - :func:`cassandra.query.named_tuple_factory` - return a result row as a named tuple
+        - :func:`cassandra.query.dict_factory` - return a result row as a dict
+        - :func:`cassandra.query.ordered_dict_factory` - return a result row as an OrderedDict
 
         """
         return self._row_factory

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -49,13 +49,12 @@ def execute_concurrent(session, statements_and_parameters, concurrency=100, rais
 
     `results_generator` controls how the results are returned.
 
-        If :const:`False`, the results are returned only after all requests have completed.
-
-        If :const:`True`, a generator expression is returned. Using a generator results in a constrained
-        memory footprint when the results set will be large -- results are yielded
-        as they return instead of materializing the entire list at once. The trade for lower memory
-        footprint is marginal CPU overhead (more thread coordination and sorting out-of-order results
-        on-the-fly).
+    * If :const:`False`, the results are returned only after all requests have completed.
+    * If :const:`True`, a generator expression is returned. Using a generator results in a constrained
+      memory footprint when the results set will be large -- results are yielded
+      as they return instead of materializing the entire list at once. The trade for lower memory
+      footprint is marginal CPU overhead (more thread coordination and sorting out-of-order results
+      on-the-fly).
 
     A sequence of ``ExecutionResult(success, result_or_exc)`` namedtuples is returned
     in the same order that the statements were passed in.  If ``success`` is :const:`False`,

--- a/cassandra/metrics.py
+++ b/cassandra/metrics.py
@@ -37,17 +37,17 @@ class Metrics(object):
     A :class:`greplin.scales.PmfStat` timer for requests. This is a dict-like
     object with the following keys:
 
-      * count - number of requests that have been timed
-      * min - min latency
-      * max - max latency
-      * mean - mean latency
-      * stddev - standard deviation for latencies
-      * median - median latency
-      * 75percentile - 75th percentile latencies
-      * 95percentile - 95th percentile latencies
-      * 98percentile - 98th percentile latencies
-      * 99percentile - 99th percentile latencies
-      * 999percentile - 99.9th percentile latencies
+    * count - number of requests that have been timed
+    * min - min latency
+    * max - max latency
+    * mean - mean latency
+    * stddev - standard deviation for latencies
+    * median - median latency
+    * 75percentile - 75th percentile latencies
+    * 95percentile - 95th percentile latencies
+    * 98percentile - 98th percentile latencies
+    * 99percentile - 99th percentile latencies
+    * 999percentile - 99.9th percentile latencies
     """
 
     connection_errors = None

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -883,9 +883,9 @@ class Time(object):
         """
         Initializer value can be:
 
-            - integer_type: absolute nanoseconds in the day
-            - datetime.time: built-in time
-            - string_type: a string time of the form "HH:MM:SS[.mmmuuunnn]"
+        - integer_type: absolute nanoseconds in the day
+        - datetime.time: built-in time
+        - string_type: a string time of the form "HH:MM:SS[.mmmuuunnn]"
         """
         if isinstance(value, six.integer_types):
             self._from_timestamp(value)
@@ -1012,9 +1012,9 @@ class Date(object):
         """
         Initializer value can be:
 
-            - integer_type: absolute days from epoch (1970, 1, 1). Can be negative.
-            - datetime.date: built-in date
-            - string_type: a string time of the form "yyyy-mm-dd"
+        - integer_type: absolute days from epoch (1970, 1, 1). Can be negative.
+        - datetime.date: built-in date
+        - string_type: a string time of the form "yyyy-mm-dd"
         """
         if isinstance(value, six.integer_types):
             self.days_from_epoch = value

--- a/docs/api/cassandra/cqlengine/columns.rst
+++ b/docs/api/cassandra/cqlengine/columns.rst
@@ -6,12 +6,12 @@
 Columns
 -------
 
-    Columns in your models map to columns in your CQL table. You define CQL columns by defining column attributes on your model classes.
-    For a model to be valid it needs at least one primary key column and one non-primary key column.
+Columns in your models map to columns in your CQL table. You define CQL columns by defining column attributes on your model classes.
+For a model to be valid it needs at least one primary key column and one non-primary key column.
 
-    Just as in CQL, the order you define your columns in is important, and is the same order they are defined in on a model's corresponding table.
+Just as in CQL, the order you define your columns in is important, and is the same order they are defined in on a model's corresponding table.
 
-    Each column on your model definitions needs to be an instance of a Column class.
+Each column on your model definitions needs to be an instance of a Column class.
 
 .. autoclass:: Column(**kwargs)
 

--- a/docs/api/cassandra/protocol.rst
+++ b/docs/api/cassandra/protocol.rst
@@ -45,11 +45,11 @@ and ``NumpyProtocolHandler``. They can be used as follows:
 
 These protocol handlers comprise different parsers, and return results as described below:
 
-    - ProtocolHandler: this default implementation is a drop-in replacement for the pure-Python version.
-        The rows are all parsed upfront, before results are returned.
+- ProtocolHandler: this default implementation is a drop-in replacement for the pure-Python version.
+  The rows are all parsed upfront, before results are returned.
 
-    - LazyProtocolHandler: near drop-in replacement for the above, except that it returns an iterator over rows,
-        lazily decoded into the default row format (this is more efficient since all decoded results are not materialized at once)
+- LazyProtocolHandler: near drop-in replacement for the above, except that it returns an iterator over rows,
+  lazily decoded into the default row format (this is more efficient since all decoded results are not materialized at once)
 
-    - NumpyProtocolHander: deserializes results directly into NumPy arrays. This facilitates efficient integration with
-        analysis toolkits such as Pandas.
+- NumpyProtocolHander: deserializes results directly into NumPy arrays. This facilitates efficient integration with
+  analysis toolkits such as Pandas.

--- a/docs/cqlengine/batches.rst
+++ b/docs/cqlengine/batches.rst
@@ -8,101 +8,101 @@ cqlengine supports batch queries using the BatchQuery class. Batch queries can b
 Batch Query General Use Pattern
 ===============================
 
-    You can only create, update, and delete rows with a batch query, attempting to read rows out of the database with a batch query will fail.
+You can only create, update, and delete rows with a batch query, attempting to read rows out of the database with a batch query will fail.
 
-    .. code-block:: python
+.. code-block:: python
 
-        from cassandra.cqlengine.query import BatchQuery
+    from cassandra.cqlengine.query import BatchQuery
 
-        #using a context manager
-        with BatchQuery() as b:
-            now = datetime.now()
-            em1 = ExampleModel.batch(b).create(example_type=0, description="1", created_at=now)
-            em2 = ExampleModel.batch(b).create(example_type=0, description="2", created_at=now)
-            em3 = ExampleModel.batch(b).create(example_type=0, description="3", created_at=now)
-
-        # -- or --
-
-        #manually
-        b = BatchQuery()
+    #using a context manager
+    with BatchQuery() as b:
         now = datetime.now()
         em1 = ExampleModel.batch(b).create(example_type=0, description="1", created_at=now)
         em2 = ExampleModel.batch(b).create(example_type=0, description="2", created_at=now)
         em3 = ExampleModel.batch(b).create(example_type=0, description="3", created_at=now)
-        b.execute()
 
-        # updating in a batch
+    # -- or --
 
-        b = BatchQuery()
-        em1.description = "new description"
-        em1.batch(b).save()
-        em2.description = "another new description"
-        em2.batch(b).save()
-        b.execute()
+    #manually
+    b = BatchQuery()
+    now = datetime.now()
+    em1 = ExampleModel.batch(b).create(example_type=0, description="1", created_at=now)
+    em2 = ExampleModel.batch(b).create(example_type=0, description="2", created_at=now)
+    em3 = ExampleModel.batch(b).create(example_type=0, description="3", created_at=now)
+    b.execute()
 
-        # deleting in a batch
-        b = BatchQuery()
-        ExampleModel.objects(id=some_id).batch(b).delete()
-        ExampleModel.objects(id=some_id2).batch(b).delete()
-        b.execute()
+    # updating in a batch
+
+    b = BatchQuery()
+    em1.description = "new description"
+    em1.batch(b).save()
+    em2.description = "another new description"
+    em2.batch(b).save()
+    b.execute()
+
+    # deleting in a batch
+    b = BatchQuery()
+    ExampleModel.objects(id=some_id).batch(b).delete()
+    ExampleModel.objects(id=some_id2).batch(b).delete()
+    b.execute()
 
 
-    Typically you will not want the block to execute if an exception occurs inside the `with` block.  However, in the case that this is desirable, it's achievable by using the following syntax:
+Typically you will not want the block to execute if an exception occurs inside the `with` block.  However, in the case that this is desirable, it's achievable by using the following syntax:
 
-    .. code-block:: python
+.. code-block:: python
 
-        with BatchQuery(execute_on_exception=True) as b:
-            LogEntry.batch(b).create(k=1, v=1)
-            mystery_function() # exception thrown in here
-            LogEntry.batch(b).create(k=1, v=2) # this code is never reached due to the exception, but anything leading up to here will execute in the batch.
+    with BatchQuery(execute_on_exception=True) as b:
+        LogEntry.batch(b).create(k=1, v=1)
+        mystery_function() # exception thrown in here
+        LogEntry.batch(b).create(k=1, v=2) # this code is never reached due to the exception, but anything leading up to here will execute in the batch.
 
-    If an exception is thrown somewhere in the block, any statements that have been added to the batch will still be executed.  This is useful for some logging situations.
+If an exception is thrown somewhere in the block, any statements that have been added to the batch will still be executed.  This is useful for some logging situations.
 
 Batch Query Execution Callbacks
 ===============================
 
-    In order to allow secondary tasks to be chained to the end of batch, BatchQuery instances allow callbacks to be
-    registered with the batch, to be executed immediately after the batch executes.
+In order to allow secondary tasks to be chained to the end of batch, BatchQuery instances allow callbacks to be
+registered with the batch, to be executed immediately after the batch executes.
 
-    Multiple callbacks can be attached to same BatchQuery instance, they are executed in the same order that they
-    are added to the batch.
+Multiple callbacks can be attached to same BatchQuery instance, they are executed in the same order that they
+are added to the batch.
 
-    The callbacks attached to a given batch instance are executed only if the batch executes. If the batch is used as a
-    context manager and an exception is raised, the queued up callbacks will not be run.
+The callbacks attached to a given batch instance are executed only if the batch executes. If the batch is used as a
+context manager and an exception is raised, the queued up callbacks will not be run.
 
-    .. code-block:: python
+.. code-block:: python
 
-        def my_callback(*args, **kwargs):
-            pass
+    def my_callback(*args, **kwargs):
+        pass
 
-        batch = BatchQuery()
+    batch = BatchQuery()
 
-        batch.add_callback(my_callback)
-        batch.add_callback(my_callback, 'positional arg', named_arg='named arg value')
+    batch.add_callback(my_callback)
+    batch.add_callback(my_callback, 'positional arg', named_arg='named arg value')
 
-        # if you need reference to the batch within the callback,
-        # just trap it in the arguments to be passed to the callback:
-        batch.add_callback(my_callback, cqlengine_batch=batch)
+    # if you need reference to the batch within the callback,
+    # just trap it in the arguments to be passed to the callback:
+    batch.add_callback(my_callback, cqlengine_batch=batch)
 
-        # once the batch executes...
-        batch.execute()
+    # once the batch executes...
+    batch.execute()
 
-        # the effect of the above scheduled callbacks will be similar to
-        my_callback()
-        my_callback('positional arg', named_arg='named arg value')
-        my_callback(cqlengine_batch=batch)
+    # the effect of the above scheduled callbacks will be similar to
+    my_callback()
+    my_callback('positional arg', named_arg='named arg value')
+    my_callback(cqlengine_batch=batch)
 
-    Failure in any of the callbacks does not affect the batch's execution, as the callbacks are started after the execution
-    of the batch is complete.
+Failure in any of the callbacks does not affect the batch's execution, as the callbacks are started after the execution
+of the batch is complete.
 
 Logged vs Unlogged Batches
 ---------------------------
-    By default, queries in cqlengine are LOGGED, which carries additional overhead from UNLOGGED.  To explicitly state which batch type to use, simply:
+By default, queries in cqlengine are LOGGED, which carries additional overhead from UNLOGGED.  To explicitly state which batch type to use, simply:
 
 
-    .. code-block:: python
+.. code-block:: python
 
-        from cassandra.cqlengine.query import BatchType
-        with BatchQuery(batch_type=BatchType.Unlogged) as b:
-            LogEntry.batch(b).create(k=1, v=1)
-            LogEntry.batch(b).create(k=1, v=2)
+    from cassandra.cqlengine.query import BatchType
+    with BatchQuery(batch_type=BatchType.Unlogged) as b:
+        LogEntry.batch(b).create(k=1, v=1)
+        LogEntry.batch(b).create(k=1, v=2)

--- a/docs/cqlengine/connections.rst
+++ b/docs/cqlengine/connections.rst
@@ -110,7 +110,7 @@ You can use the :attr:`using() <.query.ModelQuerySet.using>` method to select a 
 
         Automobile.objects.using(connection='cluster1').create(manufacturer='honda', year=2010, model='civic')
         q = Automobile.objects.filter(manufacturer='Tesla')
-        autos = q.using(keyspace='ks2, connection='cluster2').all()
+        autos = q.using(keyspace='ks2', connection='cluster2').all()
 
         for auto in autos:
             auto.using(connection='cluster1').save()

--- a/docs/cqlengine/connections.rst
+++ b/docs/cqlengine/connections.rst
@@ -10,22 +10,22 @@ Register a new connection
 
 To use cqlengine, you need at least a default connection. If you initialize cqlengine's connections with with :func:`connection.setup <.connection.setup>`, a connection will be created automatically. If you want to use another cluster/session, you need to register a new cqlengine connection. You register a connection with :func:`~.connection.register_connection`:
 
-    .. code-block:: python
+.. code-block:: python
 
-        from cassandra.cqlengine import connection
+    from cassandra.cqlengine import connection
 
-        connection.setup(['127.0.0.1')
-        connection.register_connection('cluster2', ['127.0.0.2'])
+    connection.setup(['127.0.0.1')
+    connection.register_connection('cluster2', ['127.0.0.2'])
 
 :func:`~.connection.register_connection` can take a list of hosts, as shown above, in which case it will create a connection with a new session. It can also take a `session` argument if you've already created a session:
 
-    .. code-block:: python
+.. code-block:: python
 
-        from cassandra.cqlengine import connection
-        from cassandra.cluster import Cluster
+    from cassandra.cqlengine import connection
+    from cassandra.cluster import Cluster
 
-        session = Cluster(['127.0.0.1']).connect()
-        connection.register_connection('cluster3', session=session)
+    session = Cluster(['127.0.0.1']).connect()
+    connection.register_connection('cluster3', session=session)
 
 
 Change the default connection
@@ -33,51 +33,51 @@ Change the default connection
 
 You can change the default cqlengine connection on registration:
 
-    .. code-block:: python
+.. code-block:: python
 
-        from cassandra.cqlengine import connection
+    from cassandra.cqlengine import connection
 
-        connection.register_connection('cluster2', ['127.0.0.2'] default=True)
+    connection.register_connection('cluster2', ['127.0.0.2'] default=True)
 
 or on the fly using :func:`~.connection.set_default_connection`
 
-    .. code-block:: python
+.. code-block:: python
 
-        connection.set_default_connection('cluster2')
+    connection.set_default_connection('cluster2')
 
 Unregister a connection
 =======================
 
 You can unregister a connection using :func:`~.connection.unregister_connection`:
 
-    .. code-block:: python
+.. code-block:: python
 
-        connection.unregister_connection('cluster2')
+    connection.unregister_connection('cluster2')
 
 Management
 ==========
 
 When using multiples connections, you also need to sync your models on all connections (and keyspaces) that you need operate on. Management commands have been improved to ease this part. Here is an example:
 
-    .. code-block:: python
+.. code-block:: python
 
-       from cassandra.cqlengine import management
+   from cassandra.cqlengine import management
 
-       keyspaces = ['ks1', 'ks2']
-       conns = ['cluster1', 'cluster2']
+   keyspaces = ['ks1', 'ks2']
+   conns = ['cluster1', 'cluster2']
 
-       # registers your connections
-       # ...
+   # registers your connections
+   # ...
 
-       # create all keyspaces on all connections
-       for ks in keyspaces:
-           management.create_simple_keyspace(ks, connections=conns)
+   # create all keyspaces on all connections
+   for ks in keyspaces:
+       management.create_simple_keyspace(ks, connections=conns)
 
-       # define your Automobile model
-       # ...
+   # define your Automobile model
+   # ...
 
-       # sync your models
-       management.sync_table(Automobile, keyspaces=keyspaces, connections=conns)
+   # sync your models
+   management.sync_table(Automobile, keyspaces=keyspaces, connections=conns)
 
 
 Connection Selection
@@ -90,40 +90,40 @@ Default Model Connection
 
 You can specify a default connection per model:
 
-    .. code-block:: python
+.. code-block:: python
 
-        class Automobile(Model):
-            __keyspace__ = 'test'
-            __connection__ = 'cluster2'
-            manufacturer = columns.Text(primary_key=True)
-            year = columns.Integer(primary_key=True)
-            model = columns.Text(primary_key=True)
+    class Automobile(Model):
+        __keyspace__ = 'test'
+        __connection__ = 'cluster2'
+        manufacturer = columns.Text(primary_key=True)
+        year = columns.Integer(primary_key=True)
+        model = columns.Text(primary_key=True)
 
-        print len(Automobile.objects.all())  # executed on the connection 'cluster2'
+    print len(Automobile.objects.all())  # executed on the connection 'cluster2'
 
 QuerySet and model instance
 ---------------------------
 
 You can use the :attr:`using() <.query.ModelQuerySet.using>` method to select a connection (or keyspace):
 
-    .. code-block:: python
+.. code-block:: python
 
-        Automobile.objects.using(connection='cluster1').create(manufacturer='honda', year=2010, model='civic')
-        q = Automobile.objects.filter(manufacturer='Tesla')
-        autos = q.using(keyspace='ks2', connection='cluster2').all()
+    Automobile.objects.using(connection='cluster1').create(manufacturer='honda', year=2010, model='civic')
+    q = Automobile.objects.filter(manufacturer='Tesla')
+    autos = q.using(keyspace='ks2', connection='cluster2').all()
 
-        for auto in autos:
-            auto.using(connection='cluster1').save()
+    for auto in autos:
+        auto.using(connection='cluster1').save()
 
 Context Manager
 ---------------
 
 You can use the ContextQuery as well to select a connection:
 
-    .. code-block:: python
+.. code-block:: python
 
-        with ContextQuery(Automobile, connection='cluster1') as A:
-            A.objects.filter(manufacturer='honda').all()  # executed on 'cluster1'
+    with ContextQuery(Automobile, connection='cluster1') as A:
+        A.objects.filter(manufacturer='honda').all()  # executed on 'cluster1'
 
 
 BatchQuery
@@ -131,7 +131,7 @@ BatchQuery
 
 With a BatchQuery, you can select the connection with the context manager. Note that all operations in the batch need to use the same connection.
 
-    .. code-block:: python
+.. code-block:: python
 
-        with BatchQuery(connection='cluster1') as b:
-            Automobile.objects.batch(b).create(manufacturer='honda', year=2010, model='civic')
+    with BatchQuery(connection='cluster1') as b:
+        Automobile.objects.batch(b).create(manufacturer='honda', year=2010, model='civic')

--- a/docs/cqlengine/faq.rst
+++ b/docs/cqlengine/faq.rst
@@ -14,9 +14,9 @@ Statement Ordering is not supported by CQL3 batches. Therefore,
 once cassandra needs resolving conflict(Updating the same column in one batch),
 The algorithm below would be used.
 
- * If timestamps are different, pick the column with the largest timestamp (the value being a regular column or a tombstone)
- * If timestamps are the same, and one of the columns in a tombstone ('null') - pick the tombstone
- * If timestamps are the same, and none of the columns are tombstones, pick the column with the largest value
+* If timestamps are different, pick the column with the largest timestamp (the value being a regular column or a tombstone)
+* If timestamps are the same, and one of the columns in a tombstone ('null') - pick the tombstone
+* If timestamps are the same, and none of the columns are tombstones, pick the column with the largest value
 
 Below is an example to show this scenario.
 

--- a/docs/cqlengine/queryset.rst
+++ b/docs/cqlengine/queryset.rst
@@ -119,92 +119,92 @@ Accessing objects in a QuerySet
 Filtering Operators
 ===================
 
-    :attr:`Equal To <query.QueryOperator.EqualsOperator>`
+:attr:`Equal To <query.QueryOperator.EqualsOperator>`
 
-        The default filtering operator.
+    The default filtering operator.
 
-        .. code-block:: python
+    .. code-block:: python
 
-            q = Automobile.objects.filter(manufacturer='Tesla')
-            q = q.filter(year=2012)  #year == 2012
+        q = Automobile.objects.filter(manufacturer='Tesla')
+        q = q.filter(year=2012)  #year == 2012
 
-    In addition to simple equal to queries, cqlengine also supports querying with other operators by appending a ``__<op>`` to the field name on the filtering call
+In addition to simple equal to queries, cqlengine also supports querying with other operators by appending a ``__<op>`` to the field name on the filtering call
 
-    :attr:`in (__in) <query.QueryOperator.InOperator>`
+:attr:`in (__in) <query.QueryOperator.InOperator>`
 
-        .. code-block:: python
+    .. code-block:: python
 
-            q = Automobile.objects.filter(manufacturer='Tesla')
-            q = q.filter(year__in=[2011, 2012])
+        q = Automobile.objects.filter(manufacturer='Tesla')
+        q = q.filter(year__in=[2011, 2012])
 
 
-    :attr:`> (__gt) <query.QueryOperator.GreaterThanOperator>`
+:attr:`> (__gt) <query.QueryOperator.GreaterThanOperator>`
 
-        .. code-block:: python
+    .. code-block:: python
 
-            q = Automobile.objects.filter(manufacturer='Tesla')
-            q = q.filter(year__gt=2010)  # year > 2010
+        q = Automobile.objects.filter(manufacturer='Tesla')
+        q = q.filter(year__gt=2010)  # year > 2010
 
-            # or the nicer syntax
+        # or the nicer syntax
 
-            q.filter(Automobile.year > 2010)
+        q.filter(Automobile.year > 2010)
 
-    :attr:`>= (__gte) <query.QueryOperator.GreaterThanOrEqualOperator>`
+:attr:`>= (__gte) <query.QueryOperator.GreaterThanOrEqualOperator>`
 
-        .. code-block:: python
+    .. code-block:: python
 
-            q = Automobile.objects.filter(manufacturer='Tesla')
-            q = q.filter(year__gte=2010)  # year >= 2010
+        q = Automobile.objects.filter(manufacturer='Tesla')
+        q = q.filter(year__gte=2010)  # year >= 2010
 
-            # or the nicer syntax
+        # or the nicer syntax
 
-            q.filter(Automobile.year >= 2010)
+        q.filter(Automobile.year >= 2010)
 
-    :attr:`< (__lt) <query.QueryOperator.LessThanOperator>`
+:attr:`< (__lt) <query.QueryOperator.LessThanOperator>`
 
-        .. code-block:: python
+    .. code-block:: python
 
-            q = Automobile.objects.filter(manufacturer='Tesla')
-            q = q.filter(year__lt=2012)  # year < 2012
+        q = Automobile.objects.filter(manufacturer='Tesla')
+        q = q.filter(year__lt=2012)  # year < 2012
 
-            # or...
+        # or...
 
-            q.filter(Automobile.year < 2012)
+        q.filter(Automobile.year < 2012)
 
-    :attr:`<= (__lte) <query.QueryOperator.LessThanOrEqualOperator>`
+:attr:`<= (__lte) <query.QueryOperator.LessThanOrEqualOperator>`
 
-        .. code-block:: python
+    .. code-block:: python
 
-            q = Automobile.objects.filter(manufacturer='Tesla')
-            q = q.filter(year__lte=2012)  # year <= 2012
+        q = Automobile.objects.filter(manufacturer='Tesla')
+        q = q.filter(year__lte=2012)  # year <= 2012
 
-            q.filter(Automobile.year <= 2012)
+        q.filter(Automobile.year <= 2012)
 
-    :attr:`CONTAINS (__contains) <query.QueryOperator.ContainsOperator>`
+:attr:`CONTAINS (__contains) <query.QueryOperator.ContainsOperator>`
 
-        The CONTAINS operator is available for all collection types (List, Set, Map).
+    The CONTAINS operator is available for all collection types (List, Set, Map).
 
-        .. code-block:: python
+    .. code-block:: python
 
-            q = Automobile.objects.filter(manufacturer='Tesla')
-            q.filter(options__contains='backup camera').allow_filtering()
+        q = Automobile.objects.filter(manufacturer='Tesla')
+        q.filter(options__contains='backup camera').allow_filtering()
 
-        Note that we need to use allow_filtering() since the *options* column has no secondary index.
+    Note that we need to use allow_filtering() since the *options* column has no secondary index.
 
-    :attr:`LIKE (__like) <query.QueryOperator.LikeOperator>`
+:attr:`LIKE (__like) <query.QueryOperator.LikeOperator>`
 
-        The LIKE operator is available for text columns that have a SASI secondary index.
+    The LIKE operator is available for text columns that have a SASI secondary index.
 
-        .. code-block:: python
+    .. code-block:: python
 
-            q = Automobile.objects.filter(model__like='%Civic%').allow_filtering()
+        q = Automobile.objects.filter(model__like='%Civic%').allow_filtering()
 
-        Limitations:
-        - Currently, cqlengine does not support SASI index creation. To use this feature,
-          you need to create the SASI index using the core driver.
-        - Queries using LIKE must use allow_filtering() since the *model* column has no
-          standard secondary index. Note that the server will use the SASI index properly
-          when executing the query.
+    Limitations:
+    - Currently, cqlengine does not support SASI index creation. To use this feature,
+      you need to create the SASI index using the core driver.
+    - Queries using LIKE must use allow_filtering() since the *model* column has no
+      standard secondary index. Note that the server will use the SASI index properly
+      when executing the query.
 
 TimeUUID Functions
 ==================

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,6 +20,44 @@ You can use ``pip install --pre cassandra-driver`` if you need to install a beta
 
 ***Note**: if intending to use optional extensions, install the `dependencies <#optional-non-python-dependencies>`_ first. The driver may need to be reinstalled if dependencies are added after the initial installation.
 
+Speeding Up Installation
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, installing the driver through ``pip`` uses Cython to compile
+certain parts of the driver.
+This makes those hot paths faster at runtime, but the Cython compilation
+process can take a long time -- as long as 10 minutes in some environments.
+
+In environments where performance is less important, it may be worth it to
+:ref:`disable Cython as documented below <cython-extensions>`.
+You can also use ``CASS_DRIVER_BUILD_CONCURRENCY`` to increase the number of
+threads used to build the driver and any C extensions:
+
+    $ # installing from source
+    $ CASS_DRIVER_BUILD_CONCURRENCY=8 python setup.py install
+    $ # installing from pip
+    $ CASS_DRIVER_BUILD_CONCURRENCY=8 pip install cassandra-driver
+
+Finally, you can `build a wheel <https://packaging.python.org/tutorials/distributing-packages/#wheels>`_ from the driver's source and distribute that to computers
+that depend on it. For example:
+
+    $ git clone https://github.com/datastax/python-driver.git
+    $ cd python-driver
+    $ git checkout 3.14.0 # or other desired tag
+    $ pip install wheel
+    $ python setup.py bdist_wheel
+    $ # build wheel with optional concurrency settings
+    $ CASS_DRIVER_BUILD_CONCURRENCY=8 python setup.py bdist_wheel
+    $ scp ./dist/cassandra_driver-3.14.0-cp27-cp27mu-linux_x86_64.whl user@host:/remote_dir
+
+Then, on the remote machine or machines, simply
+
+    $ pip install /remote_dir/cassandra_driver-3.14.0-cp27-cp27mu-linux_x86_64.whl
+
+Note that the wheel created this way is a `platform wheel
+<https://packaging.python.org/tutorials/distributing-packages/#platform-wheels>`_
+and as such will not work across platforms or architectures.
+
 OSX Installation Error
 ^^^^^^^^^^^^^^^^^^^^^^
 If you're installing on OSX and have XCode 5.1 installed, you may see an error like this::
@@ -122,6 +160,8 @@ On RedHat and RedHat-based systems like CentOS and Fedora::
 On OS X, homebrew installations of Python should provide the necessary headers.
 
 See :ref:`windows_build` for notes on configuring the build environment on Windows.
+
+.. _cython-extensions:
 
 Cython-based Extensions
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,6 +33,8 @@ In environments where performance is less important, it may be worth it to
 You can also use ``CASS_DRIVER_BUILD_CONCURRENCY`` to increase the number of
 threads used to build the driver and any C extensions:
 
+.. code-block:: bash
+
     $ # installing from source
     $ CASS_DRIVER_BUILD_CONCURRENCY=8 python setup.py install
     $ # installing from pip
@@ -40,6 +42,8 @@ threads used to build the driver and any C extensions:
 
 Finally, you can `build a wheel <https://packaging.python.org/tutorials/distributing-packages/#wheels>`_ from the driver's source and distribute that to computers
 that depend on it. For example:
+
+.. code-block:: bash
 
     $ git clone https://github.com/datastax/python-driver.git
     $ cd python-driver
@@ -51,6 +55,8 @@ that depend on it. For example:
     $ scp ./dist/cassandra_driver-3.14.0-cp27-cp27mu-linux_x86_64.whl user@host:/remote_dir
 
 Then, on the remote machine or machines, simply
+
+.. code-block:: bash
 
     $ pip install /remote_dir/cassandra_driver-3.14.0-cp27-cp27mu-linux_x86_64.whl
 
@@ -64,7 +70,9 @@ If you're installing on OSX and have XCode 5.1 installed, you may see an error l
 
     clang: error: unknown argument: '-mno-fused-madd' [-Wunused-command-line-argument-hard-error-in-future]
 
-To fix this, re-run the installation with an extra compilation flag::
+To fix this, re-run the installation with an extra compilation flag:
+
+.. code-block:: bash
 
     ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future pip install cassandra-driver
 

--- a/docs/object_mapper.rst
+++ b/docs/object_mapper.rst
@@ -46,60 +46,60 @@ Contents
 Getting Started
 ---------------
 
-    .. code-block:: python
+.. code-block:: python
 
-        import uuid
-        from cassandra.cqlengine import columns
-        from cassandra.cqlengine import connection
-        from datetime import datetime
-        from cassandra.cqlengine.management import sync_table
-        from cassandra.cqlengine.models import Model
+    import uuid
+    from cassandra.cqlengine import columns
+    from cassandra.cqlengine import connection
+    from datetime import datetime
+    from cassandra.cqlengine.management import sync_table
+    from cassandra.cqlengine.models import Model
 
-        #first, define a model
-        class ExampleModel(Model):
-            example_id      = columns.UUID(primary_key=True, default=uuid.uuid4)
-            example_type    = columns.Integer(index=True)
-            created_at      = columns.DateTime()
-            description     = columns.Text(required=False)
+    #first, define a model
+    class ExampleModel(Model):
+        example_id      = columns.UUID(primary_key=True, default=uuid.uuid4)
+        example_type    = columns.Integer(index=True)
+        created_at      = columns.DateTime()
+        description     = columns.Text(required=False)
 
-        #next, setup the connection to your cassandra server(s)...
-        # see http://datastax.github.io/python-driver/api/cassandra/cluster.html for options
-        # the list of hosts will be passed to create a Cluster() instance
-        connection.setup(['127.0.0.1'], "cqlengine", protocol_version=3)
+    #next, setup the connection to your cassandra server(s)...
+    # see http://datastax.github.io/python-driver/api/cassandra/cluster.html for options
+    # the list of hosts will be passed to create a Cluster() instance
+    connection.setup(['127.0.0.1'], "cqlengine", protocol_version=3)
 
-        #...and create your CQL table
-        >>> sync_table(ExampleModel)
+    #...and create your CQL table
+    >>> sync_table(ExampleModel)
 
-        #now we can create some rows:
-        >>> em1 = ExampleModel.create(example_type=0, description="example1", created_at=datetime.now())
-        >>> em2 = ExampleModel.create(example_type=0, description="example2", created_at=datetime.now())
-        >>> em3 = ExampleModel.create(example_type=0, description="example3", created_at=datetime.now())
-        >>> em4 = ExampleModel.create(example_type=0, description="example4", created_at=datetime.now())
-        >>> em5 = ExampleModel.create(example_type=1, description="example5", created_at=datetime.now())
-        >>> em6 = ExampleModel.create(example_type=1, description="example6", created_at=datetime.now())
-        >>> em7 = ExampleModel.create(example_type=1, description="example7", created_at=datetime.now())
-        >>> em8 = ExampleModel.create(example_type=1, description="example8", created_at=datetime.now())
+    #now we can create some rows:
+    >>> em1 = ExampleModel.create(example_type=0, description="example1", created_at=datetime.now())
+    >>> em2 = ExampleModel.create(example_type=0, description="example2", created_at=datetime.now())
+    >>> em3 = ExampleModel.create(example_type=0, description="example3", created_at=datetime.now())
+    >>> em4 = ExampleModel.create(example_type=0, description="example4", created_at=datetime.now())
+    >>> em5 = ExampleModel.create(example_type=1, description="example5", created_at=datetime.now())
+    >>> em6 = ExampleModel.create(example_type=1, description="example6", created_at=datetime.now())
+    >>> em7 = ExampleModel.create(example_type=1, description="example7", created_at=datetime.now())
+    >>> em8 = ExampleModel.create(example_type=1, description="example8", created_at=datetime.now())
 
-        #and now we can run some queries against our table
-        >>> ExampleModel.objects.count()
-        8
-        >>> q = ExampleModel.objects(example_type=1)
-        >>> q.count()
-        4
-        >>> for instance in q:
-        >>>     print instance.description
-        example5
-        example6
-        example7
-        example8
+    #and now we can run some queries against our table
+    >>> ExampleModel.objects.count()
+    8
+    >>> q = ExampleModel.objects(example_type=1)
+    >>> q.count()
+    4
+    >>> for instance in q:
+    >>>     print instance.description
+    example5
+    example6
+    example7
+    example8
 
-        #here we are applying additional filtering to an existing query
-        #query objects are immutable, so calling filter returns a new
-        #query object
-        >>> q2 = q.filter(example_id=em5.example_id)
+    #here we are applying additional filtering to an existing query
+    #query objects are immutable, so calling filter returns a new
+    #query object
+    >>> q2 = q.filter(example_id=em5.example_id)
 
-        >>> q2.count()
-        1
-        >>> for instance in q2:
-        >>>     print instance.description
-        example5
+    >>> q2.count()
+    1
+    >>> for instance in q2:
+    >>>     print instance.description
+    example5


### PR DESCRIPTION
[PYTHON-868](https://datastax-oss.atlassian.net/browse/PYTHON-868): The most important bit here is the first commit, which documents how to work around/shorten/avoid long Cython compilation times. I've also removed a lot of indentation from parts of the docs where it's unnecessary -- I thought this would be necessary to fix some docs issues, but it turns out that's unrelated. However, I think that removing them is an improvement nonetheless, as it removes a bunch of meaningless `<blockquote>` blocks.