### PR TITLE
Introduce WritePipeline and ReadPipeline objects

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -2,7 +2,8 @@
 > performance and are instead to be used as relative results to compare the
 > different request methods.
 >
-> All tests were done on a local laptop running Cassandra 3.11.2 on OS X.
+> All tests were done on a single node within AWS running Cassandra 3.11.3 on
+> an `m5.4xlarge` instance.
 
 # Write Throughputs
 
@@ -20,16 +21,19 @@ parallel requests and `OperationTimedOut` exceptions are not raised, this is
 the fastest the driver can perform.
 
 ```
-+ python benchmarks/callback_full_pipeline.py --num-ops 50000
-2018-08-03 18:05:09,744 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:05:09,744 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:05:09,978 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:05:21,523 [INFO] root: Total time: 9.06s
-2018-08-03 18:05:21,523 [INFO] root: Average throughput: 5516.36/sec
-2018-08-03 18:05:21,523 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:05:21,652 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:05:33,723 [INFO] root: Total time: 9.60s
-2018-08-03 18:05:33,723 [INFO] root: Average throughput: 5208.19/sec
++ python benchmarks/callback_full_pipeline.py --num-ops 150000 -H 172.30.0.56
+2018-08-07 04:24:10,824 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:24:10,958 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:24:27,816 [INFO] root: Total time: 13.82s
+2018-08-07 04:24:27,816 [INFO] root: Average throughput: 10853.92/sec
+2018-08-07 04:24:27,816 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:24:28,047 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:24:43,761 [INFO] root: Total time: 12.87s
+2018-08-07 04:24:43,761 [INFO] root: Average throughput: 11655.05/sec
+2018-08-07 04:24:43,761 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:24:43,891 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:25:02,320 [INFO] root: Total time: 15.54s
+2018-08-07 04:25:02,320 [INFO] root: Average throughput: 9652.95/sec
 ```
 
 ## WritePipeline Object
@@ -50,18 +54,19 @@ is too large, all futures are first consumed internally by calling
 requests have returned.
 
 ```
-+ python benchmarks/pipeline.py --num-ops 50000
-2018-08-03 18:05:33,947 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:05:33,947 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:05:34,072 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:05:36,137 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:05:50,133 [INFO] root: Total time: 13.52s
-2018-08-03 18:05:50,134 [INFO] root: Average throughput: 3698.07/sec
-2018-08-03 18:05:50,134 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:05:50,258 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:05:52,504 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:06:16,780 [INFO] root: Total time: 23.94s
-2018-08-03 18:06:16,780 [INFO] root: Average throughput: 2088.48/sec
++ python benchmarks/pipeline.py --num-ops 150000 -H 172.30.0.56
+2018-08-07 04:25:04,885 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:25:05,020 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:25:30,845 [INFO] root: Total time: 23.32s
+2018-08-07 04:25:30,845 [INFO] root: Average throughput: 6431.47/sec
+2018-08-07 04:25:30,846 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:25:31,078 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:25:56,541 [INFO] root: Total time: 22.90s
+2018-08-07 04:25:56,541 [INFO] root: Average throughput: 6551.19/sec
+2018-08-07 04:25:56,541 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:25:56,671 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:26:36,229 [INFO] root: Total time: 37.06s
+2018-08-07 04:26:36,230 [INFO] root: Average throughput: 4047.98/sec
 ```
 
 ## Future Batches
@@ -77,16 +82,19 @@ Before exiting, all futures within the future `Queue` are consumed to ensure
 all pending requests have been processed.
 
 ```
-+ python benchmarks/future_batches.py --num-ops 50000
-2018-08-03 18:06:17,364 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:06:17,364 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:06:17,491 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:06:34,970 [INFO] root: Total time: 15.02s
-2018-08-03 18:06:34,971 [INFO] root: Average throughput: 3329.23/sec
-2018-08-03 18:06:34,971 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:06:35,100 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:06:58,580 [INFO] root: Total time: 21.02s
-2018-08-03 18:06:58,580 [INFO] root: Average throughput: 2378.37/sec
++ python benchmarks/future_batches.py --num-ops 150000 -H 172.30.0.56
+2018-08-07 04:26:39,062 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:26:39,194 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:27:05,877 [INFO] root: Total time: 23.78s
+2018-08-07 04:27:05,877 [INFO] root: Average throughput: 6308.53/sec
+2018-08-07 04:27:05,877 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:27:06,108 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:27:31,350 [INFO] root: Total time: 22.29s
+2018-08-07 04:27:31,350 [INFO] root: Average throughput: 6730.50/sec
+2018-08-07 04:27:31,350 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:27:31,526 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:28:09,978 [INFO] root: Total time: 35.64s
+2018-08-07 04:28:09,978 [INFO] root: Average throughput: 4209.29/sec
 ```
 
 ## Future Full Pipeline
@@ -102,16 +110,19 @@ Before exiting, all futures within the future `Queue` are consumed to ensure
 all pending requests have been processed.
 
 ```
-+ python benchmarks/future_full_pipeline.py --num-ops 50000
-2018-08-03 18:06:59,129 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:06:59,129 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:06:59,256 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:07:18,166 [INFO] root: Total time: 16.41s
-2018-08-03 18:07:18,166 [INFO] root: Average throughput: 3046.46/sec
-2018-08-03 18:07:18,166 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:07:18,297 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:07:45,822 [INFO] root: Total time: 25.03s
-2018-08-03 18:07:45,822 [INFO] root: Average throughput: 1997.40/sec
++ python benchmarks/future_full_pipeline.py --num-ops 150000 -H 172.30.0.56
+2018-08-07 04:28:12,587 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:28:12,722 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:28:42,443 [INFO] root: Total time: 26.82s
+2018-08-07 04:28:42,443 [INFO] root: Average throughput: 5592.19/sec
+2018-08-07 04:28:42,443 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:28:42,674 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:29:10,494 [INFO] root: Total time: 24.94s
+2018-08-07 04:29:10,494 [INFO] root: Average throughput: 6014.01/sec
+2018-08-07 04:29:10,494 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:29:10,626 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:29:52,830 [INFO] root: Total time: 39.28s
+2018-08-07 04:29:52,830 [INFO] root: Average throughput: 3819.16/sec
 ```
 
 ## Future Full Throttle
@@ -131,16 +142,19 @@ times FIFO consumption of read requests are required since the resulting
 data may be merged with known data.
 
 ```
-+ python benchmarks/future_full_throttle.py --num-ops 50000
-2018-08-03 18:07:46,160 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:07:46,161 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:07:46,286 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:08:05,541 [INFO] root: Total time: 16.57s
-2018-08-03 18:08:05,541 [INFO] root: Average throughput: 3018.07/sec
-2018-08-03 18:08:05,541 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:08:05,663 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:08:34,282 [INFO] root: Total time: 26.11s
-2018-08-03 18:08:34,282 [INFO] root: Average throughput: 1914.96/sec
++ python benchmarks/future_full_throttle.py --num-ops 150000 -H 172.30.0.56
+2018-08-07 04:29:55,634 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:29:55,766 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:30:28,940 [INFO] root: Total time: 30.34s
+2018-08-07 04:30:28,940 [INFO] root: Average throughput: 4944.40/sec
+2018-08-07 04:30:28,940 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:30:29,174 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:31:03,236 [INFO] root: Total time: 31.15s
+2018-08-07 04:31:03,236 [INFO] root: Average throughput: 4816.09/sec
+2018-08-07 04:31:03,236 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:31:03,367 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:31:40,248 [INFO] root: Total time: 34.04s
+2018-08-07 04:31:40,248 [INFO] root: Average throughput: 4406.98/sec
 ```
 
 ## Synchronous Requests
@@ -151,16 +165,19 @@ Since only *one* request is in-flight at a given time, this will be the slowest
 request method.
 
 ```
-+ python benchmarks/sync.py --num-ops 50000
-2018-08-03 18:08:35,390 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:08:35,390 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:08:35,521 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:09:11,932 [INFO] root: Total time: 34.01s
-2018-08-03 18:09:11,932 [INFO] root: Average throughput: 1470.28/sec
-2018-08-03 18:09:11,932 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:09:12,059 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:09:53,698 [INFO] root: Total time: 39.22s
-2018-08-03 18:09:53,698 [INFO] root: Average throughput: 1274.94/sec
++ python benchmarks/sync.py --num-ops 150000 -H 172.30.0.56
+2018-08-07 04:31:44,558 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:31:44,690 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:32:37,343 [INFO] root: Total time: 50.14s
+2018-08-07 04:32:37,343 [INFO] root: Average throughput: 2991.66/sec
+2018-08-07 04:32:37,343 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:32:37,575 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:33:22,182 [INFO] root: Total time: 42.08s
+2018-08-07 04:33:22,183 [INFO] root: Average throughput: 3565.04/sec
+2018-08-07 04:33:22,183 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:33:22,314 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:34:21,940 [INFO] root: Total time: 57.17s
+2018-08-07 04:34:21,940 [INFO] root: Average throughput: 2623.56/sec
 ```
 
 # Read Throughputs
@@ -179,16 +196,19 @@ parallel requests and `OperationTimedOut` exceptions are not raised, this is
 the fastest the driver can perform.
 
 ```
-+ python benchmarks/callback_full_pipeline.py --num-ops 50000 --read
-2018-08-03 18:09:54,088 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:09:54,089 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:09:54,319 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:11:02,393 [INFO] root: Total time: 65.60s
-2018-08-03 18:11:02,393 [INFO] root: Average throughput: 762.24/sec
-2018-08-03 18:11:02,393 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:11:02,526 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:12:10,430 [INFO] root: Total time: 65.51s
-2018-08-03 18:12:10,431 [INFO] root: Average throughput: 763.20/sec
++ python benchmarks/callback_full_pipeline.py --num-ops 150000 -H 172.30.0.56 --read
+2018-08-07 04:36:37,101 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:36:37,233 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:38:07,919 [INFO] root: Total time: 88.10s
+2018-08-07 04:38:07,919 [INFO] root: Average throughput: 1702.70/sec
+2018-08-07 04:38:07,919 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:38:08,151 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:39:37,585 [INFO] root: Total time: 86.94s
+2018-08-07 04:39:37,586 [INFO] root: Average throughput: 1725.25/sec
+2018-08-07 04:39:37,586 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:39:37,716 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:41:09,767 [INFO] root: Total time: 89.52s
+2018-08-07 04:41:09,767 [INFO] root: Average throughput: 1675.67/sec
 ```
 
 ## ReadPipeline Object
