### PR TITLE
PYTHON-941 Improve error for batch WriteTimeouts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Other
 * Warn users when using the deprecated Session.default_consistency_level (PYTHON-953)
 * Add DSE smoke test to OSS driver tests (PYTHON-894)
 * Document long compilation times and workarounds (PYTHON-868)
+* Improve error for batch WriteTimeouts (PYTHON-941)
 
 3.13.0
 ======

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -409,16 +409,21 @@ class Timeout(RequestExecutionException):
     the operation
     """
 
-    def __init__(self, summary_message, **kwargs):
-        self.consistency = kwargs.get("consistency")
-        self.required_responses = kwargs.get("required_responses")
-        self.received_responses = kwargs.get("received_responses")
-        if "consistency" in kwargs:
-            kwargs["consistency"] = consistency_value_to_name(kwargs["consistency"])
+    def __init__(self, summary_message, consistency=None, required_responses=None,
+                 received_responses=None, **kwargs):
+        self.consistency = consistency
+        self.required_responses = required_responses
+        self.received_responses = received_responses
+
         if "write_type" in kwargs:
             kwargs["write_type"] = WriteType.value_to_name[kwargs["write_type"]]
 
-        Exception.__init__(self, summary_message + ' info=' + repr(kwargs))
+        info = {'consistency': consistency_value_to_name(consistency),
+                'required_responses': required_responses,
+                'received_responses': received_responses}
+        info.update(kwargs)
+
+        Exception.__init__(self, summary_message + ' info=' + repr(info))
 
 
 class ReadTimeout(Timeout):

--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -17,6 +17,14 @@ import logging
 from random import randint, shuffle
 from threading import Lock
 import socket
+from cassandra import WriteType as WT
+
+
+# This is done this way because WriteType was originally
+# defined here and in order not to break the API.
+# It may removed in the next mayor.
+WriteType = WT
+
 
 from cassandra import ConsistencyLevel, OperationTimedOut
 
@@ -688,72 +696,6 @@ class ExponentialReconnectionPolicy(ReconnectionPolicy):
                     yield self.max_delay
 
             i += 1
-
-
-class WriteType(object):
-    """
-    For usage with :class:`.RetryPolicy`, this describe a type
-    of write operation.
-    """
-
-    SIMPLE = 0
-    """
-    A write to a single partition key. Such writes are guaranteed to be atomic
-    and isolated.
-    """
-
-    BATCH = 1
-    """
-    A write to multiple partition keys that used the distributed batch log to
-    ensure atomicity.
-    """
-
-    UNLOGGED_BATCH = 2
-    """
-    A write to multiple partition keys that did not use the distributed batch
-    log. Atomicity for such writes is not guaranteed.
-    """
-
-    COUNTER = 3
-    """
-    A counter write (for one or multiple partition keys). Such writes should
-    not be replayed in order to avoid overcount.
-    """
-
-    BATCH_LOG = 4
-    """
-    The initial write to the distributed batch log that Cassandra performs
-    internally before a BATCH write.
-    """
-
-    CAS = 5
-    """
-    A lighweight-transaction write, such as "DELETE ... IF EXISTS".
-    """
-
-    VIEW = 6
-    """
-    This WriteType is only seen in results for requests that were unable to
-    complete MV operations.
-    """
-
-    CDC = 7
-    """
-    This WriteType is only seen in results for requests that were unable to
-    complete CDC operations.
-    """
-
-
-WriteType.name_to_value = {
-    'SIMPLE': WriteType.SIMPLE,
-    'BATCH': WriteType.BATCH,
-    'UNLOGGED_BATCH': WriteType.UNLOGGED_BATCH,
-    'COUNTER': WriteType.COUNTER,
-    'BATCH_LOG': WriteType.BATCH_LOG,
-    'CAS': WriteType.CAS,
-    'VIEW': WriteType.VIEW,
-    'CDC': WriteType.CDC
-}
 
 
 class RetryPolicy(object):

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -40,7 +40,7 @@ from cassandra.cqltypes import (AsciiType, BytesType, BooleanType,
                                 UTF8Type, VarcharType, UUIDType, UserType,
                                 TupleType, lookup_casstype, SimpleDateType,
                                 TimeType, ByteType, ShortType, DurationType)
-from cassandra.policies import WriteType
+from cassandra import WriteType
 from cassandra.cython_deps import HAVE_CYTHON, HAVE_NUMPY
 from cassandra import util
 

--- a/tests/integration/simulacron/test_cluster.py
+++ b/tests/integration/simulacron/test_cluster.py
@@ -1,0 +1,55 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa
+
+from tests.integration.simulacron import SimulacronCluster
+from tests.integration import requiressimulacron
+from tests.integration.simulacron.utils import prime_query
+
+from cassandra import WriteTimeout, WriteType, ConsistencyLevel
+
+@requiressimulacron
+class ClusterTests(SimulacronCluster):
+    def test_writetimeout(self):
+        write_type = "UNLOGGED_BATCH"
+        consistency = "LOCAL_QUORUM"
+        received_responses = 1
+        required_responses = 4
+
+        query_to_prime_simple = "SELECT * from simulacron_keyspace.simple"
+        then = {
+            "result": "write_timeout",
+            "delay_in_ms": 0,
+            "consistency_level": consistency,
+            "received": received_responses,
+            "block_for": required_responses,
+            "write_type": write_type,
+            "ignore_on_prepare": True
+        }
+        prime_query(query_to_prime_simple, then=then, rows=None, column_types=None)
+
+        try:
+            self.session.execute(query_to_prime_simple)
+        except WriteTimeout as wt:
+            self.assertEqual(wt.write_type, WriteType.name_to_value[write_type])
+            self.assertEqual(wt.consistency, ConsistencyLevel.name_to_value[consistency])
+            self.assertEqual(wt.received_responses, received_responses)
+            self.assertEqual(wt.required_responses, required_responses)
+            self.assertIn(write_type, str(wt))
+            self.assertIn(consistency, str(wt))
+            self.assertIn(str(received_responses), str(wt))
+            self.assertIn(str(required_responses), str(wt))

--- a/tests/integration/simulacron/test_cluster.py
+++ b/tests/integration/simulacron/test_cluster.py
@@ -42,14 +42,14 @@ class ClusterTests(SimulacronCluster):
         }
         prime_query(query_to_prime_simple, then=then, rows=None, column_types=None)
 
-        try:
+        with self.assertRaises(WriteTimeout) as assert_raised_context:
             self.session.execute(query_to_prime_simple)
-        except WriteTimeout as wt:
-            self.assertEqual(wt.write_type, WriteType.name_to_value[write_type])
-            self.assertEqual(wt.consistency, ConsistencyLevel.name_to_value[consistency])
-            self.assertEqual(wt.received_responses, received_responses)
-            self.assertEqual(wt.required_responses, required_responses)
-            self.assertIn(write_type, str(wt))
-            self.assertIn(consistency, str(wt))
-            self.assertIn(str(received_responses), str(wt))
-            self.assertIn(str(required_responses), str(wt))
+        wt = assert_raised_context.exception
+        self.assertEqual(wt.write_type, WriteType.name_to_value[write_type])
+        self.assertEqual(wt.consistency, ConsistencyLevel.name_to_value[consistency])
+        self.assertEqual(wt.received_responses, received_responses)
+        self.assertEqual(wt.required_responses, required_responses)
+        self.assertIn(write_type, str(wt))
+        self.assertIn(consistency, str(wt))
+        self.assertIn(str(received_responses), str(wt))
+        self.assertIn(str(required_responses), str(wt))

--- a/tests/integration/simulacron/test_policies.py
+++ b/tests/integration/simulacron/test_policies.py
@@ -29,8 +29,8 @@ from tests.integration.simulacron.utils import start_and_prime_singledc, prime_q
 from itertools import count
 from packaging.version import Version
 
-class BadRoundRobinPolicy(RoundRobinPolicy):
 
+class BadRoundRobinPolicy(RoundRobinPolicy):
     def make_query_plan(self, working_keyspace=None, query=None):
         pos = self._position
         self._position += 1
@@ -293,6 +293,7 @@ class RetryPolicyTests(unittest.TestCase):
 
         with self.assertRaises(WriteTimeout):
             self.session.execute(query_to_prime_simple)
+
         #CDC should be ignored
         self.session.execute(query_to_prime_cdc)
 


### PR DESCRIPTION
Many changes just to add something an error message, but we were getting circular import errors if we leaved `WriteType` in policies