### PR TITLE
PYTHON-1065: Add jitter to ExponentialReconnectionPolicy

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Features
 * Abstract Host Connection information (PYTHON-1079)
 * Improve version parsing to support a non-integer 4th component (PYTHON-1091)
 * Expose on_request_error method in the RetryPolicy (PYTHON-1064)
+* Add jitter to ExponentialReconnectionPolicy (PYTHON-1065)
 
 Bug Fixes
 ---------


### PR DESCRIPTION
@jorgebay I noticed when I was done implementing this feature that the nodejs impl does a bit more than the python and the Java ones. The nodeJS one applies only +0-15% when the delay is base_delay and only -0-15% when it's max delay. Do you think it's mandatory to modify?