### PR TITLE
PYTHON-1105: Include param values in cqlengine logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Features
 * Add Python 3.7 support (PYTHON-1016)
 * Future-proof Mapping imports (PYTHON-1023)
 * Remove invalid warning in set_session when we initialize a default connection (PYTHON-1104)
+* Include param values in cqlengine logging (PYTHON-1105)
 Bug Fixes
 ---------
 * as_cql_query UDF/UDA parameters incorrectly includes "frozen" if arguments are collections (PYTHON-1031)

--- a/cassandra/cqlengine/connection.py
+++ b/cassandra/cqlengine/connection.py
@@ -335,7 +335,7 @@ def execute(query, params=None, consistency_level=None, timeout=NOT_SET, connect
         query = SimpleStatement(str(query), consistency_level=consistency_level, fetch_size=query.fetch_size)
     elif isinstance(query, six.string_types):
         query = SimpleStatement(query, consistency_level=consistency_level)
-    log.debug(format_log_context(query.query_string, connection=connection))
+    log.debug(format_log_context('Query: {}, Params: {}'.format(query.query_string, params), connection=connection))
 
     result = conn.session.execute(query, params, timeout=timeout)
 


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/PYTHON-1105