### PR TITLE
Python test cluster pep8 fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Bug Fixes
 ---------
 * Tokenmap.get_replicas returns the wrong value if token coincides with the end of the range (PYTHON-978)
 * Python Driver fails with "more than 255 arguments" python exception when > 255 columns specified in query response (PYTHON-893)
+* Hang in integration.standard.test_cluster.ClusterTests.test_set_keyspace_twice (PYTHON-998)
 
 Other
 -----

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -251,7 +251,7 @@ class ClusterTests(unittest.TestCase):
         """
 
         cluster = Cluster()
-        self.assertLessEqual(cluster.protocol_version,  cassandra.ProtocolVersion.MAX_SUPPORTED)
+        self.assertLessEqual(cluster.protocol_version, cassandra.ProtocolVersion.MAX_SUPPORTED)
         session = cluster.connect()
         updated_protocol_version = session._protocol_version
         updated_cluster_version = cluster.protocol_version
@@ -582,7 +582,7 @@ class ClusterTests(unittest.TestCase):
         cluster = Cluster(protocol_version=PROTOCOL_VERSION)
         session = cluster.connect()
 
-        result = session.execute( "SELECT * FROM system.local", trace=True)
+        result = session.execute("SELECT * FROM system.local", trace=True)
         self._check_trace(result.get_query_trace())
 
         query = "SELECT * FROM system.local"
@@ -759,7 +759,7 @@ class ClusterTests(unittest.TestCase):
                     connection_request_ids[id(c)] = deque(c.request_ids)  # copy of request ids
 
         # let two heatbeat intervals pass (first one had startup messages in it)
-        time.sleep(2 * interval + interval/2)
+        time.sleep(2 * interval + interval / 2)
 
         connections = [c for holders in cluster.get_connection_holders() for c in holders.get_connections()]
 

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -513,7 +513,6 @@ class ClusterTests(unittest.TestCase):
         new_schema_ver = uuid4()
         session.execute("UPDATE system.local SET schema_version=%s WHERE key='local'", (new_schema_ver,))
 
-
         try:
             agreement_timeout = 1
 
@@ -645,7 +644,6 @@ class ClusterTests(unittest.TestCase):
                 break
         else:
             raise Exception("get_query_trace didn't raise TraceUnavailable after {} tries".format(max_retry_count))
-
 
         for i in range(max_retry_count):
             future = session.execute_async(statement, trace=True)
@@ -1234,6 +1232,7 @@ class LocalHostAdressTranslator(AddressTranslator):
     def translate(self, addr):
         new_addr = self.addr_map.get(addr)
         return new_addr
+
 
 @local
 class TestAddressTranslation(unittest.TestCase):

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -200,23 +200,31 @@ class ClusterTests(unittest.TestCase):
 
         @test_category connection
         """
+        def cleanup():
+            """
+            When this test fails, the inline .shutdown() calls don't get
+            called, so we register this as a cleanup.
+            """
+            self.cluster_to_shutdown.shutdown()
+        self.addCleanup(cleanup)
+
         # Test with empty list
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        self.cluster_to_shutdown = Cluster(protocol_version=PROTOCOL_VERSION)
         with self.assertRaises(NoHostAvailable):
-            Session(cluster, [])
-        cluster.shutdown()
+            Session(self.cluster_to_shutdown, [])
+        self.cluster_to_shutdown.shutdown()
 
         # Test with only invalid
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        self.cluster_to_shutdown = Cluster(protocol_version=PROTOCOL_VERSION)
         with self.assertRaises(NoHostAvailable):
