### PR TITLE
PYTHON-1042: replacement for lz4 test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+3.17.0
+======
+NOT RELEASED
+
+Other
+-----
+* Fail faster on incorrect lz4 import (PYTHON-1042)
+
+
 3.16.0
 ======
 November 12, 2018

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -68,6 +68,17 @@ else:
     except ImportError:
         lz4_block = lz4
 
+    try:
+        lz4_block.compress
+        lz4_block.decompress
+    except AttributeError:
+        raise ImportError(
+            'lz4 not imported correctly. Imported object should have '
+            '.compress and and .decompress attributes but does not. '
+            'Please file a bug report on JIRA. (Imported object was '
+            '{lz4_block})'.format(lz4_block=repr(lz4_block))
+        )
+
     # Cassandra writes the uncompressed message length in big endian order,
     # but the lz4 lib requires little endian order, so we wrap these
     # functions to handle that

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -411,14 +411,6 @@ class ConnectionHeartbeatTest(unittest.TestCase):
             [call(connection)] * get_holders.call_count)
 
 
-class LZ4Tests(unittest.TestCase):
-    def test_lz4_is_correctly_imported(self):
-        try:
-            import lz4
-        except ImportError:
-            return
-        from lz4 import block as lz4_block
-
 class TimerTest(unittest.TestCase):
 
     def test_timer_collision(self):


### PR DESCRIPTION
Supercedes #952 to fail fast if we import lz4 incorrectly.