@@ -208,18 +228,19 @@ and allows pending requests to be executed asynchronously each time an
 additional result is consumed.
 
 ```
-+ python benchmarks/pipeline.py --num-ops 50000 --read
-2018-08-03 18:12:11,132 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:12:11,132 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:12:11,259 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:12:13,333 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:13:14,372 [INFO] root: Total time: 60.69s
-2018-08-03 18:13:14,372 [INFO] root: Average throughput: 823.80/sec
-2018-08-03 18:13:14,372 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:13:14,504 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:13:16,636 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:14:49,721 [INFO] root: Total time: 92.69s
-2018-08-03 18:14:49,721 [INFO] root: Average throughput: 539.44/sec
++ python benchmarks/pipeline.py --num-ops 150000 -H 172.30.0.56 --read
+2018-08-07 04:41:12,342 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:41:12,475 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:43:01,004 [INFO] root: Total time: 106.03s
+2018-08-07 04:43:01,005 [INFO] root: Average throughput: 1414.65/sec
+2018-08-07 04:43:01,005 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:43:01,242 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:44:48,072 [INFO] root: Total time: 104.32s
+2018-08-07 04:44:48,072 [INFO] root: Average throughput: 1437.86/sec
+2018-08-07 04:44:48,072 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:44:48,314 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:46:48,665 [INFO] root: Total time: 117.68s
+2018-08-07 04:46:48,666 [INFO] root: Average throughput: 1274.69/sec
 ```
 
 ## Future Batches
@@ -235,16 +256,19 @@ Before exiting, all futures within the future `Queue` are consumed to ensure
 all pending requests have been processed.
 
 ```
-+ python benchmarks/future_batches.py --num-ops 50000 --read
-2018-08-03 18:14:50,149 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:14:50,149 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:14:50,387 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:15:55,079 [INFO] root: Total time: 62.27s
-2018-08-03 18:15:55,080 [INFO] root: Average throughput: 802.95/sec
-2018-08-03 18:15:55,080 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:15:55,209 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:17:51,799 [INFO] root: Total time: 114.16s
-2018-08-03 18:17:51,799 [INFO] root: Average throughput: 437.98/sec
++ python benchmarks/future_batches.py --num-ops 150000 -H 172.30.0.56 --read
+2018-08-07 04:46:51,271 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:46:51,403 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:48:24,745 [INFO] root: Total time: 90.75s
+2018-08-07 04:48:24,745 [INFO] root: Average throughput: 1652.84/sec
+2018-08-07 04:48:24,745 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:48:24,976 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:49:55,937 [INFO] root: Total time: 88.45s
+2018-08-07 04:49:55,937 [INFO] root: Average throughput: 1695.87/sec
+2018-08-07 04:49:55,937 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:49:56,068 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:51:46,465 [INFO] root: Total time: 107.96s
+2018-08-07 04:51:46,465 [INFO] root: Average throughput: 1389.43/sec
 ```
 
 ## Future Full Pipeline
@@ -260,16 +284,19 @@ Before exiting, all futures within the future `Queue` are consumed to ensure
 all pending requests have been processed.
 
 ```
-+ python benchmarks/future_full_pipeline.py --num-ops 50000 --read
-2018-08-03 18:17:52,305 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:17:52,306 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:17:52,442 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:19:05,990 [INFO] root: Total time: 71.09s
-2018-08-03 18:19:05,990 [INFO] root: Average throughput: 703.34/sec
-2018-08-03 18:19:05,990 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:19:06,122 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:21:01,888 [INFO] root: Total time: 113.35s
-2018-08-03 18:21:01,889 [INFO] root: Average throughput: 441.13/sec
++ python benchmarks/future_full_pipeline.py --num-ops 150000 -H 172.30.0.56 --read
+2018-08-07 04:51:48,991 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:51:49,123 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 04:53:27,992 [INFO] root: Total time: 96.27s
+2018-08-07 04:53:27,993 [INFO] root: Average throughput: 1558.16/sec
+2018-08-07 04:53:27,993 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:53:28,222 [INFO] root: ==== LibevConnection ====
+2018-08-07 04:55:04,824 [INFO] root: Total time: 94.00s
+2018-08-07 04:55:04,824 [INFO] root: Average throughput: 1595.78/sec
+2018-08-07 04:55:04,824 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 04:55:04,955 [INFO] root: ==== TwistedConnection ====
+2018-08-07 04:56:58,690 [INFO] root: Total time: 111.22s
+2018-08-07 04:56:58,690 [INFO] root: Average throughput: 1348.73/sec
 ```
 
 ## Future Full Throttle
@@ -288,31 +315,24 @@ While FIFO verification of write requests may not be required, often
 times FIFO consumption of read requests are required since the resulting
 data may be merged with known data.
 
-**Note:** The following execution could not complete successfully on my local
-machine due to the large number of parallel requests. The faulty throughput is
-omitted below.
+**Note:** The following execution could not complete successfully due to the
+large number of parallel requests. The number of operations was divided by 10
+in order to gain a basic idea of throughput.
 
 ```
-+ python benchmarks/future_full_throttle.py --num-ops 50000 --read
-2018-08-03 18:21:02,576 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:21:02,576 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:21:02,814 [INFO] root: ==== AsyncoreConnection ====
-Exception in thread Thread-4:
-Traceback (most recent call last):
-  File "/usr/local/Cellar/python/2.7.13_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 801, in __bootstrap_inner
-    self.run()
-  File "benchmarks/future_full_throttle.py", line 34, in run
-    future.result()
-  File "/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra/cluster.py", line 4033, in result
-    raise self._final_exception
-OperationTimedOut: errors={'127.0.0.1': 'Client request timeout. See Session.execute[_async](timeout)'}, last_host=127.0.0.1
-
-2018-08-03 18:21:35,466 [INFO] root: Total time: --.--s
-2018-08-03 18:21:35,467 [INFO] root: Average throughput: --/sec
-2018-08-03 18:21:35,472 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:21:35,764 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:23:06,036 [INFO] root: Total time: 87.72s
-2018-08-03 18:23:06,037 [INFO] root: Average throughput: 569.97/sec
++ python benchmarks/future_full_throttle.py --num-ops 15000 -H 172.30.0.56 --read
+2018-08-07 05:19:45,419 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 05:19:45,651 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 05:19:59,715 [INFO] root: Total time: 11.45s
+2018-08-07 05:19:59,716 [INFO] root: Average throughput: 1309.58/sec
+2018-08-07 05:19:59,716 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 05:19:59,946 [INFO] root: ==== LibevConnection ====
+2018-08-07 05:20:12,663 [INFO] root: Total time: 10.24s
+2018-08-07 05:20:12,663 [INFO] root: Average throughput: 1464.50/sec
+2018-08-07 05:20:12,663 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 05:20:12,893 [INFO] root: ==== TwistedConnection ====
+2018-08-07 05:20:25,810 [INFO] root: Total time: 10.52s
+2018-08-07 05:20:25,810 [INFO] root: Average throughput: 1425.74/sec
 ```
 
 ## Synchronous Requests
@@ -323,15 +343,19 @@ Since only *one* request is in-flight at a given time, this will be the slowest
 request method.
 
 ```
-+ python benchmarks/sync.py --num-ops 50000 --read
-2018-08-03 18:23:07,726 [WARNING] root: Not benchmarking libev reactor because libev is not available
-2018-08-03 18:23:07,726 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:23:07,852 [INFO] root: ==== AsyncoreConnection ====
-2018-08-03 18:24:50,007 [INFO] root: Total time: 99.68s
-2018-08-03 18:24:50,007 [INFO] root: Average throughput: 501.60/sec
-2018-08-03 18:24:50,007 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
-2018-08-03 18:24:50,244 [INFO] root: ==== TwistedConnection ====
-2018-08-03 18:26:23,052 [INFO] root: Total time: 90.39s
++ python benchmarks/sync.py --num-ops 150000 -H 172.30.0.56 --read
+2018-08-07 05:08:30,524 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 05:08:30,757 [INFO] root: ==== AsyncoreConnection ====
+2018-08-07 05:10:32,994 [INFO] root: Total time: 119.74s
+2018-08-07 05:10:32,994 [INFO] root: Average throughput: 1252.74/sec
+2018-08-07 05:10:32,994 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 05:10:33,125 [INFO] root: ==== LibevConnection ====
+2018-08-07 05:12:27,412 [INFO] root: Total time: 111.74s
+2018-08-07 05:12:27,413 [INFO] root: Average throughput: 1342.39/sec
+2018-08-07 05:12:27,413 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-07 05:12:27,543 [INFO] root: ==== TwistedConnection ====
+2018-08-07 05:14:41,783 [INFO] root: Total time: 131.86s
+2018-08-07 05:14:41,783 [INFO] root: Average throughput: 1137.60/sec
 ```
 
 # Pipeline Tuning

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,10 +10,10 @@
 
 This request method fires off all asynchronous requests at the same time.
 
-When the `ResponseFuture`'s callback is executed the callback code ensures all
-pending requests are completed before exiting the code block by setting a
-Python `Event` in the callback while waiting for the `Event` in the main
-thread.
+When the `ResponseFuture`'s callback is executed, the callback code ensures all
+pending requests are completed before exiting the code block. This is done by
+setting a Python `Event` in the callback while waiting for the `Event` in the
+main thread.
 
 Assuming the Cassandra cluster is not overloaded by the large number of
 parallel requests and `OperationTimedOut` exceptions are not raised, this is
