### PR TITLE
Handle case where there is both TTL and TIMESTAMP

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,12 +8,12 @@ Features
 * Abstract Host Connection information (PYTHON-1079)
 * Improve version parsing to support a non-integer 4th component (PYTHON-1091)
 * Expose on_request_error method in the RetryPolicy (PYTHON-1064)
-* Add test for error when combining TTL and TIMESTAMP on INSERT (PYTHON-1093)
 
 Bug Fixes
 ---------
 
 * Fix error when preparing queries with beta protocol v5 (PYTHON-1081)
+* Fix error when combining TTL and TIMESTAMP on INSERT (PYTHON-1093)
 
 3.17.1
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Features
 * Abstract Host Connection information (PYTHON-1079)
 * Improve version parsing to support a non-integer 4th component (PYTHON-1091)
 * Expose on_request_error method in the RetryPolicy (PYTHON-1064)
+* Add test for error when combining TTL and TIMESTAMP on INSERT (PYTHON-1093)
 
 Bug Fixes
 ---------

--- a/cassandra/cqlengine/statements.py
+++ b/cassandra/cqlengine/statements.py
@@ -755,7 +755,8 @@ class InsertStatement(AssignmentStatement):
             qs += ["USING TTL {0}".format(self.ttl)]
 
         if self.timestamp:
-            qs += ["USING TIMESTAMP {0}".format(self.timestamp_normalized)]
+            statement = "AND TIMESTAMP {0}" if self.ttl else "USING TIMESTAMP {0}"
+            qs += [statement.format(self.timestamp_normalized)]
 
         return ' '.join(qs)
 

--- a/tests/integration/cqlengine/test_timestamp.py
+++ b/tests/integration/cqlengine/test_timestamp.py
@@ -83,6 +83,16 @@ class CreateWithTimestampTest(BaseTimestampTest):
 
         "USING TIMESTAMP".should.be.within(query)
 
+    def test_non_batch_syntax_with_ttl_unit(self):
+
+        with mock.patch.object(self.session, "execute") as m:
+            TestTimestampModel.timestamp(timedelta(seconds=30)).ttl(30).create(
+                count=1)
+
+        query = m.call_args[0][0].query_string
+
+        query.should.match(r"USING TTL \d* AND TIMESTAMP")
+
 
 class UpdateWithTimestampTest(BaseTimestampTest):
     def setUp(self):


### PR DESCRIPTION
The existing code causes an error like so:
```
cassandra.protocol.SyntaxException: <Error from server: code=2000 [Syntax error in CQL query] message="line 1:101 missing EOF at 'TIMESTAMP' (...({row}) USING TTL {ttl} [USING] TIMESTAMP {timestamp})">
```

by checking for the ttl in the timestamp code we can change the generated query from `USING TTL {ttl} USING TIMESTAMP {timestamp}` => `USING TTL {ttl} AND TIMESTAMP {timestamp}`, which is correct.