### PR TITLE
Fix UDT changed behavior with updating fields of UDT

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -979,15 +979,13 @@ class Map(BaseContainerColumn):
 class UDTValueManager(BaseValueManager):
     @property
     def changed(self):
-        if self.explicit:
-            return self.value != self.previous_value
+        if self.explicit or self.previous_value is not None:
+            return self.value != self.previous_value or \
+                   (self.value is not None and self.value.has_changed_fields())
 
         default_value = self.column.get_default()
         if not self.column._val_is_null(default_value):
             return self.value != default_value
-        elif self.previous_value is None:
-            return not self.column._val_is_null(self.value) and self.value.has_changed_fields()
-
         return False
 
     def reset_previous_value(self):

--- a/tests/integration/cqlengine/model/test_updates.py
+++ b/tests/integration/cqlengine/model/test_updates.py
@@ -346,6 +346,24 @@ class ModelWithDefaultTests(BaseCassEngTestCase):
         self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(),
                          {'id': 2, 'dummy': 2, 'mf': {1: 1, 4: 4}, "udt": udt, "udt_default": udt_default})
 
+        # test update udt object
+        udt_default.age = 2
+        item.update(udt_default=udt_default)
+        self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(), item._as_dict())
+        self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(),
+                         {'id': 2, 'dummy': 2, 'mf': {1: 1, 4: 4}, "udt": udt, "udt_default": udt_default})
+
+        udt_default.age = 3
+        item.save()
+        self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(), item._as_dict())
+        self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(),
+                         {'id': 2, 'dummy': 2, 'mf': {1: 1, 4: 4}, "udt": udt, "udt_default": udt_default})
+
+        udt_default.age = 1
+        item.save()
+        self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(), item._as_dict())
+        self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(),
+                         {'id': 2, 'dummy': 2, 'mf': {1: 1, 4: 4}, "udt": udt, "udt_default": udt_default})
 
     def test_udt_to_python(self):
         """

--- a/tests/integration/cqlengine/model/test_updates.py
+++ b/tests/integration/cqlengine/model/test_updates.py
@@ -346,19 +346,21 @@ class ModelWithDefaultTests(BaseCassEngTestCase):
         self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(),
                          {'id': 2, 'dummy': 2, 'mf': {1: 1, 4: 4}, "udt": udt, "udt_default": udt_default})
 
-        # test update udt object
+        # test update udt fields
         udt_default.age = 2
         item.update(udt_default=udt_default)
         self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(), item._as_dict())
         self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(),
                          {'id': 2, 'dummy': 2, 'mf': {1: 1, 4: 4}, "udt": udt, "udt_default": udt_default})
 
+        # test update udt fields implicitly
         udt_default.age = 3
         item.save()
         self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(), item._as_dict())
         self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(),
                          {'id': 2, 'dummy': 2, 'mf': {1: 1, 4: 4}, "udt": udt, "udt_default": udt_default})
 
+        # test update udt fields to default value implicitly
         udt_default.age = 1
         item.save()
         self.assertEqual(ModelWithDefaultCollection.objects.get(id=2)._as_dict(), item._as_dict())


### PR DESCRIPTION
### Issue: It doesn't work when only updating fields of UDT.

```python
item.udt.age = 1
item.save()

# or 
item.update(udt=item.udt)
```
In these cases, cqlengine won't treat `udt` as `changed`.