@@ -42,7 +42,7 @@ and `WritePipeline.execute()` is called for each asynchronous request.
 `WritePipeline.confirm()` is used to ensure all requests were processed
 correctly before exiting the code block.
 
-Internally, the `WritePipeline` creates a request `Queue` which are executed
+Internally, the `WritePipeline` creates a request `Queue` which is executed
 and managed via `ResponseFuture` callbacks. If the number of pending futures
 is too large, all futures are first consumed internally by calling
 `WritePipeline.confirm()` before allowing new requests to be created.
@@ -169,10 +169,10 @@ request method.
 
 This request method fires off all asynchronous requests at the same time.
 
-When the `ResponseFuture`'s callback is executed the callback code ensures all
-pending requests are completed before exiting the code block by setting a
-Python `Event` in the callback while waiting for the `Event` in the main
-thread.
+When the `ResponseFuture`'s callback is executed, the callback code ensures all
+pending requests are completed before exiting the code block. This is done by
+setting a Python `Event` in the callback while waiting for the `Event` in the
+main thread.
 
 Assuming the Cassandra cluster is not overloaded by the large number of
 parallel requests and `OperationTimedOut` exceptions are not raised, this is
@@ -200,7 +200,7 @@ To the developer, the `ReadPipeline` is initialized with a Cassandra `session`
 and `ReadPipeline.execute()` is called for each asynchronous request.
 `ReadPipeline.results()` is used to consume all requests in FIFO ordering.
 
-Internally, the `ReadPipeline` creates a request `Queue` which are executed
+Internally, the `ReadPipeline` creates a request `Queue` which is executed
 and managed via `ResponseFuture` callbacks. If the number of unconsumed results
 is too large, no new requests are created.
 `ReadPipeline.results()` iterates over a `Queue` of `ResponseFuture` objects

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,18 +22,18 @@ the fastest the driver can perform.
 
 ```
 + python benchmarks/callback_full_pipeline.py --num-ops 150000 -H 172.30.0.56
-2018-08-07 04:24:10,824 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:24:10,958 [INFO] root: ==== AsyncoreConnection ====
-2018-08-07 04:24:27,816 [INFO] root: Total time: 13.82s
-2018-08-07 04:24:27,816 [INFO] root: Average throughput: 10853.92/sec
-2018-08-07 04:24:27,816 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:24:28,047 [INFO] root: ==== LibevConnection ====
-2018-08-07 04:24:43,761 [INFO] root: Total time: 12.87s
-2018-08-07 04:24:43,761 [INFO] root: Average throughput: 11655.05/sec
-2018-08-07 04:24:43,761 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:24:43,891 [INFO] root: ==== TwistedConnection ====
-2018-08-07 04:25:02,320 [INFO] root: Total time: 15.54s
-2018-08-07 04:25:02,320 [INFO] root: Average throughput: 9652.95/sec
+2018-08-08 19:17:16,303 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:17:16,435 [INFO] root: ==== AsyncoreConnection ====
+2018-08-08 19:17:33,679 [INFO] root: Total time: 14.27s
+2018-08-08 19:17:33,679 [INFO] root: Average throughput: 10511.13/sec
+2018-08-08 19:17:33,679 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:17:33,911 [INFO] root: ==== LibevConnection ====
+2018-08-08 19:17:50,300 [INFO] root: Total time: 13.32s
+2018-08-08 19:17:50,300 [INFO] root: Average throughput: 11261.17/sec
+2018-08-08 19:17:50,300 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:17:50,432 [INFO] root: ==== TwistedConnection ====
+2018-08-08 19:18:10,613 [INFO] root: Total time: 17.17s
+2018-08-08 19:18:10,613 [INFO] root: Average throughput: 8733.76/sec
 ```
 
 ## WritePipeline Object
@@ -55,18 +55,18 @@ requests have returned.
 
 ```
 + python benchmarks/pipeline.py --num-ops 150000 -H 172.30.0.56
-2018-08-07 04:25:04,885 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:25:05,020 [INFO] root: ==== AsyncoreConnection ====
-2018-08-07 04:25:30,845 [INFO] root: Total time: 23.32s
-2018-08-07 04:25:30,845 [INFO] root: Average throughput: 6431.47/sec
-2018-08-07 04:25:30,846 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:25:31,078 [INFO] root: ==== LibevConnection ====
-2018-08-07 04:25:56,541 [INFO] root: Total time: 22.90s
-2018-08-07 04:25:56,541 [INFO] root: Average throughput: 6551.19/sec
-2018-08-07 04:25:56,541 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:25:56,671 [INFO] root: ==== TwistedConnection ====
-2018-08-07 04:26:36,229 [INFO] root: Total time: 37.06s
-2018-08-07 04:26:36,230 [INFO] root: Average throughput: 4047.98/sec
+2018-08-08 19:18:20,317 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:18:20,449 [INFO] root: ==== AsyncoreConnection ====
+2018-08-08 19:18:46,428 [INFO] root: Total time: 23.41s
+2018-08-08 19:18:46,429 [INFO] root: Average throughput: 6407.10/sec
+2018-08-08 19:18:46,429 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:18:46,662 [INFO] root: ==== LibevConnection ====
+2018-08-08 19:19:13,132 [INFO] root: Total time: 23.70s
+2018-08-08 19:19:13,132 [INFO] root: Average throughput: 6328.08/sec
+2018-08-08 19:19:13,132 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:19:13,364 [INFO] root: ==== TwistedConnection ====
+2018-08-08 19:19:51,967 [INFO] root: Total time: 36.05s
+2018-08-08 19:19:51,967 [INFO] root: Average throughput: 4161.26/sec
 ```
 
 ## Future Batches
@@ -197,18 +197,18 @@ the fastest the driver can perform.
 
 ```
 + python benchmarks/callback_full_pipeline.py --num-ops 150000 -H 172.30.0.56 --read
-2018-08-07 04:36:37,101 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:36:37,233 [INFO] root: ==== AsyncoreConnection ====
-2018-08-07 04:38:07,919 [INFO] root: Total time: 88.10s
-2018-08-07 04:38:07,919 [INFO] root: Average throughput: 1702.70/sec
-2018-08-07 04:38:07,919 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:38:08,151 [INFO] root: ==== LibevConnection ====
-2018-08-07 04:39:37,585 [INFO] root: Total time: 86.94s
-2018-08-07 04:39:37,586 [INFO] root: Average throughput: 1725.25/sec
-2018-08-07 04:39:37,586 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:39:37,716 [INFO] root: ==== TwistedConnection ====
-2018-08-07 04:41:09,767 [INFO] root: Total time: 89.52s
-2018-08-07 04:41:09,767 [INFO] root: Average throughput: 1675.67/sec
+2018-08-08 19:20:18,369 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:20:18,503 [INFO] root: ==== AsyncoreConnection ====
+2018-08-08 19:21:52,157 [INFO] root: Total time: 91.14s
+2018-08-08 19:21:52,157 [INFO] root: Average throughput: 1645.89/sec
+2018-08-08 19:21:52,157 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:21:52,389 [INFO] root: ==== LibevConnection ====
+2018-08-08 19:23:23,840 [INFO] root: Total time: 88.85s
+2018-08-08 19:23:23,840 [INFO] root: Average throughput: 1688.30/sec
+2018-08-08 19:23:23,840 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:23:23,975 [INFO] root: ==== TwistedConnection ====
+2018-08-08 19:24:58,355 [INFO] root: Total time: 91.94s
+2018-08-08 19:24:58,355 [INFO] root: Average throughput: 1631.56/sec
 ```
 
 ## ReadPipeline Object
@@ -229,18 +229,18 @@ additional result is consumed.
 
 ```
 + python benchmarks/pipeline.py --num-ops 150000 -H 172.30.0.56 --read
-2018-08-07 04:41:12,342 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:41:12,475 [INFO] root: ==== AsyncoreConnection ====
-2018-08-07 04:43:01,004 [INFO] root: Total time: 106.03s
-2018-08-07 04:43:01,005 [INFO] root: Average throughput: 1414.65/sec
-2018-08-07 04:43:01,005 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:43:01,242 [INFO] root: ==== LibevConnection ====
-2018-08-07 04:44:48,072 [INFO] root: Total time: 104.32s
-2018-08-07 04:44:48,072 [INFO] root: Average throughput: 1437.86/sec
-2018-08-07 04:44:48,072 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-07 04:44:48,314 [INFO] root: ==== TwistedConnection ====
-2018-08-07 04:46:48,665 [INFO] root: Total time: 117.68s
-2018-08-07 04:46:48,666 [INFO] root: Average throughput: 1274.69/sec
+2018-08-08 19:25:59,768 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:25:59,900 [INFO] root: ==== AsyncoreConnection ====
+2018-08-08 19:27:46,331 [INFO] root: Total time: 103.91s
+2018-08-08 19:27:46,331 [INFO] root: Average throughput: 1443.52/sec
+2018-08-08 19:27:46,331 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:27:46,563 [INFO] root: ==== LibevConnection ====
+2018-08-08 19:29:31,621 [INFO] root: Total time: 102.48s
+2018-08-08 19:29:31,622 [INFO] root: Average throughput: 1463.72/sec
+2018-08-08 19:29:31,622 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:29:31,751 [INFO] root: ==== TwistedConnection ====
+2018-08-08 19:31:27,978 [INFO] root: Total time: 113.79s
+2018-08-08 19:31:27,978 [INFO] root: Average throughput: 1318.23/sec
 ```
 
 ## Future Batches

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -22,18 +22,18 @@ the fastest the driver can perform.
 
 ```
 + python benchmarks/callback_full_pipeline.py --num-ops 150000 -H 172.30.0.56
-2018-08-08 19:17:16,303 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:17:16,435 [INFO] root: ==== AsyncoreConnection ====
-2018-08-08 19:17:33,679 [INFO] root: Total time: 14.27s
-2018-08-08 19:17:33,679 [INFO] root: Average throughput: 10511.13/sec
-2018-08-08 19:17:33,679 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:17:33,911 [INFO] root: ==== LibevConnection ====
-2018-08-08 19:17:50,300 [INFO] root: Total time: 13.32s
-2018-08-08 19:17:50,300 [INFO] root: Average throughput: 11261.17/sec
-2018-08-08 19:17:50,300 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:17:50,432 [INFO] root: ==== TwistedConnection ====
-2018-08-08 19:18:10,613 [INFO] root: Total time: 17.17s
-2018-08-08 19:18:10,613 [INFO] root: Average throughput: 8733.76/sec
+2018-08-08 19:51:42,392 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:51:42,625 [INFO] root: ==== AsyncoreConnection ====
+2018-08-08 19:51:59,315 [INFO] root: Total time: 13.77s
+2018-08-08 19:51:59,316 [INFO] root: Average throughput: 10893.45/sec
+2018-08-08 19:51:59,316 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:51:59,547 [INFO] root: ==== LibevConnection ====
+2018-08-08 19:52:15,718 [INFO] root: Total time: 13.17s
+2018-08-08 19:52:15,718 [INFO] root: Average throughput: 11390.19/sec
+2018-08-08 19:52:15,718 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:52:16,049 [INFO] root: ==== TwistedConnection ====
+2018-08-08 19:52:34,524 [INFO] root: Total time: 15.67s
+2018-08-08 19:52:34,524 [INFO] root: Average throughput: 9571.80/sec
 ```
 
 ## WritePipeline Object
