### PR TITLE
Improve error messages on persistent schema disagreements 

### DIFF
--- a/tests/integration/long/test_schema.py
+++ b/tests/integration/long/test_schema.py
@@ -142,7 +142,7 @@ class SchemaTests(unittest.TestCase):
         rs = session.execute("DROP KEYSPACE test_schema_disagreement")
         self.check_and_wait_for_agreement(session, rs, False)
         cluster.shutdown()
-        
+
         # These should have schema agreement
         cluster = Cluster(protocol_version=PROTOCOL_VERSION, max_schema_agreement_wait=100)
         session = cluster.connect()

--- a/tests/integration/long/test_schema.py
+++ b/tests/integration/long/test_schema.py
@@ -158,4 +158,12 @@ class SchemaTests(unittest.TestCase):
     def check_and_wait_for_agreement(self, session, rs, exepected):
         self.assertEqual(rs.response_future.is_schema_agreed, exepected)
         if not rs.response_future.is_schema_agreed:
-            session.cluster.control_connection.wait_for_schema_agreement(wait_time=1000)
+            cc = session.cluster.control_connection
+            agreed = cc.wait_for_schema_agreement(wait_time=1000)
+            self.assertTrue(
+                agreed,
+                ('schema {agreed_or_not} as expected at checking time, but '
+                 'then schemas did not agree; cannot continue test'.format(
+                     agreed_or_not=('agreed' if exepected else 'did not agree')
+                 ))
+            )


### PR DESCRIPTION
`wait_for_schema_agreement` doesn't raise an exception if the schema doesn't agree, so this change adds a check for its result. If we see failures as a result of persistent schema disagreements, they'll have the new error message instead of more confusing C* errors.

I made this change when I saw the failure in [this test run](http://jenkins-devtools.datastax.lan/job/datastax.python-driver.master.nightly_master/30/CASSANDRA_VERSION=3.11,CYTHON=CYTHON,OS_VERSION=ubuntu%2Fbionic64%2Fpython-driver,PYTHON_VERSION=3.5/testReport/junit/tests.integration.long.test_schema/SchemaTests/test_for_schema_disagreement_attribute/). If the test failed because the schema update failed entirely, then this change won't help improve the error. However, I think this change does improve the message in other failure cases.