### PR TITLE
TTL and TIMESTAMP in cqlengine (round 2)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Features
 Bug Fixes
 ---------
 * as_cql_query UDF/UDA parameters incorrectly includes "frozen" if arguments are collections (PYTHON-1031)
+* cqlengine does not currently support combining TTL and TIMESTAMP on INSERT (PYTHON-1093)
 * Fix incorrect metadata for compact counter tables (PYTHON-1100)
 * Call ConnectionException with correct kwargs (PYTHON-1117)
 * Can't connect to clusters built from source because version parsing doesn't handle 'x.y-SNAPSHOT' (PYTHON-1118)

--- a/cassandra/cqlengine/statements.py
+++ b/cassandra/cqlengine/statements.py
@@ -751,13 +751,15 @@ class InsertStatement(AssignmentStatement):
         if self.if_not_exists:
             qs += ["IF NOT EXISTS"]
 
+        using_options = []
         if self.ttl:
-            qs += ["USING TTL {0}".format(self.ttl)]
+            using_options += ["TTL {}".format(self.ttl)]
 
         if self.timestamp:
-            statement = "AND TIMESTAMP {0}" if self.ttl else "USING TIMESTAMP {0}"
-            qs += [statement.format(self.timestamp_normalized)]
+            using_options += ["TIMESTAMP {}".format(self.timestamp_normalized)]
 
+        if using_options:
+            qs += ["USING {}".format(" AND ".join(using_options))]
         return ' '.join(qs)
 
 

--- a/cassandra/cqlengine/statements.py
+++ b/cassandra/cqlengine/statements.py
@@ -755,7 +755,8 @@ class InsertStatement(AssignmentStatement):
             qs += ["USING TTL {0}".format(self.ttl)]
 
         if self.timestamp:
-            qs += ["USING TIMESTAMP {0}".format(self.timestamp_normalized)]
+            statement = "AND TIMESTAMP {0}" if self.ttl else "USING TIMESTAMP {0}"
+            qs += [statement.format(self.timestamp_normalized)]
 
         return ' '.join(qs)
 

--- a/tests/integration/cqlengine/test_timestamp.py
+++ b/tests/integration/cqlengine/test_timestamp.py
@@ -74,6 +74,10 @@ class CreateWithTimestampTest(BaseTimestampTest):
         tmp = TestTimestampModel.timestamp(timedelta(seconds=30)).create(count=1)
         tmp.should.be.ok
 
+    def test_non_batch_syntax_with_tll_integration(self):
+        tmp = TestTimestampModel.timestamp(timedelta(seconds=30)).ttl(30).create(count=1)
+        tmp.should.be.ok
+
     def test_non_batch_syntax_unit(self):
 
         with mock.patch.object(self.session, "execute") as m:

--- a/tests/integration/cqlengine/test_timestamp.py
+++ b/tests/integration/cqlengine/test_timestamp.py
@@ -83,6 +83,16 @@ class CreateWithTimestampTest(BaseTimestampTest):
 
         "USING TIMESTAMP".should.be.within(query)
 
+    def test_non_batch_syntax_with_ttl_unit(self):
+
+        with mock.patch.object(self.session, "execute") as m:
+            TestTimestampModel.timestamp(timedelta(seconds=30)).ttl(30).create(
+                count=1)
+
+        query = m.call_args[0][0].query_string
+
+        query.should.match(r"USING TTL \d* AND TIMESTAMP")
+
 
 class UpdateWithTimestampTest(BaseTimestampTest):
     def setUp(self):


### PR DESCRIPTION
https://datastax-oss.atlassian.net/browse/PYTHON-1093

Continuation of #1018 (keeping the original commits) with an added integration test, some small code changes to make it consistent with the Update statement, and a rebase to keep the changelog current.