### PR TITLE
[PYTHON-1031] Remove "frozen" from metadata of function arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Features
 * Remove invalid warning in set_session when we initialize a default connection (PYTHON-1104)
 Bug Fixes
 ---------
-* Fix 'as_cql_query UDF/UDA parameters incorrectly includes "frozen" if arguments are collections' (PYTHON-1031)
+* as_cql_query UDF/UDA parameters incorrectly includes "frozen" if arguments are collections (PYTHON-1031)
 * Fix incorrect metadata for compact counter tables (PYTHON-1100)
 * Call ConnectionException with correct kwargs (PYTHON-1117)
 * Can't connect to clusters built from source because version parsing doesn't handle 'x.y-SNAPSHOT' (PYTHON-1118)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features
 * Remove invalid warning in set_session when we initialize a default connection (PYTHON-1104)
 Bug Fixes
 ---------
+* Fix 'as_cql_query UDF/UDA parameters incorrectly includes "frozen" if arguments are collections' (PYTHON-1031)
 * Fix incorrect metadata for compact counter tables (PYTHON-1100)
 * Call ConnectionException with correct kwargs (PYTHON-1117)
 * Can't connect to clusters built from source because version parsing doesn't handle 'x.y-SNAPSHOT' (PYTHON-1118)

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -28,6 +28,7 @@ the corresponding CQL or Cassandra type strings.
 # .from_cql_literal() and .as_cql_literal() classmethods (or whatever).
 
 from __future__ import absolute_import  # to enable import io from stdlib
+import ast
 from binascii import unhexlify
 import calendar
 from collections import namedtuple
@@ -119,6 +120,76 @@ casstype_scanner = re.Scanner((
     (r'[a-zA-Z0-9_.:=>]+', lambda s, t: t),
     (r'[\s,]', None),
 ))
+
+
+def cqltype_to_python(cql_string):
+    """
+    Given a cql type string, creates a list that can be manipulated in python
+    Example:
+        int -> ['int']
+        frozen<tuple<text, int>> -> ['frozen', ['tuple', ['text', 'int']]]
+    """
+    scanner = re.Scanner((
+        (r'[a-zA-Z0-9_]+', lambda s, t: "'{}'".format(t)),
+        (r'<', lambda s, t: ', ['),
+        (r'>', lambda s, t: ']'),
+        (r'[, ]', lambda s, t: t),
+        (r'".*?"', lambda s, t: "'{}'".format(t)),
+    ))
+
+    scanned_tokens = scanner.scan(cql_string)[0]
+    hierarchy = ast.literal_eval(''.join(scanned_tokens))
+    if isinstance(hierarchy, str):
+        return [hierarchy]
+    else:
+        return list(hierarchy)
+
+
+def python_to_cqltype(types):
+    """
+    Opposite of the `cql_to_python` function. Given a python list, creates a cql type string from the representation
+    Example:
+        ['int'] -> int
+        ['frozen', ['tuple', ['text', 'int']]] -> frozen<tuple<text, int>>
+    """
+    scanner = re.Scanner((
+        (r"'[a-zA-Z0-9_]+'", lambda s, t: t[1:-1]),
+        (r'^\[', lambda s, t: None),
+        (r'\]$', lambda s, t: None),
+        (r',\s*\[', lambda s, t: '<'),
+        (r'\]', lambda s, t: '>'),
+        (r'[, ]', lambda s, t: t),
+        (r'\'".*?"\'', lambda s, t: t[1:-1]),
+    ))
+
+    scanned_tokens = scanner.scan(repr(types))[0]
+    cql = ''.join(scanned_tokens).replace('\\\\', '\\')
+    return cql
+
+
+def _strip_frozen_from_python(types):
+    """
+    Given a python list representing a cql type, removes 'frozen'
+    Example:
+        ['frozen', ['tuple', ['text', 'int']]] -> ['tuple', ['text', 'int']]
+    """
+    while 'frozen' in types:
+        index = types.index('frozen')
+        types = types[:index] + types[index + 1] + types[index + 2:]
+    new_types = [_strip_frozen_from_python(item) if isinstance(item, list) else item for item in types]
+    return new_types
+
+
+def strip_frozen(cql):
+    """
+    Given a cql type string, and removes frozen
+    Example:
+        frozen<tuple<int>> -> tuple<int>
+    """
+    types = cqltype_to_python(cql)
+    types_without_frozen = _strip_frozen_from_python(types)
+    cql = python_to_cqltype(types_without_frozen)
+    return cql
 
 
 def lookup_casstype_simple(casstype):

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -139,10 +139,7 @@ def cqltype_to_python(cql_string):
 
     scanned_tokens = scanner.scan(cql_string)[0]
     hierarchy = ast.literal_eval(''.join(scanned_tokens))
