### PR TITLE
Python 914: use datetime.fromtimestamp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 ======
 NOT RELEASED
 
+Bug Fixes
+---------
+* Convert Python timestamps to UUID without float multiplication (PYTHON-914)
+
 Other
 -----
 * Fail faster on incorrect lz4 import (PYTHON-1042)

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -100,11 +100,12 @@ def uuid_from_time(time_arg, node=None, clock_seq=None):
     :rtype: :class:`uuid.UUID`
 
     """
-    if hasattr(time_arg, 'utctimetuple'):
-        seconds = int(calendar.timegm(time_arg.utctimetuple()))
-        microseconds = (seconds * 1e6) + time_arg.time().microsecond
-    else:
-        microseconds = int(time_arg * 1e6)
+    # PYTHON-914: use builtin utils to convert float into datetime without
+    # multiplication errors
+    if not hasattr(time_arg, 'utctimetuple'):
+        time_arg = datetime.datetime.fromtimestamp(time_arg)
+    seconds = int(calendar.timegm(time_arg.utctimetuple()))
+    microseconds = (seconds * 1e6) + time_arg.time().microsecond
 
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -105,11 +105,11 @@ def uuid_from_time(time_arg, node=None, clock_seq=None):
     if not hasattr(time_arg, 'utctimetuple'):
         time_arg = datetime.datetime.fromtimestamp(time_arg)
     seconds = int(calendar.timegm(time_arg.utctimetuple()))
-    microseconds = (seconds * 1e6) + time_arg.time().microsecond
+    microseconds = (seconds * 1000000) + time_arg.time().microsecond
 
     # 0x01b21dd213814000 is the number of 100-ns intervals between the
     # UUID epoch 1582-10-15 00:00:00 and the Unix epoch 1970-01-01 00:00:00.
-    intervals = int(microseconds * 10) + 0x01b21dd213814000
+    intervals = microseconds * 10 + 0x01b21dd213814000
 
     time_low = intervals & 0xffffffff
     time_mid = (intervals >> 32) & 0xffff


### PR DESCRIPTION
See the commit message for the first commit for comments on the solution here. I've also made a multiplication change that makes an `int` call unnecessary.