### PR TITLE
PYTHON-1016: Python 3.7 eventlet reactor fix

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1061,7 +1061,7 @@ class Cluster(object):
             HostDistance.REMOTE: DEFAULT_MAX_CONNECTIONS_PER_REMOTE_HOST
         }
 
-        self.executor = ThreadPoolExecutor(max_workers=executor_threads)
+        self.executor = self._create_thread_pool_executor(max_workers=executor_threads)
         self.scheduler = _Scheduler(self.executor)
 
         self._lock = RLock()
@@ -1075,6 +1075,42 @@ class Cluster(object):
             self.schema_event_refresh_window, self.topology_event_refresh_window,
             self.status_event_refresh_window,
             schema_metadata_enabled, token_metadata_enabled)
+
+    def _create_thread_pool_executor(self, **kwargs):
+        """
+        Create a ThreadPoolExecutor for the cluster. In most cases, the built-in
+        `concurrent.futures.ThreadPoolExecutor` is used.
+
+        Python 3.7 and Eventlet cause the `concurrent.futures.ThreadPoolExecutor`
+        to hang indefinitely. In that case, the user needs to have the `futurist`
+        package so we can use the `futurist.GreenThreadPoolExecutor` class instead.
+
+        :param kwargs: All keyword args are passed to the ThreadPoolExecutor constructor.
+        :return: A ThreadPoolExecutor instance.
+        """
+        tpe_class = ThreadPoolExecutor
+        if sys.version_info[0] >= 3 and sys.version_info[1] >= 7:
+            try:
+                from cassandra.io.eventletreactor import EventletConnection
+                is_eventlet = issubclass(self.connection_class, EventletConnection)
+            except:
+                # Eventlet is not available or can't be detected
+                return tpe_class(**kwargs)
+
+            if is_eventlet:
+                try:
+                    from futurist import GreenThreadPoolExecutor
+                    tpe_class = GreenThreadPoolExecutor
+                except ImportError:
+                    # futurist is not available
+                    raise ImportError(
+                        ("Python 3.7 and Eventlet cause the `concurrent.futures.ThreadPoolExecutor` "
+                         "to hang indefinitely. If you want to use the Eventlet reactor, you "
+                         "need to install the `futurist` package to allow the driver to use "
+                         "the GreenThreadPoolExecutor. See https://github.com/eventlet/eventlet/issues/508 "
+                         "for more details."))
+
+        return tpe_class(**kwargs)
 
     def register_user_type(self, keyspace, user_type, klass):
         """

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,5 @@ gevent>=1.0
 eventlet
 cython>=0.20,<0.30
 packaging
+futurist; python_version >= '3.7'
 asynctest; python_version > '3.4'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -21,6 +21,7 @@ import sys
 import socket
 import platform
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 log = logging.getLogger()
 log.setLevel('DEBUG')
@@ -58,6 +59,7 @@ def is_eventlet_time_monkey_patched():
 def is_monkey_patched():
     return is_gevent_monkey_patched() or is_eventlet_monkey_patched()
 
+thread_pool_executor_class = ThreadPoolExecutor
 
 EVENT_LOOP_MANAGER = os.getenv('EVENT_LOOP_MANAGER', "libev")
 if "gevent" in EVENT_LOOP_MANAGER:
@@ -71,6 +73,13 @@ elif "eventlet" in EVENT_LOOP_MANAGER:
 
     from cassandra.io.eventletreactor import EventletConnection
     connection_class = EventletConnection
+
+    try:
+        from futurist import GreenThreadPoolExecutor
+        thread_pool_executor_class = GreenThreadPoolExecutor
+    except:
+        # futurist is installed only with python >=3.7
+        pass
 elif "asyncore" in EVENT_LOOP_MANAGER:
     from cassandra.io.asyncorereactor import AsyncoreConnection
     connection_class = AsyncoreConnection

--- a/tests/integration/simulacron/test_connection.py
+++ b/tests/integration/simulacron/test_connection.py
@@ -19,8 +19,6 @@ except ImportError:
 import logging
 import time
 
-from concurrent.futures import ThreadPoolExecutor
-
 from mock import Mock
 
 from cassandra import OperationTimedOut
@@ -28,6 +26,7 @@ from cassandra.cluster import (EXEC_PROFILE_DEFAULT, Cluster, ExecutionProfile,
                                _Scheduler, NoHostAvailable)
 from cassandra.policies import HostStateListener, RoundRobinPolicy
 from cassandra.io.asyncorereactor import AsyncoreConnection
+from tests import connection_class, thread_pool_executor_class
 from tests.integration import (PROTOCOL_VERSION, requiressimulacron)
 from tests.integration.util import assert_quiescent_pool_state
 from tests.integration.simulacron import SimulacronBase
@@ -55,7 +54,7 @@ class TrackDownListener(HostStateListener):
     def on_remove(self, host):
         pass
 
-class ThreadTracker(ThreadPoolExecutor):
+class ThreadTracker(thread_pool_executor_class):
     called_functions = []
 
     def submit(self, fn, *args, **kwargs):
@@ -339,9 +338,9 @@ class ConnectionTests(SimulacronBase):
         self.assertEqual(listener.hosts_marked_down, [])
         assert_quiescent_pool_state(self, cluster)
 
-    def test_can_shutdown_asyncoreconnection_subclass(self):
+    def test_can_shutdown_connection_subclass(self):
         start_and_prime_singledc()
-        class ExtendedConnection(AsyncoreConnection):
+        class ExtendedConnection(connection_class):
             pass
 
         cluster = Cluster(contact_points=["127.0.0.2"],

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps = nose
        cython
        eventlet
        twisted <15.5.0
+       futurist
 
 [testenv]
 deps = {[base]deps}


### PR DESCRIPTION
This is part of the python 3.7 support for the next release. Unfortunately, the Eventlet reactor is not compatible with the built-in concurrent.futures.ThreadPoolExecutor. 

This Pull Request basically detects this situation and raise an error to the user. To use Python 3.7 and Eventlet, the user has to install an additional package, so we can use a custom thread pool made for it.

@aholmberg Can you do a quick review?