### PR TITLE
tox: remove 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/README-dev.rst
+++ b/README-dev.rst
@@ -124,7 +124,7 @@ it with the ``PROTOCOL_VERSION`` environment variable::
 
 Testing Multiple Python Versions
 --------------------------------
-If you want to test all of python 2.7, 3.3, 3.4 and pypy, use tox (this is what
+If you want to test all of python 2.7, 3.4, 3.5, 3.6 and pypy, use tox (this is what
 TravisCI runs)::
 
     tox

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ DataStax Python Driver for Apache Cassandra
 
 A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ and highly-tunable Python client library for Apache Cassandra (2.1+) using exclusively Cassandra's binary protocol and Cassandra Query Language v3.
 
-The driver supports Python 2.7, 3.3, 3.4, 3.5, and 3.6.
+The driver supports Python 2.7, 3.4, 3.5, and 3.6.
 
 If you require compatibility with DataStax Enterprise, use the `DataStax Enterprise Python Driver <http://docs.datastax.com/en/developer/python-dse-driver/>`_.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ A Python client driver for `Apache Cassandra <http://cassandra.apache.org>`_.
 This driver works exclusively with the Cassandra Query Language v3 (CQL3)
 and Cassandra's native protocol.  Cassandra 2.1+ is supported.
 
-The driver supports Python 2.7, 3.3, 3.4, 3.5, and 3.6.
+The driver supports Python 2.7, 3.4, 3.5, and 3.6.
 
 This driver is open source under the
 `Apache v2 License <http://www.apache.org/licenses/LICENSE-2.0.html>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Supported Platforms
 -------------------
-Python 2.6, 2.7, 3.3, and 3.4 are supported.  Both CPython (the standard Python
+Python 2.7, 3.4, 3.5 and 3.6 are supported.  Both CPython (the standard Python
 implementation) and `PyPy <http://pypy.org>`_ are supported and tested.
 
 Linux, OSX, and Windows are supported.

--- a/setup.py
+++ b/setup.py
@@ -429,7 +429,6 @@ def run_setup(extensions):
             'Operating System :: OS Independent',
             'Programming Language :: Python',
             'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35,36},pypy
+envlist = py{27,34,35,36},pypy
 
 [base]
 deps = nose


### PR DESCRIPTION
3.3 has been removed from Travis, and it could start running the tests on 3.7