### PR TITLE
Fire callbacks on ResponseFutures before unleashing result()

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3948,11 +3948,15 @@ class ResponseFuture(object):
                 for (fn, args, kwargs) in self._callbacks
             )
 
-        self._event.set()
-
         # apply each callback
         for callback_partial in to_call:
             callback_partial()
+
+        # this should come after the callbacks are fired so that when mixing
+        # callbacks and .result() we know the callbacks are all done by the
+        # time .result() returns.
+        self._event.set()
+
 
     def _set_final_exception(self, response):
         self._cancel_timer()
@@ -3969,11 +3973,15 @@ class ResponseFuture(object):
                 partial(fn, response, *args, **kwargs)
                 for (fn, args, kwargs) in self._errbacks
             )
-        self._event.set()
 
         # apply each callback
         for callback_partial in to_call:
             callback_partial()
+
+        # this should come after the callbacks are fired so that when mixing
+        # callbacks and .result() we know the callbacks are all done by the
+        # time .result() returns.
+        self._event.set()
 
     def _retry(self, reuse_connection, consistency_level, host):
         if self._final_exception:


### PR DESCRIPTION
When callbacks and blocking on .result() are mixed, it's currently a
race for which happens first. By flipping the order of operations here,
we guarantee that the callbacks are all complete before unleashing the
main thread. This makes it possible to reliably do stuff with callbacks
like collect metrics while the main application uses .result().

For reference, here's [the issue described in another context](https://github.com/reddit/baseplate/issues/100) and [the code in question](https://github.com/reddit/baseplate/blob/master/baseplate/context/cassandra.py#L134-L152).

I'm submitting this as a straw-man. I'm not sure what the downsides of flipping this would be but figured a diff would be the best way to show what I had in mind.

p.s. It appears the mailing list in the README is non-existent and the Slack
requires agreeing to various legal agreements for DataStax Academy to get
access. Sorry if jumping straight to a PR was bad form.