-            Session(cluster, [Host("1.2.3.4", SimpleConvictionPolicy)])
-        cluster.shutdown()
+            Session(self.cluster_to_shutdown, [Host("1.2.3.4", SimpleConvictionPolicy)])
+        self.cluster_to_shutdown.shutdown()
 
         # Test with valid and invalid hosts
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
-        Session(cluster, [Host(x, SimpleConvictionPolicy) for x in
-                                      ("127.0.0.1", "127.0.0.2", "1.2.3.4")])
-        cluster.shutdown()
+        self.cluster_to_shutdown = Cluster(protocol_version=PROTOCOL_VERSION)
+        Session(self.cluster_to_shutdown, [Host(x, SimpleConvictionPolicy) for x in
+                                           ("127.0.0.1", "127.0.0.2", "1.2.3.4")])
+        self.cluster_to_shutdown.shutdown()
 
     def test_protocol_negotiation(self):
         """

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -369,7 +369,8 @@ class ClusterTests(unittest.TestCase):
         """
         Check for v2 auth_provider compliance
         """
-        bad_auth_provider = lambda x: {'username': 'foo', 'password': 'bar'}
+        def bad_auth_provider(_):
+            return {'username': 'foo', 'password': 'bar'}
         self.assertRaises(TypeError, Cluster, auth_provider=bad_auth_provider, protocol_version=2)
         c = Cluster(protocol_version=2)
         self.assertRaises(TypeError, setattr, c, 'auth_provider', bad_auth_provider)

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -161,14 +161,16 @@ class ClusterTests(unittest.TestCase):
 
         cluster = Cluster(protocol_version=PROTOCOL_VERSION)
         session = cluster.connect()
-        result = execute_until_pass(session,
+        result = execute_until_pass(
+            session,
             """
             CREATE KEYSPACE clustertests
             WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'}
             """)
         self.assertFalse(result)
 
-        result = execute_with_long_wait_retry(session,
+        result = execute_with_long_wait_retry(
+            session,
             """
             CREATE TABLE clustertests.cf0 (
                 a text,
@@ -1133,8 +1135,10 @@ class ClusterTests(unittest.TestCase):
         available_hosts = [host for host in ["127.0.0.1", "127.0.0.2", "127.0.0.3"] if host != only_replica]
         with Cluster(contact_points=available_hosts,
                      protocol_version=PROTOCOL_VERSION,
-                     load_balancing_policy=HostFilterPolicy(RoundRobinPolicy(),
-                     predicate=lambda host: host.address != only_replica)) as cluster:
+                     load_balancing_policy=HostFilterPolicy(
+                         RoundRobinPolicy(),
+                         predicate=lambda host: host.address != only_replica)
+                     ) as cluster:
 
             session = cluster.connect(wait_for_all_pools=True)
             prepared = session.prepare("""SELECT * from test1rf.table_with_big_key
@@ -1274,15 +1278,19 @@ class TestAddressTranslation(unittest.TestCase):
             self.assertEqual(adder_map.get(str(host)), host.broadcast_address)
         c.shutdown()
 
+
 @local
 class ContextManagementTest(unittest.TestCase):
     load_balancing_policy = HostFilterPolicy(
         RoundRobinPolicy(), lambda host: host.address == CASSANDRA_IP
     )
-    cluster_kwargs = {'execution_profiles': {EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=
-                                                                                    load_balancing_policy)},
-                      'schema_metadata_enabled': False,
-                      'token_metadata_enabled': False}
+    cluster_kwargs = {
+        'execution_profiles': {
+            EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=load_balancing_policy)
+        },
+        'schema_metadata_enabled': False,
+        'token_metadata_enabled': False
+    }
 
     def test_no_connect(self):
         """

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -85,7 +85,7 @@ class ClusterTests(unittest.TestCase):
         """
         ingored_host_policy = IgnoredHostPolicy(["127.0.0.2", "127.0.0.3"])
         cluster = Cluster(protocol_version=PROTOCOL_VERSION, load_balancing_policy=ingored_host_policy)
-        session = cluster.connect()
+        cluster.connect()
         for host in cluster.metadata.all_hosts():
             if str(host) == "127.0.0.1":
                 self.assertTrue(host.is_up)
@@ -420,7 +420,7 @@ class ClusterTests(unittest.TestCase):
 
     def test_refresh_schema(self):
         cluster = Cluster(protocol_version=PROTOCOL_VERSION)
-        session = cluster.connect()
+        cluster.connect()
 
         original_meta = cluster.metadata.keyspaces
         # full schema refresh, with wait
@@ -432,7 +432,7 @@ class ClusterTests(unittest.TestCase):
 
     def test_refresh_schema_keyspace(self):
         cluster = Cluster(protocol_version=PROTOCOL_VERSION)
-        session = cluster.connect()
+        cluster.connect()
 
         original_meta = cluster.metadata.keyspaces
         original_system_meta = original_meta['system']
@@ -448,7 +448,7 @@ class ClusterTests(unittest.TestCase):
 
     def test_refresh_schema_table(self):
         cluster = Cluster(protocol_version=PROTOCOL_VERSION)
-        session = cluster.connect()
+        cluster.connect()
 
         original_meta = cluster.metadata.keyspaces
         original_system_meta = original_meta['system']
@@ -542,7 +542,7 @@ class ClusterTests(unittest.TestCase):
             # cluster agreement bypass
             c = Cluster(protocol_version=PROTOCOL_VERSION, max_schema_agreement_wait=0)
             start_time = time.time()
-            s = c.connect()
+            c.connect()
             end_time = time.time()
             self.assertLess(end_time - start_time, refresh_threshold)
             self.assertTrue(c.metadata.keyspaces)
@@ -786,7 +786,7 @@ class ClusterTests(unittest.TestCase):
         self.assertEqual(len(holders), len(cluster.metadata.all_hosts()) + 1)  # hosts pools, 1 for cc
 
         # include additional sessions
-        session2 = cluster.connect(wait_for_all_pools=True)
+        cluster.connect(wait_for_all_pools=True)
 
         holders = cluster.get_connection_holders()
         self.assertIn(cluster.control_connection, holders)
@@ -805,7 +805,7 @@ class ClusterTests(unittest.TestCase):
         # heartbeat disabled with '0'
         cluster = Cluster(protocol_version=PROTOCOL_VERSION, idle_heartbeat_interval=0)
         self.assertEqual(cluster.idle_heartbeat_interval, 0)
-        session = cluster.connect()
+        cluster.connect()
 
         # let two heatbeat intervals pass (first one had startup messages in it)
         time.sleep(2 * Cluster.idle_heartbeat_interval)
@@ -821,7 +821,7 @@ class ClusterTests(unittest.TestCase):
         # Ensure that in_flight and request_ids quiesce after cluster operations
         cluster = Cluster(protocol_version=PROTOCOL_VERSION, idle_heartbeat_interval=0)  # no idle heartbeat here, pool management is tested in test_idle_heartbeat
         session = cluster.connect()
-        session2 = cluster.connect()
+        cluster.connect()
 
         # prepare
         p = session.prepare("SELECT * FROM system.local WHERE key=?")
@@ -936,7 +936,7 @@ class ClusterTests(unittest.TestCase):
             session = cluster.connect(wait_for_all_pools=True)
 
             # default is DCA RR for all hosts
-            expected_hosts = set(cluster.metadata.all_hosts())
+            set(cluster.metadata.all_hosts())
             rr1_queried_hosts = set()
             rr2_queried_hosts = set()
 
@@ -962,7 +962,7 @@ class ClusterTests(unittest.TestCase):
         with Cluster() as cluster:
             session = cluster.connect()
             cluster.add_execution_profile("ta1", ta1)
-            rs = session.execute(query, execution_profile='ta1')
+            session.execute(query, execution_profile='ta1')
 
     def test_clone_shared_lbp(self):
         """

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -17,33 +17,40 @@ try:
 except ImportError:
     import unittest  # noqa
 
+import logging
+import sys
+import time
+import warnings
 from collections import deque
 from copy import copy
-from mock import Mock, call, patch
-import time
 from uuid import uuid4
-import logging
-import warnings
+
+from mock import Mock, call, patch
 from packaging.version import Version
 
 import cassandra
-from cassandra.cluster import Cluster, NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT
-from cassandra.concurrent import execute_concurrent
-from cassandra.policies import (RoundRobinPolicy, ExponentialReconnectionPolicy,
-                                RetryPolicy, SimpleConvictionPolicy, HostDistance,
-                                AddressTranslator, TokenAwarePolicy, HostFilterPolicy)
-from cassandra import ConsistencyLevel
-
-from cassandra.query import SimpleStatement, TraceUnavailable, tuple_factory
+from cassandra import ConsistencyLevel, connection
 from cassandra.auth import PlainTextAuthProvider, SaslAuthProvider
-from cassandra import connection
-
+from cassandra.cluster import (EXEC_PROFILE_DEFAULT, Cluster, ExecutionProfile,
+                               NoHostAvailable)
+from cassandra.concurrent import execute_concurrent
+from cassandra.policies import (AddressTranslator,
+                                ExponentialReconnectionPolicy, HostDistance,
+                                HostFilterPolicy, RetryPolicy,
+                                RoundRobinPolicy, SimpleConvictionPolicy,
+                                TokenAwarePolicy)
+from cassandra.query import SimpleStatement, TraceUnavailable, tuple_factory
 from tests import notwindows
-from tests.integration import use_singledc, PROTOCOL_VERSION, get_server_versions, CASSANDRA_VERSION, \
-    execute_until_pass, execute_with_long_wait_retry, get_node, MockLoggingHandler, get_unsupported_lower_protocol, \
-    get_unsupported_upper_protocol, protocolv5, local, CASSANDRA_IP, greaterthanorequalcass30, lessthanorequalcass40
+from tests.integration import (CASSANDRA_IP, CASSANDRA_VERSION,
+                               PROTOCOL_VERSION, MockLoggingHandler,
+                               execute_until_pass,
+                               execute_with_long_wait_retry, get_node,
+                               get_server_versions,
+                               get_unsupported_lower_protocol,
+                               get_unsupported_upper_protocol,
+                               greaterthanorequalcass30, lessthanorequalcass40,
+                               local, protocolv5, use_singledc)
 from tests.integration.util import assert_quiescent_pool_state
-import sys
 
 
 def setup_module():


### PR DESCRIPTION
Cleanup post #966; don't merge if that PR isn't merged. Just some cleanup in test_cluster; can be squashed on commit.