### PR TITLE
PYTHON-891: Improve handling of ssl errors when sending a message

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,10 @@ Features
 * Add Cluster ssl_context option to enable SSL (PYTHON-995)
 * Allow encrypted private keys for 2-way SSL cluster connections (PYTHON-995)
 
+Bug Fixes
+---------
+* NoHostAvailable when all hosts are up and connectable (PYTHON-891)
+
 Other
 -----
 * Fail faster on incorrect lz4 import (PYTHON-1042)

--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -402,7 +402,8 @@ class AsyncoreConnection(Connection, asyncore.dispatcher):
                 sent = self.send(next_msg)
                 self._readable = True
             except socket.error as err:
-                if (err.args[0] in NONBLOCKING):
+                if (err.args[0] in NONBLOCKING or
+                        err.args[0] in (ssl.SSL_ERROR_WANT_READ, ssl.SSL_ERROR_WANT_WRITE)):
                     with self.deque_lock:
                         self.deque.appendleft(next_msg)
                 else:

--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -316,7 +316,8 @@ class LibevConnection(Connection):
             try:
                 sent = self._socket.send(next_msg)
             except socket.error as err:
-                if (err.args[0] in NONBLOCKING):
+                if (err.args[0] in NONBLOCKING or
+                        err.args[0] in (ssl.SSL_ERROR_WANT_READ, ssl.SSL_ERROR_WANT_WRITE)):
                     with self._deque_lock:
                         self.deque.appendleft(next_msg)
                 else:


### PR DESCRIPTION
This is similar to the PYTHON-1024 fix. This PR improves how SSL WANT_READ/WANT_WRITE errors are handled. Basically, we just re-queue the chunk to complete the message instead of erroring the connection.

Note: The asyncio fix is not included in this PR.