### PR TITLE
PYTHON-1015: Fix wrong resultset indexing use

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
-3.15.2
+3.16.0
 ======
+NOT RELEASED
 
 Bug Fixes
 ---------
@@ -10,6 +11,7 @@ Bug Fixes
 Other
 -----
 * Fix tests when RF is not maintained if we decomission a node (PYTHON-1017)
+* Fix wrong use of ResultSet indexing (PYTHON-1015)
 
 3.15.1
 ======

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -76,7 +76,7 @@ def check_applied(result):
     except Exception:
         applied = True  # result was not LWT form
     if not applied:
-        raise LWTException(result[0])
+        raise LWTException(result.one())
 
 
 class AbstractQueryableColumn(UnicodeMixin):
@@ -841,7 +841,7 @@ class AbstractQuerySet(object):
             query = self._select_query()
             query.count = True
             result = self._execute(query)
-            count_row = result[0].popitem()
+            count_row = result.one().popitem()
             self._count = count_row[1]
         return self._count
 


### PR DESCRIPTION
There are many resultset indexing use in tests. This is normal since all those fixes are in the 4.x branch. I did some attempts to ignore those warning when running tests without luck. 