@@ -55,18 +55,18 @@ requests have returned.
 
 ```
 + python benchmarks/pipeline.py --num-ops 150000 -H 172.30.0.56
-2018-08-08 19:18:20,317 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:18:20,449 [INFO] root: ==== AsyncoreConnection ====
-2018-08-08 19:18:46,428 [INFO] root: Total time: 23.41s
-2018-08-08 19:18:46,429 [INFO] root: Average throughput: 6407.10/sec
-2018-08-08 19:18:46,429 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:18:46,662 [INFO] root: ==== LibevConnection ====
-2018-08-08 19:19:13,132 [INFO] root: Total time: 23.70s
-2018-08-08 19:19:13,132 [INFO] root: Average throughput: 6328.08/sec
-2018-08-08 19:19:13,132 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:19:13,364 [INFO] root: ==== TwistedConnection ====
-2018-08-08 19:19:51,967 [INFO] root: Total time: 36.05s
-2018-08-08 19:19:51,967 [INFO] root: Average throughput: 4161.26/sec
+2018-08-08 19:52:47,102 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:52:47,337 [INFO] root: ==== AsyncoreConnection ====
+2018-08-08 19:53:12,381 [INFO] root: Total time: 22.55s
+2018-08-08 19:53:12,381 [INFO] root: Average throughput: 6653.16/sec
+2018-08-08 19:53:12,381 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:53:12,612 [INFO] root: ==== LibevConnection ====
+2018-08-08 19:53:37,060 [INFO] root: Total time: 21.79s
+2018-08-08 19:53:37,060 [INFO] root: Average throughput: 6884.64/sec
+2018-08-08 19:53:37,060 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:53:37,292 [INFO] root: ==== TwistedConnection ====
+2018-08-08 19:54:13,721 [INFO] root: Total time: 34.00s
+2018-08-08 19:54:13,721 [INFO] root: Average throughput: 4411.34/sec
 ```
 
 ## Future Batches
@@ -197,18 +197,18 @@ the fastest the driver can perform.
 
 ```
 + python benchmarks/callback_full_pipeline.py --num-ops 150000 -H 172.30.0.56 --read
-2018-08-08 19:20:18,369 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:20:18,503 [INFO] root: ==== AsyncoreConnection ====
-2018-08-08 19:21:52,157 [INFO] root: Total time: 91.14s
-2018-08-08 19:21:52,157 [INFO] root: Average throughput: 1645.89/sec
-2018-08-08 19:21:52,157 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:21:52,389 [INFO] root: ==== LibevConnection ====
-2018-08-08 19:23:23,840 [INFO] root: Total time: 88.85s
-2018-08-08 19:23:23,840 [INFO] root: Average throughput: 1688.30/sec
-2018-08-08 19:23:23,840 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:23:23,975 [INFO] root: ==== TwistedConnection ====
-2018-08-08 19:24:58,355 [INFO] root: Total time: 91.94s
-2018-08-08 19:24:58,355 [INFO] root: Average throughput: 1631.56/sec
+2018-08-08 19:54:26,365 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:54:26,598 [INFO] root: ==== AsyncoreConnection ====
+2018-08-08 19:55:57,287 [INFO] root: Total time: 88.30s
+2018-08-08 19:55:57,287 [INFO] root: Average throughput: 1698.66/sec
+2018-08-08 19:55:57,287 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:55:57,418 [INFO] root: ==== LibevConnection ====
+2018-08-08 19:57:26,697 [INFO] root: Total time: 86.66s
+2018-08-08 19:57:26,697 [INFO] root: Average throughput: 1730.82/sec
+2018-08-08 19:57:26,697 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:57:26,928 [INFO] root: ==== TwistedConnection ====
+2018-08-08 19:58:58,523 [INFO] root: Total time: 89.22s
+2018-08-08 19:58:58,523 [INFO] root: Average throughput: 1681.22/sec
 ```
 
 ## ReadPipeline Object
