### PR TITLE
[PYTHON-1119] Set the proper default ExecutionProfile.row_factory value

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Bug Fixes
 * Fix incorrect metadata for compact counter tables (PYTHON-1100)
 * Call ConnectionException with correct kwargs (PYTHON-1117)
 * Can't connect to clusters built from source because version parsing doesn't handle 'x.y-SNAPSHOT' (PYTHON-1118)
+* Set the proper default ExecutionProfile.row_factory value (PYTHON-1119)
 3.18.0
 ======
 May 27, 2019

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -258,7 +258,7 @@ class ExecutionProfile(object):
     Request timeout used when not overridden in :meth:`.Session.execute`
     """
 
-    row_factory = staticmethod(tuple_factory)
+    row_factory = staticmethod(named_tuple_factory)
     """
     A callable to format results, accepting ``(colnames, rows)`` where ``colnames`` is a list of column names, and
     ``rows`` is a list of tuples, with each tuple representing a row of parsed values.

--- a/docs/api/cassandra/cluster.rst
+++ b/docs/api/cassandra/cluster.rst
@@ -118,7 +118,7 @@
 
    .. automethod:: set_meta_refresh_enabled
 
-.. autoclass:: ExecutionProfile (load_balancing_policy=<object object>, retry_policy=None, consistency_level=LOCAL_ONE, serial_consistency_level=None, request_timeout=10.0, row_factory=<function tuple_factory>, speculative_execution_policy=None)
+.. autoclass:: ExecutionProfile (load_balancing_policy=<object object>, retry_policy=None, consistency_level=LOCAL_ONE, serial_consistency_level=None, request_timeout=10.0, row_factory=<function named_tuple_factory>, speculative_execution_policy=None)
    :members:
    :exclude-members: consistency_level
 


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/PYTHON-1119

from local build of docs:
![image](https://user-images.githubusercontent.com/153674/61983932-d8abc800-afc7-11e9-93ec-bd776db8d106.png)
