### PR TITLE
PYTHON-1068: send driver name/version in startup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 ======
 NOT RELEASED
 
+Features
+--------
+* Send driver name and version in startup message (PYTHON-1068)
+
 Other
 -----
 * Fail faster on incorrect lz4 import (PYTHON-1042)

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -106,6 +106,8 @@ else:
     locally_supported_compressions['snappy'] = (snappy.compress, decompress)
 
 
+DRIVER_NAME, DRIVER_VERSION = 'DataStax Python Driver', sys.modules['cassandra'].__version__
+
 PROTOCOL_VERSION_MASK = 0x7f
 
 HEADER_DIRECTION_FROM_CLIENT = 0x00
@@ -721,7 +723,8 @@ class Connection(object):
     @defunct_on_error
     def _send_startup_message(self, compression=None, no_compact=False):
         log.debug("Sending StartupMessage on %s", self)
-        opts = {}
+        opts = {'DRIVER_NAME': DRIVER_NAME,
+                'DRIVER_VERSION': DRIVER_VERSION}
         if compression:
             opts['COMPRESSION'] = compression
         if no_compact:


### PR DESCRIPTION
The tests passed except for the `test-dse` tests. Test run 1 is the same code; the new force-pushed commit was just a commit message change.

You can verify that the feature works manually by connecting to a C* instance running `trunk` and checking `s.execute('SELECT * FROM system_views.clients'))`.