### PR TITLE
Fix twisted tests (PYTHON-1037)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -48,11 +48,11 @@ schedules:
     branches:
       include: [/dev-python.*/]
     env_vars: |
-      EVENT_LOOP_MANAGER='libev'
+      EVENT_LOOP_MANAGER='twisted'
       EXCLUDE_LONG=1
     matrix:
       exclude:
-        - python: [2.7, 3.4, 3.6, 3.7]
+        - python: [3.6, 3.7]
         - cassandra: ['2.0', '2.1', '2.2', '3.0', 'test-dse']
 
   release_test:

--- a/build.yaml
+++ b/build.yaml
@@ -48,11 +48,11 @@ schedules:
     branches:
       include: [/dev-python.*/]
     env_vars: |
-      EVENT_LOOP_MANAGER='twisted'
+      EVENT_LOOP_MANAGER='libev'
       EXCLUDE_LONG=1
     matrix:
       exclude:
-        - python: [3.6, 3.7]
+        - python: [2.7, 3.4, 3.6, 3.7]
         - cassandra: ['2.0', '2.1', '2.2', '3.0', 'test-dse']
 
   release_test:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,8 @@ unittest2
 pytz
 sure
 pure-sasl
-twisted[tls]==19.2.1
+twisted; python_version >= '3.5'
+twisted[tls]==19.2.1; python_version < '3.5'
 gevent>=1.0
 eventlet
 cython>=0.20,<0.30

--- a/tests/integration/simulacron/test_endpoint.py
+++ b/tests/integration/simulacron/test_endpoint.py
@@ -27,8 +27,9 @@ from tests.integration.simulacron import SimulacronCluster
 @total_ordering
 class AddressEndPoint(EndPoint):
 
-    def __init__(self, address):
+    def __init__(self, address, port=9042):
         self._address = address
+        self._port = port
 
     @property
     def address(self):
@@ -36,14 +37,14 @@ class AddressEndPoint(EndPoint):
 
     @property
     def port(self):
-        return None
+        return self._port
 
     def resolve(self):
-        return self._address, 9042  # connection purpose
+        return self._address, self._port  # connection purpose
 
     def __eq__(self, other):
         return isinstance(other, AddressEndPoint) and \
-               self.address == other.address
+            self.address == other.address
 
     def __hash__(self):
         return hash(self.address)
@@ -99,7 +100,8 @@ class EndPointTests(SimulacronCluster):
         cluster = Cluster(
             contact_points=[AddressEndPoint('127.0.0.1')],
             protocol_version=PROTOCOL_VERSION,
-            endpoint_factory=AddressEndPointFactory()
+            endpoint_factory=AddressEndPointFactory(),
+            compression=False,
         )
         cluster.connect(wait_for_all_pools=True)
 


### PR DESCRIPTION
Updated twisted dependency so windows install doesn't take 30 minutes. In testing the changes, also noticed a test failing for all twisted builds, so fixed the test as well.

Windows build:
https://ci.appveyor.com/project/DataStax/python-driver/builds/27114069

Jenkins build customized to use twisted:
https://jenkins-drivers.build.dsinternal.org/view/python-driver/job/datastax.python-driver.dev-python-1037-twisted.commit_branches_dev/
