### PR TITLE
gevent: requires ares.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
     - build-essential
     - python-dev
     - pypy-dev
+    - libc-ares-dev
     - libev4
     - libev-dev
 


### PR DESCRIPTION
Fixing the pypy tests, for 3.3 (see #953)