### PR TITLE
[PYTHON-1110] Fix ForcedHostSwitchPolicy not always choosing correct …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Features
 Bug Fixes
 ---------
 * Call ConnectionException with correct kwargs (PYTHON-1117)
+* Fix integration test failures: test_prepare_on_all_hosts (PYTHON-1110)
 3.18.0
 ======
 May 27, 2019

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,6 @@ Features
 Bug Fixes
 ---------
 * Call ConnectionException with correct kwargs (PYTHON-1117)
-* Fix integration test failures: test_prepare_on_all_hosts (PYTHON-1110)
 3.18.0
 ======
 May 27, 2019


### PR DESCRIPTION
…host in prepared tests.
https://datastax-oss.atlassian.net/browse/PYTHON-1110

`ForcedHostSwitchPolicy` was causing failures if more than one query was happening between statement executions. Replaced it with a `ForcedHostIndexPolicy` that allows us to hardcode the node to send requests to, and updated the tests that used the old policy accordingly.

