### PR TITLE
Python 1008

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@
 Bug Fixes
 ---------
 * Improve and fix socket error-catching code in nonblocking-socket reactors (PYTHON-1024)
+* Non-ASCII characters in schema break CQL string generation (PYTHON-1008)
 
 Other
 -----

--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -224,12 +224,15 @@ class Encoder(object):
         """
         return '{%s}' % ', '.join(self.mapping.get(type(v), self.cql_encode_object)(v) for v in val)
 
-    def cql_encode_all_types(self, val):
+    def cql_encode_all_types(self, val, as_text_type=False):
         """
         Converts any type into a CQL string, defaulting to ``cql_encode_object``
         if :attr:`~Encoder.mapping` does not contain an entry for the type.
         """
-        return self.mapping.get(type(val), self.cql_encode_object)(val)
+        encoded = self.mapping.get(type(val), self.cql_encode_object)(val)
+        if as_text_type and not isinstance(encoded, six.text_type):
+            return encoded.decode('utf-8')
+        return encoded
 
     if six.PY3:
         def cql_encode_ipaddress(self, val):

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1435,10 +1435,8 @@ class IndexMetadata(object):
                 index_target,
                 class_name)
             if options:
-                opts_cql_encoded = _encoder.cql_encode_all_types(options)
-                # PYTHON-1008
-                if isinstance(opts_cql_encoded, six.binary_type):
-                    opts_cql_encoded = opts_cql_encoded.decode('utf-8')
+                # PYTHON-1008: `ret` will always be a unicode
+                opts_cql_encoded = _encoder.cql_encode_all_types(options, as_text_type=True)
                 ret += " WITH OPTIONS = %s" % opts_cql_encoded
             return ret
 

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1435,7 +1435,7 @@ class IndexMetadata(object):
                 index_target,
                 class_name)
             if options:
-                opts_cql_encoded = Encoder().cql_encode_all_types(options)
+                opts_cql_encoded = _encoder.cql_encode_all_types(options)
                 # PYTHON-1008
                 if isinstance(opts_cql_encoded, six.binary_type):
                     opts_cql_encoded = opts_cql_encoded.decode('utf-8')

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1435,7 +1435,11 @@ class IndexMetadata(object):
                 index_target,
                 class_name)
             if options:
-                ret += " WITH OPTIONS = %s" % Encoder().cql_encode_all_types(options)
+                opts_cql_encoded = Encoder().cql_encode_all_types(options)
+                # PYTHON-1008
+                if isinstance(opts_cql_encoded, six.binary_type):
+                    opts_cql_encoded = opts_cql_encoded.decode('utf-8')
+                ret += " WITH OPTIONS = %s" % opts_cql_encoded
             return ret
 
     def export_as_string(self):

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -18,6 +18,7 @@ except ImportError:
     import unittest  # noqa
 
 from binascii import unhexlify
+import logging
 from mock import Mock
 import os
 import six
@@ -36,6 +37,9 @@ from cassandra.metadata import (Murmur3Token, MD5Token,
                                 Metadata, TokenMap)
 from cassandra.policies import SimpleConvictionPolicy
 from cassandra.pool import Host
+
+
+log = logging.getLogger(__name__)
 
 
 class StrategiesTest(unittest.TestCase):
@@ -536,9 +540,12 @@ class UnicodeIdentifiersTests(unittest.TestCase):
 
     def test_index(self):
         im = IndexMetadata(self.name, self.name, self.name, kind='', index_options={'target': self.name})
-        im.export_as_string()
+        log.debug(im.export_as_string())
         im = IndexMetadata(self.name, self.name, self.name, kind='CUSTOM', index_options={'target': self.name, 'class_name': 'Class'})
-        im.export_as_string()
+        log.debug(im.export_as_string())
+        # PYTHON-1008
+        im = IndexMetadata(self.name, self.name, self.name, kind='CUSTOM', index_options={'target': self.name, 'class_name': 'Class', 'delimiter': self.name})
+        log.debug(im.export_as_string())
 
     def test_function(self):
         fm = Function(self.name, self.name, (u'int', u'int'), (u'x', u'y'), u'int', u'language', self.name, False)


### PR DESCRIPTION
Adds a failing test, and then a fix, for [PYTHON-1008](https://datastax-oss.atlassian.net/browse/PYTHON-1008). I explained the bug in a commit message, reproduced below:

>The CREATE CUSTOM INDEX statement initially generated in
`IndexMetadata.as_cql_query` is always a `unicode` object under Python 2,
because they are derived from CQL `text` fields in in
`system_schema.indexes`, and we serialize the bytes we get from
`text`-type values with `.encode('utf-8')`.

>The result of `cql_encode_all_types` is always a `six.binary_type`, i.e.
a `str` under Python 2.

>Notably, Python 2 `str` objects cannot be cast to `unicode` objects if
they contain non-ASCII characters, including those used to encode
Unicode characters in UTF-8. These casting errors can occur during
attempts to concatenate these objects:

```
>>> u"I'm a `unicode` object" + ", and I am a `str`."
u"I'm a `unicode` object, and I am a `str`."
>>> u"I'm a `unicode` object" + ", and I am a `str` with unicode code points \xf0\x9f\x98\xac"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xf0 in position 45: ordinal not in range(128)
```

>So, the error reported in CASSANDRA-14632 happens when we try to
concatenate a `str` containing escaped UTF-8 bytes, as generated by
`cql_encode_all_types`, onto `ret`, a `unicode`.

>Since we know `ret` is always a `six.text_type`, we can check if we need
to convert the result of `cql_encode_all_types`, and do so. We should
only ever need to under Python 2.
