### PR TITLE
Remove doc pointing RoundRobinPolicy as default

### DIFF
--- a/cassandra/policies.py
+++ b/cassandra/policies.py
@@ -155,8 +155,6 @@ class RoundRobinPolicy(LoadBalancingPolicy):
     A subclass of :class:`.LoadBalancingPolicy` which evenly
     distributes queries across all nodes in the cluster,
     regardless of what datacenter the nodes may be in.
-
-    This load balancing policy is used by default.
     """
     _live_hosts = frozenset(())
     _position = 0


### PR DESCRIPTION
Remove a sentence from the API docs pointing to `RoundRobinPolicy` as the default lbp.