### PR TITLE
[PYTHON-1121] Fix queryset generation for cqlengine Token instances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Bug Fixes
 ---------
 * Connection setup methods prevent using ExecutionProfile in cqlengine (PYTHON-1009)
 * Driver deadlock if all connections dropped by heartbeat whilst request in flight and request times out (PYTHON-1044)
+* Exception when use pk__token__gt filter In python 3.7 (PYTHON-1121)
 
 3.19.0
 ======

--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -1071,7 +1071,7 @@ class _PartitionKeysToken(Column):
     """
 
     def __init__(self, model):
-        self.partition_columns = model._partition_keys.values()
+        self.partition_columns = list(model._partition_keys.values())
         super(_PartitionKeysToken, self).__init__(partition_key=True)
 
     @property

--- a/tests/integration/cqlengine/query/test_queryoperators.py
+++ b/tests/integration/cqlengine/query/test_queryoperators.py
@@ -94,6 +94,7 @@ class TestTokenFunction(BaseCassEngTestCase):
         # pk__token equality
         r = TokenTestModel.objects(pk__token=functions.Token(last_token))
         self.assertEqual(len(r), 1)
+        r.all()  # Attempt to obtain queryset for results. This has thrown an exception in the past
 
     def test_compound_pk_token_function(self):
 


### PR DESCRIPTION
Python 2 returned lists for `.values()`. Python 3 returns view objects that aren't pickleable. This is the root of the error in PYTHON-1121.