### PR TITLE
[PYTHON-622] Performance Improvement for NetworkTopologyStrategy make_token_replica_map

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Features
 * Future-proof Mapping imports (PYTHON-1023)
 * Remove invalid warning in set_session when we initialize a default connection (PYTHON-1104)
 * Include param values in cqlengine logging (PYTHON-1105)
+* NTS Token Replica Map Generation is slow (PYTHON-622)
+
 Bug Fixes
 ---------
 * as_cql_query UDF/UDA parameters incorrectly includes "frozen" if arguments are collections (PYTHON-1031)
@@ -16,7 +18,6 @@ Bug Fixes
 * Call ConnectionException with correct kwargs (PYTHON-1117)
 * Can't connect to clusters built from source because version parsing doesn't handle 'x.y-SNAPSHOT' (PYTHON-1118)
 * Set the proper default ExecutionProfile.row_factory value (PYTHON-1119)
-* NTS Token Replica Map Generation is slow (PYTHON-622)
 
 3.18.0
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Bug Fixes
 * Call ConnectionException with correct kwargs (PYTHON-1117)
 * Can't connect to clusters built from source because version parsing doesn't handle 'x.y-SNAPSHOT' (PYTHON-1118)
 * Set the proper default ExecutionProfile.row_factory value (PYTHON-1119)
+* NTS Token Replica Map Generation is slow (PYTHON-622)
+
 3.18.0
 ======
 May 27, 2019

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -536,7 +536,12 @@ class NetworkTopologyStrategy(ReplicationStrategy):
                 racks_placed = set()
                 racks_this_dc = dc_racks[dc]
                 hosts_this_dc = len(hosts_per_dc[dc])
-                for token_offset in islice(cycle(token_offsets), index, index + num_tokens):
+
+                for token_offset_index in six.moves.range(index, index+num_tokens):
+                    if token_offset_index >= len(token_offsets):
+                        token_offset_index = token_offset_index - len(token_offsets)
+
+                    token_offset = token_offsets[token_offset_index]
                     host = token_to_host_owner[ring[token_offset]]
                     if replicas_remaining == 0 or replicas_this_dc == hosts_this_dc:
                         break


### PR DESCRIPTION
This update makes the `make_token_replica_map` function multiple times
faster. 

**Problem**

The previous implementation used a combination of islice and cycle.
`cycle` will build an internal list, and save every element it produces.
`islice` will iterate over everything in it's sequence up to `start`.
On every token in the ring, it will build the entire list of offsets again in memory up to that tokens index in the list. The `islice` and `cycle` combination was used to allow nice wrapping around of the list.

I've replaced this with a simple iteration over the existing list.

Timings on my (admittingly slow) machine for these tests show
differences in speed of:

pre_change:

test_nts_token_performance_large_cluster:
4.509002365055494

test_nts_token_performance_large_with_small_backup
5.222048101015389

post_change:

test_nts_token_performance_large_cluster:
0.2818319270154461

test_nts_token_performance_large_with_small_backup
0.6304094420047477

I've done some more performance testing on a load-testing cluster with
200 nodes and 256 vnodes, and the performance improvement is roughly
30x.

@GregBestland added some very useful performance tests for this in [PYTHON-622], however the way
that the tokens were generated and distributed in the ring meant the
tests were quite slow due to the fact that each nodes vnodes tokens were
adjacent in the ring causing many iterations to find the next replica on
a different physical node.


Note: we probably don't want to include these tests in the standard suite as they are. Any recommendations for what tests to include would be appreciated.

[PYTHON-622]: https://datastax-oss.atlassian.net/browse/PYTHON-622