### PR TITLE
avoid python3.7 deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+3.18.1
+======
+NOT RELEASED
+
+Other
+-----
+
+* Avoid deprecation warnings when using Python 3.7 (PYTHON-1023)
+
 3.18.0
 ======
 May 27, 2019
@@ -46,16 +55,7 @@ Bug Fixes
 Other
 -----
 * Fail faster on incorrect lz4 import (PYTHON-1042)
-* Bump Cython dependency version to 0.29 (PYTHON-1036)
-* Expand Driver SSL Documentation (PYTHON-740)
 
-Deprecations
-------------
-
-* Using Cluster.ssl_options to enable SSL is deprecated and will be removed in
-  the next major release, use ssl_context.
-* DowngradingConsistencyRetryPolicy is deprecated and will be
-  removed in the next major release. (PYTHON-937)
 
 3.16.0
 ======

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -19,7 +19,7 @@ This module houses the main classes you will interact with,
 from __future__ import absolute_import
 
 import atexit
-from collections import defaultdict, Mapping
+from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, FIRST_COMPLETED, wait as wait_futures
 from copy import copy
 from functools import partial, wraps
@@ -33,6 +33,11 @@ import socket
 import sys
 import time
 from threading import Lock, RLock, Thread, Event
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 import weakref
 from weakref import WeakValueDictionary

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -14,7 +14,7 @@
 
 from binascii import unhexlify
 from bisect import bisect_left
-from collections import defaultdict, Mapping
+from collections import defaultdict
 from functools import total_ordering
 from hashlib import md5
 from itertools import islice, cycle
@@ -27,6 +27,11 @@ import sys
 from threading import RLock
 import struct
 import random
+
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 
 murmur3 = None
 try:

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -713,7 +713,10 @@ class SortedSet(object):
 sortedset = SortedSet  # backwards-compatibility
 
 
-from collections import Mapping
+try:
+    from collections.abc import Mapping
+except ImportError:
+    from collections import Mapping
 from six.moves import cPickle
 
 


### PR DESCRIPTION
> cassandra/cluster.py:22: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working                                                   
  from collections import defaultdict, Mapping

Waiting for six.moves to pick up.