### PR TITLE
Python 895 require only one resolved contact point

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Bug Fixes
 * Fix OSS driver's virtual table support against DSE 6.0.X and future server releases (PYTHON-1020)
 * ResultSet.one() fails if the row_factory is using a generator (PYTHON-1026)
 * Log profile name on attempt to create existing profile (PYTHON-944)
+* Cluster instantiation fails if any contact points' hostname resolution fails (PYTHON-895)
 
 Other
 -----

--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -686,3 +686,13 @@ class UnsupportedOperation(DriverException):
     for more details.
     """
     pass
+
+
+class UnresolvableContactPoints(DriverException):
+    """
+    The driver was unable to resolve any provided hostnames.
+
+    Note that this is *not* raised when a :class:`.Cluster` is created with no
+    contact points, only when lookup fails for all hosts
+    """
+    pass

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1118,7 +1118,6 @@ class Cluster(object):
         if not_done:
             raise OperationTimedOut("Failed to create all new connection pools in the %ss timeout.")
 
-
     def get_min_requests_per_connection(self, host_distance):
         return self._min_requests_per_connection[host_distance]
 
@@ -2061,7 +2060,6 @@ class Session(object):
     .. versionadded:: 3.8.0
     """
 
-
     encoder = None
     """
     A :class:`~cassandra.encoder.Encoder` instance that will be used when
@@ -2250,7 +2248,6 @@ class Session(object):
             row_factory = execution_profile.row_factory
             load_balancing_policy = execution_profile.load_balancing_policy
             spec_exec_policy = execution_profile.speculative_execution_policy
-
 
         fetch_size = query.fetch_size
         if fetch_size is FETCH_SIZE_UNSET and self._protocol_version >= 2:

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -86,6 +86,7 @@ def _is_gevent_monkey_patched():
     import gevent.socket
     return socket.socket is gevent.socket.socket
 
+
 # default to gevent when we are monkey patched with gevent, eventlet when
 # monkey patched with eventlet, otherwise if libev is available, use that as
 # the default because it's fastest. Otherwise, use asyncore.
@@ -180,6 +181,7 @@ def _shutdown_clusters():
     clusters = _clusters_for_shutdown.copy()  # copy because shutdown modifies the global set "discard"
     for cluster in clusters:
         cluster.shutdown()
+
 
 atexit.register(_shutdown_clusters)
 

--- a/tests/integration/simulacron/__init__.py
+++ b/tests/integration/simulacron/__init__.py
@@ -35,20 +35,25 @@ class SimulacronBase(unittest.TestCase):
 
 
 class SimulacronCluster(SimulacronBase):
+
+    cluster, connect = None, True
+
     @classmethod
     def setUpClass(cls):
         if SIMULACRON_JAR is None or CASSANDRA_VERSION < Version("2.1"):
             return
 
         start_and_prime_singledc()
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION, compression=False)
-        cls.session = cls.cluster.connect(wait_for_all_pools=True)
+        if cls.connect:
+            cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION, compression=False)
+            cls.session = cls.cluster.connect(wait_for_all_pools=True)
 
     @classmethod
     def tearDownClass(cls):
         if SIMULACRON_JAR is None or CASSANDRA_VERSION < Version("2.1"):
             return
 
-        cls.cluster.shutdown()
+        if cls.cluster:
+            cls.cluster.shutdown()
         stop_simulacron()
 

--- a/tests/integration/simulacron/__init__.py
+++ b/tests/integration/simulacron/__init__.py
@@ -56,4 +56,3 @@ class SimulacronCluster(SimulacronBase):
         if cls.cluster:
             cls.cluster.shutdown()
         stop_simulacron()
-

--- a/tests/integration/simulacron/test_cluster.py
+++ b/tests/integration/simulacron/test_cluster.py
@@ -21,6 +21,8 @@ from tests.integration import requiressimulacron
 from tests.integration.simulacron.utils import prime_query
 
 from cassandra import WriteTimeout, WriteType, ConsistencyLevel
+from cassandra.cluster import Cluster
+
 
 @requiressimulacron
 class ClusterTests(SimulacronCluster):

--- a/tests/integration/simulacron/test_cluster.py
+++ b/tests/integration/simulacron/test_cluster.py
@@ -17,7 +17,7 @@ except ImportError:
     import unittest  # noqa
 
 from tests.integration.simulacron import SimulacronCluster
-from tests.integration import requiressimulacron
+from tests.integration import (requiressimulacron, PROTOCOL_VERSION)
 from tests.integration.simulacron.utils import prime_query
 
 from cassandra import WriteTimeout, WriteType, ConsistencyLevel
@@ -55,3 +55,19 @@ class ClusterTests(SimulacronCluster):
         self.assertIn(consistency, str(wt))
         self.assertIn(str(received_responses), str(wt))
         self.assertIn(str(required_responses), str(wt))
+
+    def test_connection_with_one_unresolvable_contact_point(self):
+        self.cluster.shutdown()
+
+        # shouldn't raise anything due to name resolution failures
+        Cluster(['127.0.0.1', 'doesntresolve.becauseitcant'],
+                protocol_version=PROTOCOL_VERSION,
+                compression=False)
+
+    def test_connection_with_only_unresolvable_contact_points(self):
+        self.cluster.shutdown()
+
+        # shouldn't raise anything due to name resolution failures
+        Cluster(['doesntresolve.becauseitcant'],
+                protocol_version=PROTOCOL_VERSION,
+                compression=False)


### PR DESCRIPTION
We can push this to the next release if timing necessitates it; I'm just PRing because I found this branch lying around.