### PR TITLE
PYTHON-966: Allow filter queries with fields that have an index managed outside of cqlengine

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Features
 --------
 * Add one() function to the ResultSet API (PYTHON-947)
 * Create an utility function to fetch concurrently many keys from the same replica (PYTHON-647)
+* Allow filter queries with fields that have an index managed outside of cqlengine (PYTHON-966)
 
 Other
 -----

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -114,6 +114,13 @@ class Column(object):
     bool flag, indicates an index should be created for this column
     """
 
+    custom_index = False
+    """
+    bool flag, indicates an index is managed outside of cqlengine. This is
+    useful if you want to do filter queries on fields that have custom
+    indexes.
+    """
+
     db_field = None
     """
     the fieldname this field will map to in the database
@@ -161,10 +168,12 @@ class Column(object):
                  required=False,
                  clustering_order=None,
                  discriminator_column=False,
-                 static=False):
+                 static=False,
+                 custom_index=False):
         self.partition_key = partition_key
         self.primary_key = partition_key or primary_key
         self.index = index
+        self.custom_index = custom_index
         self.db_field = db_field
         self.default = default
         self.required = required
@@ -285,6 +294,10 @@ class Column(object):
     def db_index_name(self):
         """ Returns the name of the cql index """
         return 'index_{0}'.format(self.db_field_name)
+
+    @property
+    def has_index(self):
+        return self.index or self.custom_index
 
     @property
     def cql(self):

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -1076,8 +1076,9 @@ class ModelQuerySet(AbstractQuerySet):
         # custom indexes to be queried with any operator (a difference
         # between a secondary index)
         equal_ops = [self.model._get_column_by_db_name(w.field) \
-                     for w in self._where if (isinstance(w.operator, EqualsOperator) and not isinstance(w.value, Token))
-                     or self.model._get_column_by_db_name(w.field).custom_index]
+                     for w in self._where if not isinstance(w.value, Token)
+                     and (isinstance(w.operator, EqualsOperator)
+                          or self.model._get_column_by_db_name(w.field).custom_index)]
         token_comparison = any([w for w in self._where if isinstance(w.value, Token)])
         if not any(w.primary_key or w.has_index for w in equal_ops) and not token_comparison and not self._allow_filtering:
             raise QueryException(

--- a/docs/api/cassandra/cqlengine/columns.rst
+++ b/docs/api/cassandra/cqlengine/columns.rst
@@ -21,6 +21,8 @@ Columns
 
     .. autoattribute:: index
 
+    .. autoattribute:: custom_index
+
     .. autoattribute:: db_field
 
     .. autoattribute:: default

--- a/tests/integration/cqlengine/test_connections.py
+++ b/tests/integration/cqlengine/test_connections.py
@@ -536,6 +536,7 @@ class BaseConnectionTestNoDefault(object):
         conn.register_connection('cluster', [CASSANDRA_IP])
         test_queryset.TestModel.__queryset__ = ModelQuerySetNew
         test_queryset.IndexedTestModel.__queryset__ = ModelQuerySetNew
+        test_queryset.CustomIndexedTestModel.__queryset__ = ModelQuerySetNew
         test_queryset.IndexedCollectionsTestModel.__queryset__ = ModelQuerySetNew
         test_queryset.TestMultiClusteringModel.__queryset__ = ModelQuerySetNew
 


### PR DESCRIPTION
This PR will require some DSE tests with a dse-search index.