@@ -229,18 +229,18 @@ additional result is consumed.
 
 ```
 + python benchmarks/pipeline.py --num-ops 150000 -H 172.30.0.56 --read
-2018-08-08 19:25:59,768 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:25:59,900 [INFO] root: ==== AsyncoreConnection ====
-2018-08-08 19:27:46,331 [INFO] root: Total time: 103.91s
-2018-08-08 19:27:46,331 [INFO] root: Average throughput: 1443.52/sec
-2018-08-08 19:27:46,331 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:27:46,563 [INFO] root: ==== LibevConnection ====
-2018-08-08 19:29:31,621 [INFO] root: Total time: 102.48s
-2018-08-08 19:29:31,622 [INFO] root: Average throughput: 1463.72/sec
-2018-08-08 19:29:31,622 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
-2018-08-08 19:29:31,751 [INFO] root: ==== TwistedConnection ====
-2018-08-08 19:31:27,978 [INFO] root: Total time: 113.79s
-2018-08-08 19:31:27,978 [INFO] root: Average throughput: 1318.23/sec
+2018-08-08 19:59:11,102 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 19:59:11,334 [INFO] root: ==== AsyncoreConnection ====
+2018-08-08 20:00:55,541 [INFO] root: Total time: 101.79s
+2018-08-08 20:00:55,542 [INFO] root: Average throughput: 1473.65/sec
+2018-08-08 20:00:55,542 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 20:00:55,772 [INFO] root: ==== LibevConnection ====
+2018-08-08 20:02:38,310 [INFO] root: Total time: 99.76s
+2018-08-08 20:02:38,310 [INFO] root: Average throughput: 1503.68/sec
+2018-08-08 20:02:38,310 [INFO] root: Using 'cassandra' package from ['/usr/local/lib/python2.7/dist-packages/cassandra_driver-3.14.0-py2.7-linux-x86_64.egg/cassandra']
+2018-08-08 20:02:38,540 [INFO] root: ==== TwistedConnection ====
+2018-08-08 20:04:31,720 [INFO] root: Total time: 110.77s
+2018-08-08 20:04:31,720 [INFO] root: Average throughput: 1354.11/sec
 ```
 
 ## Future Batches

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,346 @@
+> **NOTE:** The following benchmarks are not indicative of actual Cassandra
+> performance and are instead to be used as relative results to compare the
+> different request methods.
+>
+> All tests were done on a local laptop running Cassandra 3.11.2 on OS X.
+
+# Write Throughputs
+
+## Callback Full Pipeline
+
+This request method fires off all asynchronous requests at the same time.
+
+When the `ResponseFuture`'s callback is executed the callback code ensures all
+pending requests are completed before exiting the code block by setting a
+Python `Event` in the callback while waiting for the `Event` in the main
+thread.
+
+Assuming the Cassandra cluster is not overloaded by the large number of
+parallel requests and `OperationTimedOut` exceptions are not raised, this is
+the fastest the driver can perform.
+
+```
++ python benchmarks/callback_full_pipeline.py --num-ops 50000
+2018-08-03 18:05:09,744 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:05:09,744 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:05:09,978 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:05:21,523 [INFO] root: Total time: 9.06s
+2018-08-03 18:05:21,523 [INFO] root: Average throughput: 5516.36/sec
+2018-08-03 18:05:21,523 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:05:21,652 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:05:33,723 [INFO] root: Total time: 9.60s
+2018-08-03 18:05:33,723 [INFO] root: Average throughput: 5208.19/sec
+```
+
+## WritePipeline Object
+
+The `WritePipeline` object is a blend of the "Callback Full Pipeline" and
+"Future Batches" request methods.
+
+To the developer, the `WritePipeline` is initialized with a Cassandra `session`
+and `WritePipeline.execute()` is called for each asynchronous request.
+`WritePipeline.confirm()` is used to ensure all requests were processed
+correctly before exiting the code block.
+
+Internally, the `WritePipeline` creates a request `Queue` which are executed
+and managed via `ResponseFuture` callbacks. If the number of pending futures
+is too large, all futures are first consumed internally by calling
+`WritePipeline.confirm()` before allowing new requests to be created.
+`WritePipeline.confirm()` uses a Python `Event` to ensure all in-flight
+requests have returned.
+
+```
++ python benchmarks/pipeline.py --num-ops 50000
+2018-08-03 18:05:33,947 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:05:33,947 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:05:34,072 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:05:36,137 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:05:50,133 [INFO] root: Total time: 13.52s
+2018-08-03 18:05:50,134 [INFO] root: Average throughput: 3698.07/sec
+2018-08-03 18:05:50,134 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:05:50,258 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:05:52,504 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:06:16,780 [INFO] root: Total time: 23.94s
+2018-08-03 18:06:16,780 [INFO] root: Average throughput: 2088.48/sec
+```
+
+## Future Batches
+
+This request method fires off a set number of asynchronous requests and adds
+these `ResponseFuture` objects to the future `Queue`.
+
+Each time the future `Queue` reaches its maximum capacity, the future `Queue`
+is read from in its *entirety* before creating another asynchronous request
+that is added back to the future `Queue`.
+
+Before exiting, all futures within the future `Queue` are consumed to ensure
+all pending requests have been processed.
+
+```
++ python benchmarks/future_batches.py --num-ops 50000
+2018-08-03 18:06:17,364 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:06:17,364 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:06:17,491 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:06:34,970 [INFO] root: Total time: 15.02s
+2018-08-03 18:06:34,971 [INFO] root: Average throughput: 3329.23/sec
+2018-08-03 18:06:34,971 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:06:35,100 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:06:58,580 [INFO] root: Total time: 21.02s
+2018-08-03 18:06:58,580 [INFO] root: Average throughput: 2378.37/sec
+```
+
+## Future Full Pipeline
+
+This request method fires off a set number of asynchronous requests and adds
+these `ResponseFuture` objects to the future `Queue`.
+
+Once the the future `Queue` reaches its maximum capacity, the future `Queue`
+consumes a *single* future before creating a *single* asynchronous request
+that is added back to the future `Queue`.
+
+Before exiting, all futures within the future `Queue` are consumed to ensure
+all pending requests have been processed.
+
+```
++ python benchmarks/future_full_pipeline.py --num-ops 50000
+2018-08-03 18:06:59,129 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:06:59,129 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:06:59,256 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:07:18,166 [INFO] root: Total time: 16.41s
+2018-08-03 18:07:18,166 [INFO] root: Average throughput: 3046.46/sec
+2018-08-03 18:07:18,166 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:07:18,297 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:07:45,822 [INFO] root: Total time: 25.03s
+2018-08-03 18:07:45,822 [INFO] root: Average throughput: 1997.40/sec
+```
+
+## Future Full Throttle
+
+This request method fires off all asynchronous requests at the same time.
+
+Before exiting, all futures within the future `List` are consumed to ensure
+all pending requests have been processed.
+
+Assuming the Cassandra cluster is not overloaded by the large number of
+parallel requests and `OperationTimedOut` exceptions are not raised, this
+request method then synchronously consumes each future in a FIFO ordering even
+though the requests were made asynchronously.
+
+While FIFO verification of write requests may not be required, often
+times FIFO consumption of read requests are required since the resulting
+data may be merged with known data.
+
+```
++ python benchmarks/future_full_throttle.py --num-ops 50000
+2018-08-03 18:07:46,160 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:07:46,161 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:07:46,286 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:08:05,541 [INFO] root: Total time: 16.57s
+2018-08-03 18:08:05,541 [INFO] root: Average throughput: 3018.07/sec
+2018-08-03 18:08:05,541 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:08:05,663 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:08:34,282 [INFO] root: Total time: 26.11s
+2018-08-03 18:08:34,282 [INFO] root: Average throughput: 1914.96/sec
+```
+
+## Synchronous Requests
+
+This request method fires off each request synchronously.
+
+Since only *one* request is in-flight at a given time, this will be the slowest
+request method.
+
+```
++ python benchmarks/sync.py --num-ops 50000
+2018-08-03 18:08:35,390 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:08:35,390 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:08:35,521 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:09:11,932 [INFO] root: Total time: 34.01s
+2018-08-03 18:09:11,932 [INFO] root: Average throughput: 1470.28/sec
+2018-08-03 18:09:11,932 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:09:12,059 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:09:53,698 [INFO] root: Total time: 39.22s
+2018-08-03 18:09:53,698 [INFO] root: Average throughput: 1274.94/sec
+```
+
+# Read Throughputs
+
+## Callback Full Pipeline
+
+This request method fires off all asynchronous requests at the same time.
+
+When the `ResponseFuture`'s callback is executed the callback code ensures all
+pending requests are completed before exiting the code block by setting a
+Python `Event` in the callback while waiting for the `Event` in the main
+thread.
+
+Assuming the Cassandra cluster is not overloaded by the large number of
+parallel requests and `OperationTimedOut` exceptions are not raised, this is
+the fastest the driver can perform.
+
+```
++ python benchmarks/callback_full_pipeline.py --num-ops 50000 --read
+2018-08-03 18:09:54,088 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:09:54,089 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:09:54,319 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:11:02,393 [INFO] root: Total time: 65.60s
+2018-08-03 18:11:02,393 [INFO] root: Average throughput: 762.24/sec
+2018-08-03 18:11:02,393 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:11:02,526 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:12:10,430 [INFO] root: Total time: 65.51s
+2018-08-03 18:12:10,431 [INFO] root: Average throughput: 763.20/sec
+```
+
+## ReadPipeline Object
+
+The `ReadPipeline` object is a blend of the "Callback Full Pipeline" and
+"Future Full Throttle" request methods.
+
+To the developer, the `ReadPipeline` is initialized with a Cassandra `session`
+and `ReadPipeline.execute()` is called for each asynchronous request.
+`ReadPipeline.results()` is used to consume all requests in FIFO ordering.
+
+Internally, the `ReadPipeline` creates a request `Queue` which are executed
+and managed via `ResponseFuture` callbacks. If the number of unconsumed results
+is too large, no new requests are created.
+`ReadPipeline.results()` iterates over a `Queue` of `ResponseFuture` objects
+and allows pending requests to be executed asynchronously each time an
+additional result is consumed.
+
+```
++ python benchmarks/pipeline.py --num-ops 50000 --read
+2018-08-03 18:12:11,132 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:12:11,132 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:12:11,259 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:12:13,333 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:13:14,372 [INFO] root: Total time: 60.69s
+2018-08-03 18:13:14,372 [INFO] root: Average throughput: 823.80/sec
+2018-08-03 18:13:14,372 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:13:14,504 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:13:16,636 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:14:49,721 [INFO] root: Total time: 92.69s
+2018-08-03 18:14:49,721 [INFO] root: Average throughput: 539.44/sec
+```
+
+## Future Batches
+
+This request method fires off a set number of asynchronous requests and adds
+these `ResponseFuture` objects to the future `Queue`.
+
+Each time the future `Queue` reaches its maximum capacity, the future `Queue`
+is read from in its *entirety* before creating another asynchronous request
+that is added back to the future `Queue`.
+
+Before exiting, all futures within the future `Queue` are consumed to ensure
+all pending requests have been processed.
+
+```
++ python benchmarks/future_batches.py --num-ops 50000 --read
+2018-08-03 18:14:50,149 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:14:50,149 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:14:50,387 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:15:55,079 [INFO] root: Total time: 62.27s
+2018-08-03 18:15:55,080 [INFO] root: Average throughput: 802.95/sec
+2018-08-03 18:15:55,080 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:15:55,209 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:17:51,799 [INFO] root: Total time: 114.16s
+2018-08-03 18:17:51,799 [INFO] root: Average throughput: 437.98/sec
+```
+
+## Future Full Pipeline
+
+This request method fires off a set number of asynchronous requests and adds
+these `ResponseFuture` objects to the future `Queue`.
+
+Once the the future `Queue` reaches its maximum capacity, the future `Queue`
+consumes a *single* future before creating a *single* asynchronous request
+that is added back to the future `Queue`.
+
+Before exiting, all futures within the future `Queue` are consumed to ensure
+all pending requests have been processed.
+
+```
++ python benchmarks/future_full_pipeline.py --num-ops 50000 --read
+2018-08-03 18:17:52,305 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:17:52,306 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:17:52,442 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:19:05,990 [INFO] root: Total time: 71.09s
+2018-08-03 18:19:05,990 [INFO] root: Average throughput: 703.34/sec
+2018-08-03 18:19:05,990 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:19:06,122 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:21:01,888 [INFO] root: Total time: 113.35s
+2018-08-03 18:21:01,889 [INFO] root: Average throughput: 441.13/sec
+```
+
+## Future Full Throttle
+
+This request method fires off all asynchronous requests at the same time.
+
+Before exiting, all futures within the future `List` are consumed to ensure
+all pending requests have been processed.
+
+Assuming the Cassandra cluster is not overloaded by the large number of
+parallel requests and `OperationTimedOut` exceptions are not raised, this
+request method then synchronously consumes each future in a FIFO ordering even
+though the requests were made asynchronously.
+
+While FIFO verification of write requests may not be required, often
+times FIFO consumption of read requests are required since the resulting
+data may be merged with known data.
+
+**Note:** The following execution could not complete successfully on my local
+machine due to the large number of parallel requests. The faulty throughput is
+omitted below.
+
+```
++ python benchmarks/future_full_throttle.py --num-ops 50000 --read
+2018-08-03 18:21:02,576 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:21:02,576 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:21:02,814 [INFO] root: ==== AsyncoreConnection ====
+Exception in thread Thread-4:
+Traceback (most recent call last):
+  File "/usr/local/Cellar/python/2.7.13_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 801, in __bootstrap_inner
+    self.run()
+  File "benchmarks/future_full_throttle.py", line 34, in run
+    future.result()
+  File "/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra/cluster.py", line 4033, in result
+    raise self._final_exception
+OperationTimedOut: errors={'127.0.0.1': 'Client request timeout. See Session.execute[_async](timeout)'}, last_host=127.0.0.1
+
+2018-08-03 18:21:35,466 [INFO] root: Total time: --.--s
+2018-08-03 18:21:35,467 [INFO] root: Average throughput: --/sec
+2018-08-03 18:21:35,472 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:21:35,764 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:23:06,036 [INFO] root: Total time: 87.72s
+2018-08-03 18:23:06,037 [INFO] root: Average throughput: 569.97/sec
+```
+
+## Synchronous Requests
+
+This request method fires off each request synchronously.
+
+Since only *one* request is in-flight at a given time, this will be the slowest
+request method.
+
+```
++ python benchmarks/sync.py --num-ops 50000 --read
+2018-08-03 18:23:07,726 [WARNING] root: Not benchmarking libev reactor because libev is not available
+2018-08-03 18:23:07,726 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:23:07,852 [INFO] root: ==== AsyncoreConnection ====
+2018-08-03 18:24:50,007 [INFO] root: Total time: 99.68s
+2018-08-03 18:24:50,007 [INFO] root: Average throughput: 501.60/sec
+2018-08-03 18:24:50,007 [INFO] root: Using 'cassandra' package from ['/Users/joaquin/repos/tlp/python-driver/benchmarks/../cassandra']
+2018-08-03 18:24:50,244 [INFO] root: ==== TwistedConnection ====
+2018-08-03 18:26:23,052 [INFO] root: Total time: 90.39s
+```
+
+# Pipeline Tuning
+
+In order to easily tune `WritePipeline` and `ReadPipeline` parameters against
+different sized clusters running in different network environments on different
+hardware, `./benchmarks/pipeline_tuning.py` has been created to iteratively
+run the `Pipeline` benchmark using increasing parameter values.
+
+At the end of the tuning benchmark, the fastest runs are used to create an
+average of the tunable parameter values. These values are good starting points
+for future performance tuning with that specific Cassandra cluster.

