### PR TITLE
tox: enable python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
+dist: xenial
+sudo: false
+
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy-5.4.1"
+  - "3.7"
+  - "pypy2.7-6.0"
+  - "pypy3.5"
 
-sudo: false
 env:
   - CASS_DRIVER_NO_CYTHON=1
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,6 @@ nose
 mock!=1.1.*
 ccm>=2.0
 unittest2
-PyYAML
 pytz
 sure
 pure-sasl

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py{27,34,35,36},pypy
+envlist = py{27,34,35,36,37},pypy
+skip_missing_interpreters = True
 
 [base]
 deps = nose
        mock<=1.0.1
-       PyYAML
        six
        packaging
        cython


### PR DESCRIPTION
Enables 3.7-dev tests on travis

also removes PyYAML which is not used by anyone and fails on 3.7