### PR TITLE
[PYTHON-1100] Fix incorrect metadata for compact counter tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features
 
 Bug Fixes
 ---------
+* Fix incorrect metadata for compact counter tables (PYTHON-1100)
 * Call ConnectionException with correct kwargs (PYTHON-1117)
 3.18.0
 ======

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -2326,9 +2326,9 @@ class SchemaParserV3(SchemaParserV22):
             table_meta.options = self._build_table_options(row)
             flags = row.get('flags', set())
             if flags:
-                compact_static = False
-                table_meta.is_compact_storage = 'dense' in flags or 'super' in flags or 'compound' not in flags
                 is_dense = 'dense' in flags
+                compact_static = not is_dense and 'super' not in flags and 'compound' not in flags
+                table_meta.is_compact_storage = is_dense or 'super' in flags or 'compound' not in flags
             elif virtual:
                 compact_static = False
                 table_meta.is_compact_storage = False

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -405,6 +405,53 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         tablemeta = self.get_table_metadata()
         self.check_create_statement(tablemeta, create_statement)
 
+    def test_compact_storage(self):
+        create_statement = self.make_create_statement(["a"], [], ["b"])
+        create_statement += " WITH COMPACT STORAGE"
+
+        self.session.execute(create_statement)
+        tablemeta = self.get_table_metadata()
+        self.check_create_statement(tablemeta, create_statement)
+
+    def test_dense_compact_storage(self):
+        create_statement = self.make_create_statement(["a"], ["b"], ["c"])
+        create_statement += " WITH COMPACT STORAGE"
+
+        self.session.execute(create_statement)
+        tablemeta = self.get_table_metadata()
+        self.check_create_statement(tablemeta, create_statement)
+
+    def test_counter(self):
+        create_statement = (
+            "CREATE TABLE {keyspace}.{table} ("
+            "key text PRIMARY KEY, a1 counter)"
+        ).format(keyspace=self.keyspace_name, table=self.function_table_name)
+
+        self.session.execute(create_statement)
+        tablemeta = self.get_table_metadata()
+        self.check_create_statement(tablemeta, create_statement)
+
+    def test_counter_with_compact_storage(self):
+        """ PYTHON-1100 """
+        create_statement = (
+            "CREATE TABLE {keyspace}.{table} ("
+            "key text PRIMARY KEY, a1 counter) WITH COMPACT STORAGE"
+        ).format(keyspace=self.keyspace_name, table=self.function_table_name)
+
+        self.session.execute(create_statement)
+        tablemeta = self.get_table_metadata()
+        self.check_create_statement(tablemeta, create_statement)
+
+    def test_counter_with_dense_compact_storage(self):
+        create_statement = (
+            "CREATE TABLE {keyspace}.{table} ("
+            "key text, c1 text, a1 counter, PRIMARY KEY (key, c1)) WITH COMPACT STORAGE"
+        ).format(keyspace=self.keyspace_name, table=self.function_table_name)
+
+        self.session.execute(create_statement)
+        tablemeta = self.get_table_metadata()
+        self.check_create_statement(tablemeta, create_statement)
+
     def test_indexes(self):
         create_statement = self.make_create_statement(["a"], ["b", "c"], ["d", "e", "f"])
         create_statement += " WITH CLUSTERING ORDER BY (b ASC, c ASC)"


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/PYTHON-1100

I might have gone overboard with the tests, but I didn't find other tests around the compact storage flags, so figured it'd be good to add a couple other checks there too.