--- a/benchmarks/base.py
+++ b/benchmarks/base.py
@@ -91,7 +91,7 @@ def setup(options):
     log.info("Using 'cassandra' package from %s", cassandra.__path__)
 
     cluster = Cluster(options.hosts, schema_metadata_enabled=False, token_metadata_enabled=False,
-                      load_balancing_policy=(RoundRobinPolicy()))
+                      load_balancing_policy=TokenAwarePolicy(RoundRobinPolicy()))
     try:
         session = cluster.connect()
 
@@ -128,7 +128,7 @@ def setup(options):
 
 def teardown(options):
     cluster = Cluster(options.hosts, schema_metadata_enabled=False, token_metadata_enabled=False,
-                      load_balancing_policy=(RoundRobinPolicy()))
+                      load_balancing_policy=TokenAwarePolicy(RoundRobinPolicy()))
     session = cluster.connect()
     if not options.keep_data:
         session.execute("DROP KEYSPACE " + options.keyspace)

--- a/benchmarks/pipeline.py
+++ b/benchmarks/pipeline.py
@@ -30,8 +30,12 @@ class Runner(BenchmarkThread):
     def run(self):
         options, args = parse_options()
         write_pipeline = WritePipeline(self.session,
+                                       max_in_flight_requests=100,
+                                       max_unsent_write_requests=40000,
                                        allow_non_performant_queries=True)
         read_pipeline = ReadPipeline(self.session,
+                                     max_in_flight_requests=100,
+                                     max_unconsumed_read_responses=400,
                                      allow_non_performant_queries=True)
         self.start_profile()
 

--- a/benchmarks/pipeline.py
+++ b/benchmarks/pipeline.py
@@ -1,0 +1,54 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from base import benchmark, BenchmarkThread, parse_options
+
+import os
+from six.moves import range
+import sys
+
+dirname = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(dirname)
+sys.path.append(os.path.join(dirname, '..'))
+
+from cassandra.concurrent import WritePipeline, ReadPipeline
+
+
+class Runner(BenchmarkThread):
+
+    def run(self):
+        options, args = parse_options()
+        write_pipeline = WritePipeline(self.session,
+                                       allow_non_performant_queries=True)
+        read_pipeline = ReadPipeline(self.session,
+                                     allow_non_performant_queries=True)
+        self.start_profile()
+
+        for _ in range(self.num_queries):
+            if options.read:
+                read_pipeline.execute(self.query, self.values)
+            else:
+                write_pipeline.execute(self.query, self.values)
+
+        if options.read:
+            for _ in read_pipeline.results():
+                pass
+        else:
+            write_pipeline.confirm()
+
+        self.finish_profile()
+
+
+if __name__ == "__main__":
+    benchmark(Runner)

--- a/benchmarks/pipeline_tuning.py
+++ b/benchmarks/pipeline_tuning.py
@@ -60,24 +60,27 @@ class Runner(BenchmarkThread):
                 # query = prepared_statement
                 # self.values = ('key',)
 
-                start_time = time.time()
+                try:
+                    start_time = time.time()
 
-                for _ in range(self.num_queries):
+                    for _ in range(self.num_queries):
+                        if options.read:
+                            read_pipeline.execute(query, self.values)
+                        else:
+                            write_pipeline.execute(query, self.values)
+
                     if options.read:
-                        read_pipeline.execute(query, self.values)
+                        for _ in read_pipeline.results():
+                            pass
                     else:
-                        write_pipeline.execute(query, self.values)
+                        write_pipeline.confirm()
 
-                if options.read:
-                    for _ in read_pipeline.results():
-                        pass
-                else:
-                    write_pipeline.confirm()
-
-                elapsed_time = time.time() - start_time
-                result = (elapsed_time, max_in_flight_requests, buffer_size)
-                results.append(result)
-                print result
+                    elapsed_time = time.time() - start_time
+                    result = (elapsed_time, max_in_flight_requests, buffer_size)
+                    results.append(result)
+                    print result
+                except:
+                    print 'Failed:', max_in_flight_requests, buffer_size
 
         # sort the list by the shortest runtimes and choose the top results
         results.sort()

--- a/benchmarks/pipeline_tuning.py
+++ b/benchmarks/pipeline_tuning.py
@@ -82,6 +82,17 @@ class Runner(BenchmarkThread):
                 except:
                     print 'Failed:', max_in_flight_requests, buffer_size
 
+            print '=' * 60
+            print 'In Progress Stats\n'.upper()
+            self.print_stats(options, results)
+            print '=' * 60
+
+        print '=' * 60
+        print 'Final Stats\n'.upper()
+        self.print_stats(options, results)
+        print '=' * 60
+
+    def print_stats(self, options, results):
         # sort the list by the shortest runtimes and choose the top results
         results.sort()
         top_n = 10
@@ -101,18 +112,18 @@ class Runner(BenchmarkThread):
         best_average_buffer_size = int(round(best_average_buffer_size, -1))
 
         # Pretty print the top N results
-        print 'Top %s results' % top_n
+        print 'Top %s results:' % top_n
         pprint(optimal_runtimes)
 
         # Print the average value of the parameter values used for the fastest
         # runs
-        print '-' * 20
+        print '-' * 60
         print 'Best average max_in_flight_requests value:', best_average_max_in_flight_requests
         if options.read:
             print 'Best average max_unconsumed_read_responses value:', best_average_buffer_size
         else:
             print 'Best average max_unsent_write_requests value:', best_average_buffer_size
-        print '-' * 20
+        print '-' * 60
         print
 
 

--- a/benchmarks/pipeline_tuning.py
+++ b/benchmarks/pipeline_tuning.py
@@ -1,0 +1,117 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from base import benchmark, BenchmarkThread, parse_options
+
+import os
+from pprint import pprint
+from six.moves import range
+import sys
+import time
+
+dirname = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(dirname)
+sys.path.append(os.path.join(dirname, '..'))
+
+from cassandra.concurrent import WritePipeline, ReadPipeline
+
+
+def mean(numbers):
+    return float(sum(numbers)) / max(len(numbers), 1)
+
+
+class Runner(BenchmarkThread):
+
+    def run(self):
+        options, args = parse_options()
+        results = []
+
+        # test for the most performant max_in_flight_requests value from
+        # 100 to 5000 in increments of 100
+        for max_in_flight_requests in range(100, 5000, 100):
+            # test for the most performant buffer value from
+            # 100 to 50000 in increments of 100
+            for buffer_size in range(100, 50000, 100):
+                write_pipeline = WritePipeline(self.session,
+                                               max_in_flight_requests=max_in_flight_requests,
+                                               max_unsent_write_requests=buffer_size,
+                                               allow_non_performant_queries=True)
+                read_pipeline = ReadPipeline(self.session,
+                                             max_in_flight_requests=max_in_flight_requests,
+                                             max_unconsumed_read_responses=buffer_size,
+                                             allow_non_performant_queries=True)
+
+                query = self.query
+
+                # uncomment to test with prepared statements
+                # prepared_statement = self.session.prepare(
+                #     self.query.replace("'{key}'", '?'))
+                # query = prepared_statement
+                # self.values = ('key',)
+
+                start_time = time.time()
+
+                for _ in range(self.num_queries):
+                    if options.read:
+                        read_pipeline.execute(query, self.values)
+                    else:
+                        write_pipeline.execute(query, self.values)
+
+                if options.read:
+                    for _ in read_pipeline.results():
+                        pass
+                else:
+                    write_pipeline.confirm()
+
+                elapsed_time = time.time() - start_time
+                result = (elapsed_time, max_in_flight_requests, buffer_size)
+                results.append(result)
+                print result
+
+        # sort the list by the shortest runtimes and choose the top results
+        results.sort()
+        top_n = 10
+        optimal_runtimes = results[:top_n]
+
+        # create an average value of max_in_flight_requests for the top
+        # results and round to the nearest tenth unit
+        best_average_max_in_flight_requests = \
+            mean([result[1] for result in optimal_runtimes])
+        best_average_max_in_flight_requests = int(
+            round(best_average_max_in_flight_requests, -1))
+
+        # create an average value of buffer sizes for the top
+        # results and round to the nearest tenth unit
+        best_average_buffer_size = \
+            mean([result[2] for result in optimal_runtimes])
+        best_average_buffer_size = int(round(best_average_buffer_size, -1))
+
+        # Pretty print the top N results
+        print 'Top %s results' % top_n
+        pprint(optimal_runtimes)
+
+        # Print the average value of the parameter values used for the fastest
+        # runs
+        print '-' * 20
+        print 'Best average max_in_flight_requests value:', best_average_max_in_flight_requests
+        if options.read:
+            print 'Best average max_unconsumed_read_responses value:', best_average_buffer_size
+        else:
+            print 'Best average max_unsent_write_requests value:', best_average_buffer_size
+        print '-' * 20
+        print
+
+
+if __name__ == "__main__":
+    benchmark(Runner)