-    if isinstance(hierarchy, str):
-        return [hierarchy]
-    else:
-        return list(hierarchy)
+    return [hierarchy] if isinstance(hierarchy, str) else list(hierarchy)
 
 
 def python_to_cqltype(types):

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -908,9 +908,9 @@ class Aggregate(object):
         sep = '\n    ' if formatted else ' '
         keyspace = protect_name(self.keyspace)
         name = protect_name(self.name)
-        type_list = ', '.join([strip_frozen(arg_type) for arg_type in self.argument_types])
+        type_list = ', '.join([types.strip_frozen(arg_type) for arg_type in self.argument_types])
         state_func = protect_name(self.state_func)
-        state_type = strip_frozen(self.state_type)
+        state_type = types.strip_frozen(self.state_type)
 
         ret = "CREATE AGGREGATE %(keyspace)s.%(name)s(%(type_list)s)%(sep)s" \
               "SFUNC %(state_func)s%(sep)s" \
@@ -1001,7 +1001,7 @@ class Function(object):
         sep = '\n    ' if formatted else ' '
         keyspace = protect_name(self.keyspace)
         name = protect_name(self.name)
-        arg_list = ', '.join(["%s %s" % (protect_name(n), strip_frozen(t))
+        arg_list = ', '.join(["%s %s" % (protect_name(n), types.strip_frozen(t))
                              for n, t in zip(self.argument_names, self.argument_types)])
         typ = self.return_type
         lang = self.language
@@ -2834,43 +2834,3 @@ def group_keys_by_replica(session, keyspace, table, keys):
 
     return dict(keys_per_host)
 
-
-def strip_frozen(cass_type):
-    """
-    Takes a string representation of a cassandra type and removes frozen
-    E.g., 'frozen<tuple<int>>' becomes 'tuple<int>'
-    """
-    scanner = re.Scanner((
-        (r'[a-zA-Z0-9_]+', lambda s, t: t),
-        (r'[<>, ]', lambda s, t: t),
-        (r'".*?"', lambda s, t: t),
-    ))
-
-    scanned_tokens = scanner.scan(cass_type)[0]
-
-    def _strip(tokens):
-        """ Recursively remove each 'frozen' instance (and its brackets) from the list of tokens """
-        if 'frozen' not in tokens:
-            return tokens
-        updated_tokens = []
-        depth = 0
-        in_frozen = False
-        for token in tokens:
-            skip_current_token = False
-            if token == 'frozen' and not in_frozen:
-                in_frozen = True
-                skip_current_token = True
-            elif token == '<' and in_frozen:
-                depth += 1
-                if depth == 1:
-                    skip_current_token = True
-            elif token == '>' and in_frozen:
-                depth -= 1
-                if depth == 0:
-                    in_frozen = False
-                    skip_current_token = True
-            if not skip_current_token:
-                updated_tokens.append(token)
-        return _strip(updated_tokens)
-
-    return ''.join(_strip(scanned_tokens))

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 try:
     import unittest2 as unittest
 except ImportError:
@@ -25,6 +24,7 @@ import six
 import timeit
 
 import cassandra
+from cassandra.cqltypes import strip_frozen
 from cassandra.marshal import uint16_unpack, uint16_pack
 from cassandra.metadata import (Murmur3Token, MD5Token,
                                 BytesToken, ReplicationStrategy,
@@ -34,7 +34,7 @@ from cassandra.metadata import (Murmur3Token, MD5Token,
                                 UserType, KeyspaceMetadata, get_schema_parser,
                                 _UnknownStrategy, ColumnMetadata, TableMetadata,
                                 IndexMetadata, Function, Aggregate,
-                                Metadata, TokenMap, strip_frozen)
+                                Metadata, TokenMap)
 from cassandra.policies import SimpleConvictionPolicy
 from cassandra.pool import Host
 

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -34,7 +34,7 @@ from cassandra.metadata import (Murmur3Token, MD5Token,
                                 UserType, KeyspaceMetadata, get_schema_parser,
                                 _UnknownStrategy, ColumnMetadata, TableMetadata,
                                 IndexMetadata, Function, Aggregate,
-                                Metadata, TokenMap)
+                                Metadata, TokenMap, strip_frozen)
 from cassandra.policies import SimpleConvictionPolicy
 from cassandra.pool import Host
 
@@ -470,6 +470,32 @@ class UserTypesTest(unittest.TestCase):
         self.assertEqual('CREATE TYPE "MyKeyspace"."MyType" ("AbA" ascii, "keyspace" ascii)', udt.as_cql_query(formatted=False))
 
 
+class UserDefinedFunctionTest(unittest.TestCase):
+    def test_as_cql_query_removes_frozen(self):
+        func = Function("ks1", "myfunction", ["frozen<tuple<int, text>>"], ["a"], "int", "java", "return 0;", True)
+        expected_result = (
+            "CREATE FUNCTION ks1.myfunction(a tuple<int, text>) "
+            "CALLED ON NULL INPUT "
+            "RETURNS int "
+            "LANGUAGE java "
+            "AS $$return 0;$$"
+        )
+        self.assertEqual(expected_result, func.as_cql_query(formatted=False))
+
+
+class UserDefinedAggregateTest(unittest.TestCase):
+    def test_as_cql_query_removes_frozen(self):
+        aggregate = Aggregate("ks1", "myaggregate", ["frozen<tuple<int>>"], "statefunc", "frozen<tuple<int>>", "finalfunc", "(0)", "tuple<int>")
+        expected_result = (
+            "CREATE AGGREGATE ks1.myaggregate(tuple<int>) "
+            "SFUNC statefunc "
+            "STYPE tuple<int> "
+            "FINALFUNC finalfunc "
+            "INITCOND (0)"
+        )
+        self.assertEqual(expected_result, aggregate.as_cql_query(formatted=False))
+
+
 class IndexTest(unittest.TestCase):
 
     def test_build_index_as_cql(self):
@@ -575,3 +601,22 @@ class HostsTests(unittest.TestCase):
             metadata.remove_host(host)
 
         self.assertEqual(len(metadata.all_hosts()), 0)
+
+
+class MetadataHelpersTest(unittest.TestCase):
+    """ For any helper functions that need unit tests """
+    def test_strip_frozen(self):
+        self.longMessage = True
+
+        argument_to_expected_results = [
+            ('int', 'int'),
+            ('tuple<text>', 'tuple<text>'),
+            (r'map<"!@#$%^&*()[]\ frozen >>>", int>', r'map<"!@#$%^&*()[]\ frozen >>>", int>'),  # A valid UDT name
+            ('frozen<tuple<text>>', 'tuple<text>'),
+            (r'frozen<map<"!@#$%^&*()[]\ frozen >>>", int>>', r'map<"!@#$%^&*()[]\ frozen >>>", int>'),
+            ('frozen<map<frozen<tuple<int, frozen<list<text>>, int>>, frozen<map<int, frozen<tuple<int>>>>>>',
+             'map<tuple<int, list<text>, int>, map<int, tuple<int>>>'),
+        ]
+        for argument, expected_result in argument_to_expected_results:
+            result = strip_frozen(argument)
+            self.assertEqual(result, expected_result, "strip_frozen() arg: {}".format(argument))


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/PYTHON-1031

Functions don't accept frozen as part of the type arguments even though the collections get frozen after creation. To properly return the CQL statement we need to strip frozen from the type we receive from the server.