--- a/benchmarks/run_all.sh
+++ b/benchmarks/run_all.sh
@@ -15,7 +15,7 @@ python benchmarks/future_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
 python benchmarks/future_full_throttle.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
 python benchmarks/sync.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
 
-OPTIONS=--read
+OPTIONS="${OPTIONS} --read"
 
 python benchmarks/callback_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
 python benchmarks/pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}

--- a/benchmarks/run_all.sh
+++ b/benchmarks/run_all.sh
@@ -9,17 +9,29 @@ OPTIONS=
 set -x
 
 python benchmarks/callback_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/future_batches.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/future_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/future_full_throttle.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/sync.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 
 OPTIONS="${OPTIONS} --read"
 
 python benchmarks/callback_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/future_batches.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/future_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/future_full_throttle.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10
 python benchmarks/sync.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+sleep 10

--- a/benchmarks/run_all.sh
+++ b/benchmarks/run_all.sh
@@ -3,7 +3,7 @@
 # This file can be used to kick off each benchmarking test with a single
 # command.
 
-NUM_OF_OPS=50000
+NUM_OF_OPS=150000
 OPTIONS=
 
 set -x

--- a/benchmarks/run_all.sh
+++ b/benchmarks/run_all.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# This file can be used to kick off each benchmarking test with a single
+# command.
+
+NUM_OF_OPS=50000
+OPTIONS=
+
+set -x
+
+python benchmarks/callback_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/future_batches.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/future_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/future_full_throttle.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/sync.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+
+OPTIONS=--read
+
+python benchmarks/callback_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/future_batches.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/future_full_pipeline.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/future_full_throttle.py --num-ops ${NUM_OF_OPS} ${OPTIONS}
+python benchmarks/sync.py --num-ops ${NUM_OF_OPS} ${OPTIONS}

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -750,13 +750,22 @@ class WritePipeline(Pipeline):
         """
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exception_type, exception_value, traceback):
         """
         Ensures all writes are confirmed when exiting with-blocks.
 
         Failure to confirm all pending requests may cause some requests not to
         be delivered to Cassandra.
         """
+        if exception_type:
+            log.error(
+                'Exception type seen within codeblock: %s' % exception_type)
+            log.error(
+                'Exception value seen within codeblock: %s' % exception_value)
+            log.error(
+                'Exception traceback seen within codeblock: %s' % traceback)
+            log.info('Attempting to confirm() all other pending writes.')
+
         self.confirm()
 
 

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -261,11 +261,11 @@ class Pipeline(object):
     to send Cassandra requests.
     """
 
-    max_in_flight_requests = 1500
+    max_in_flight_requests = 1000
     """
     The maximum number of in-flight requests that have yet to return responses.
 
-    A default of 1500 in-flight requests for the ``WritePipeline`` and 700 for
+    A default of 1000 in-flight requests for the ``WritePipeline`` and 700 for
     the ``ReadPipeline`` are ideal for a small single node cluster. Performance
     tuning would be ideal to see the sort of throughput each individual cluster
     can achieve. Keep in mind that less in-flight requests are ideal for older
@@ -335,7 +335,7 @@ class Pipeline(object):
     """
 
     def __init__(self, session,
-                 max_in_flight_requests=1500,
+                 max_in_flight_requests=1000,
                  max_unsent_write_requests=40000,
                  max_unconsumed_read_responses=False,
                  error_handler=None,
@@ -676,11 +676,11 @@ class WritePipeline(Pipeline):
     to send Cassandra requests.
     """
 
-    max_in_flight_requests = 1500
+    max_in_flight_requests = 1000
     """
     The maximum number of in-flight requests that have yet to return responses.
 
-    A default of 1500 in-flight requests for the ``WritePipeline`` and 700 for
+    A default of 1000 in-flight requests for the ``WritePipeline`` and 700 for
     the ``ReadPipeline`` are ideal for a small single node cluster. Performance
     tuning would be ideal to see the sort of throughput each individual cluster
     can achieve. Keep in mind that less in-flight requests are ideal for older
@@ -730,7 +730,7 @@ class WritePipeline(Pipeline):
     """
 
     def __init__(self, session,
-                 max_in_flight_requests=1500,
+                 max_in_flight_requests=1000,
                  max_unsent_write_requests=40000,
                  error_handler=None,
                  allow_non_performant_queries=False):
@@ -843,7 +843,7 @@ class ReadPipeline(Pipeline):
     """
     The maximum number of in-flight requests that have yet to return responses.
 
-    A default of 1500 in-flight requests for the ``WritePipeline`` and 700 for
+    A default of 1000 in-flight requests for the ``WritePipeline`` and 700 for
     the ``ReadPipeline`` are ideal for a small single node cluster. Performance
     tuning would be ideal to see the sort of throughput each individual cluster
     can achieve. Keep in mind that less in-flight requests are ideal for older

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -280,6 +280,14 @@ class WritePipeline(object):
         # 2. creating the last future
         self.executing_lock = Lock()
 
+    def __enter__(self):
+        # add with-block support
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # ensure all writes are confirmed when exiting the with-block
+        self.confirm()
+
     def __future_callback(self, previous_result=pipeline_sentinel):
         # check to see if we're processing a future.result()
         if previous_result is not pipeline_sentinel:

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -797,7 +797,7 @@ class ReadPipeline(Pipeline):
 
     The results from :meth:`cassandra.concurrent.ReadPipeline.results()` follow
     the same ordering as statements that went into
-    :meth:`cassandra.concurrent.Pipeline.execute()` without no top-level
+    :meth:`cassandra.concurrent.Pipeline.execute()` without a top-level
     indication of the keyspace, table, nor query that was called that is not
     already accessible within the :class:`cassandra.cluster.ResultSet`.
 

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -583,16 +583,6 @@ class Pipeline(object):
         # attempt to process the newest statement
         self._maximize_in_flight_requests()
 
-    def confirm(self):
-        """
-        Blocks until all pending statements and in-flight requests have
-        returned.
-        """
-        # this Event() is set in __future_callback() if all sent requests have
-        # returned and cleared each time execute() is called since another
-        # statement is added to the `self.statements` Queue
-        self.completed_requests.wait()
-
 
 class WritePipeline(Pipeline):
     """
@@ -768,6 +758,16 @@ class WritePipeline(Pipeline):
 
         self.confirm()
 
+    def confirm(self):
+        """
+        Blocks until all pending statements and in-flight requests have
+        returned.
+        """
+        # this Event() is set in __future_callback() if all sent requests have
+        # returned and cleared each time execute() is called since another
+        # statement is added to the `self.statements` Queue
+        self.completed_requests.wait()
+
 
 class ReadPipeline(Pipeline):
     """
@@ -917,19 +917,6 @@ class ReadPipeline(Pipeline):
                                            max_unconsumed_read_responses=max_unconsumed_read_responses,
                                            error_handler=error_handler,
                                            allow_non_performant_queries=allow_non_performant_queries)
-
-    def confirm(self):
-        """
-        This is not implemented the for the ``ReadPipeline`` since we do not
-        simply want to confirm our read requests, but we also want to consume
-        them.
-        """
-        # reads should always be returned to the user, not simply checked for
-        # communication exceptions
-        raise NotImplementedError('The ReadPipeline should never discard'
-                                  ' results. Instead, call .results() to'
-                                  ' consume returned results rather than just'
-                                  ' confirming that futures were returned.')
 
     def results(self):
         """

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -423,7 +423,7 @@ class Pipeline(object):
             # being processed
             with self.in_flight_counter_lock:
                 # decrement the number of in-flight requests
-                self.in_flight_counter -= self.in_flight_counter
+                self.in_flight_counter -= 1
 
                 # if there are no more pending statements and all in-flight
                 # futures have returned set self.completed_futures to True

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -244,10 +244,6 @@ def execute_concurrent_with_args(session, statement, parameters, *args, **kwargs
 # a real result
 RESULT_SENTINEL = object()
 
-# a sentinel to detect if a kwarg was using the default value or was passed
-# a user-defined parameter
-PROTOCOL_DEFAULT = object()
-
 
 class Pipeline(object):
     """
@@ -265,9 +261,15 @@ class Pipeline(object):
     to send Cassandra requests.
     """
 
-    max_in_flight_requests = PROTOCOL_DEFAULT
+    max_in_flight_requests = 1500
     """
     The maximum number of in-flight requests that have yet to return responses.
+
+    A default of 1500 in-flight requests for the ``WritePipeline`` and 700 for
+    the ``ReadPipeline`` are ideal for a small single node cluster. Performance
+    tuning would be ideal to see the sort of throughput each individual cluster
+    can achieve. Keep in mind that less in-flight requests are ideal for older
+    versions of Cassandra.
 
     As :attr:`cassandra.concurrent.Pipeline.max_in_flight_requests` is reached,
     statements are queued up for execution as soon as a
@@ -341,16 +343,8 @@ class Pipeline(object):
         # the Cassandra session object
         self.session = session
 
-        # set max_in_flight_requests if provided
-        if max_in_flight_requests is not PROTOCOL_DEFAULT:
-            self.max_in_flight_requests = max_in_flight_requests
-        else:
-            # else, use the recommended defaults for newer protocol versions
-            # since protocol version 3 allows for more parallel requests
-            if self.session._protocol_version >= 3:
-                self.max_in_flight_requests = 1500
-            else:
-                self.max_in_flight_requests = 100
+        # set max_in_flight_requests
+        self.max_in_flight_requests = max_in_flight_requests
 
         # set the maximum number of unsent write requests before the Pipeline
         # blocks to ensure that all in-flight write requests have been
@@ -675,9 +669,15 @@ class WritePipeline(Pipeline):
     to send Cassandra requests.
     """
 
-    max_in_flight_requests = PROTOCOL_DEFAULT
+    max_in_flight_requests = 1500
     """
     The maximum number of in-flight requests that have yet to return responses.
+
+    A default of 1500 in-flight requests for the ``WritePipeline`` and 700 for
+    the ``ReadPipeline`` are ideal for a small single node cluster. Performance
+    tuning would be ideal to see the sort of throughput each individual cluster
+    can achieve. Keep in mind that less in-flight requests are ideal for older
+    versions of Cassandra.
 
     As :attr:`cassandra.concurrent.Pipeline.max_in_flight_requests` is reached,
     statements are queued up for execution as soon as a
@@ -832,9 +832,15 @@ class ReadPipeline(Pipeline):
     to send Cassandra requests.
     """
 
-    max_in_flight_requests = PROTOCOL_DEFAULT
+    max_in_flight_requests = 700
     """
     The maximum number of in-flight requests that have yet to return responses.
+
+    A default of 1500 in-flight requests for the ``WritePipeline`` and 700 for
+    the ``ReadPipeline`` are ideal for a small single node cluster. Performance
+    tuning would be ideal to see the sort of throughput each individual cluster
+    can achieve. Keep in mind that less in-flight requests are ideal for older
+    versions of Cassandra.
 
     As :attr:`Pipeline.max_in_flight_requests` is reached, statements
     are queued up for execution as soon as a

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -793,7 +793,7 @@ class ReadPipeline(Pipeline):
     The result from :meth:`cassandra.concurrent.ReadPipeline.results()` is an
     iterator of :class:`cassandra.cluster.ResultSet` objects which in turn
     another iterator over the result's rows and the same type of object
-    returned when calling :meth:`cassandra.cluster.Session.execute()`. The
+    returned when calling :meth:`cassandra.cluster.Session.execute()`.
 
     The results from :meth:`cassandra.concurrent.ReadPipeline.results()` follow
     the same ordering as statements that went into

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -276,7 +276,7 @@ class Pipeline(object):
     :class:`cassandra.cluster.ResponseFuture` is returned.
     """
 
-    max_unsent_write_requests = 50000
+    max_unsent_write_requests = 40000
     """
     This value is specifically for a ``WritePipeline`` to set the maximum
     number of queued write requests that have yet to be delivered to Cassandra.
@@ -691,7 +691,7 @@ class WritePipeline(Pipeline):
     :class:`cassandra.cluster.ResponseFuture` is returned.
     """
 
-    max_unsent_write_requests = 50000
+    max_unsent_write_requests = 40000
     """
     This value is specifically for a ``WritePipeline`` to set the maximum
     number of queued write requests that have yet to be delivered to Cassandra.

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -427,8 +427,13 @@ class Pipeline(object):
 
                 # if there are no more pending statements and all in-flight
                 # futures have returned set self.completed_futures to True
-                if self.in_flight_counter == 0:
+                if self.in_flight_counter < 1:
                     if self.statements.empty():
+                        if self.in_flight_counter < 0:
+                            raise RuntimeError('The in_flight_counter should'
+                                               ' never have been less than 0.'
+                                               ' The lock mechanism is not'
+                                               ' working as expected!')
                         self.completed_futures.set()
 
         # attempt to process the another request
@@ -912,7 +917,10 @@ class ReadPipeline(Pipeline):
         """
         # reads should always be returned to the user, not simply checked for
         # communication exceptions
-        raise NotImplementedError
+        raise NotImplementedError('The ReadPipeline should never discard'
+                                  ' results. Instead, call .results() to'
+                                  ' consume returned results rather than just'
+                                  ' confirming that futures were returned.')
 
     def results(self):
         """

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -261,11 +261,11 @@ class Pipeline(object):
     to send Cassandra requests.
     """
 
-    max_in_flight_requests = 1000
+    max_in_flight_requests = 100
     """
     The maximum number of in-flight requests that have yet to return responses.
 
-    A default of 1000 in-flight requests for the ``WritePipeline`` and 700 for
+    A default of 100 in-flight requests for the ``WritePipeline`` and 100 for
     the ``ReadPipeline`` are ideal for a small single node cluster. Performance
     tuning would be ideal to see the sort of throughput each individual cluster
     can achieve. Keep in mind that less in-flight requests are ideal for older
@@ -335,7 +335,7 @@ class Pipeline(object):
     """
 
     def __init__(self, session,
-                 max_in_flight_requests=1000,
+                 max_in_flight_requests=100,
                  max_unsent_write_requests=40000,
                  max_unconsumed_read_responses=False,
                  error_handler=None,
@@ -676,11 +676,11 @@ class WritePipeline(Pipeline):
     to send Cassandra requests.
     """
 
-    max_in_flight_requests = 1000
+    max_in_flight_requests = 100
     """
     The maximum number of in-flight requests that have yet to return responses.
 
-    A default of 1000 in-flight requests for the ``WritePipeline`` and 700 for
+    A default of 100 in-flight requests for the ``WritePipeline`` and 100 for
     the ``ReadPipeline`` are ideal for a small single node cluster. Performance
     tuning would be ideal to see the sort of throughput each individual cluster
     can achieve. Keep in mind that less in-flight requests are ideal for older
@@ -730,7 +730,7 @@ class WritePipeline(Pipeline):
     """
 
     def __init__(self, session,
-                 max_in_flight_requests=1000,
+                 max_in_flight_requests=100,
                  max_unsent_write_requests=40000,
                  error_handler=None,
                  allow_non_performant_queries=False):
@@ -839,11 +839,11 @@ class ReadPipeline(Pipeline):
     to send Cassandra requests.
     """
 
-    max_in_flight_requests = 700
+    max_in_flight_requests = 100
     """
     The maximum number of in-flight requests that have yet to return responses.
 
-    A default of 1000 in-flight requests for the ``WritePipeline`` and 700 for
+    A default of 100 in-flight requests for the ``WritePipeline`` and 100 for
     the ``ReadPipeline`` are ideal for a small single node cluster. Performance
     tuning would be ideal to see the sort of throughput each individual cluster
     can achieve. Keep in mind that less in-flight requests are ideal for older
@@ -898,7 +898,7 @@ class ReadPipeline(Pipeline):
     """
 
     def __init__(self, session,
-                 max_in_flight_requests=700,
+                 max_in_flight_requests=100,
                  max_unconsumed_read_responses=400,
                  error_handler=None,
                  allow_non_performant_queries=False):

--- a/cassandra/concurrent.py
+++ b/cassandra/concurrent.py
@@ -476,7 +476,7 @@ class Pipeline(object):
             with self.in_flight_counter_lock:
                 args, kwargs = self.statements.get_nowait()
                 self.in_flight_counter += 1
-                self.completed_futures.clear()
+            self.completed_futures.clear()
         except Empty:
             # exit early if there are no more statements to process
             return


### PR DESCRIPTION
Hello,

I've added an interface very similar to the `execute_concurrent()` method that is based off the original documentation on how to use callbacks.

The idea is a `Pipeline` object would cache requests and limit results until consumed in an effort to always have a full pipeline of requests. The initial benchmarks seem promising, but perhaps we can do better:

https://github.com/joaquincasares/python-driver/blob/TLP-308/benchmarks/README.md

Example usage of the WritePipeline can be found here: https://github.com/joaquincasares/python-driver/blob/TLP-308/cassandra/concurrent.py#L629-L641

    >>> from cassandra.cluster import Cluster
    >>> from cassandra.concurrent import WritePipeline
    >>> cluster = Cluster(['192.168.1.1', '192.168.1.2'])
    >>> session = cluster.connect()
    >>> write_pipeline = WritePipeline(session)
    >>> prepared_statement = session.prepare("INSERT INTO mykeyspace.users (name, age) VALUES (?, ?)")
    >>> write_pipeline.execute(prepared_statement, ('Jorge', 28))
    >>> write_pipeline.execute(prepared_statement, ('Jose', 28))
    >>> write_pipeline.execute(prepared_statement, ('Sara', 25))
    >>> ...
    >>> write_pipeline.confirm()
    >>> ...
    >>> cluster.shutdown()

Example usage of the ReadPipeline can be found here: https://github.com/joaquincasares/python-driver/blob/TLP-308/cassandra/concurrent.py#L825-L842

    >>> from cassandra.cluster import Cluster
    >>> from cassandra.concurrent import ReadPipeline
    >>> cluster = Cluster(['192.168.1.1', '192.168.1.2'])
    >>> session = cluster.connect()
    >>> read_pipeline = ReadPipeline(session)
    >>> prepared_statement = session.prepare('SELECT * FROM mykeyspace.users WHERE name = ?')
    >>> read_pipeline.execute(prepared_statement, ('Jorge'))
    >>> read_pipeline.execute(prepared_statement, ('Jose'))
    >>> read_pipeline.execute(prepared_statement, ('Sara'))
    >>> prepared_statement = session.prepare('SELECT * FROM old_keyspace.old_users WHERE name = ?')
    >>> read_pipeline.execute(prepared_statement, ('Jorge'))
    >>> read_pipeline.execute(prepared_statement, ('Jose'))
    >>> read_pipeline.execute(prepared_statement, ('Sara'))
    >>> for result in read_pipeline.results():
    ...     for row in result:
    ...         print row.name, row.age
    >>> ...
    >>> cluster.shutdown()

I figured to leave in each individual commit since `git blame` may be able to help if my comments ever do not have context, but don't hesitate to squash the commits if this PR is accepted.

The TL;DR is that by using `pipeline.execute()` we effectively:

* Use `session.execute_async()` without having to manage futures.
* Manage returned future counts to ensure we never run out of memory.
* Handle business logic between sending asynchronous requests and processing them.
* Remove boilerplate `future` code within applications while providing centralized performance enhancements.
* Includes a tuning application within `benchmarks/` to find the number of requests that can saturate without overloading the cluster.