### PR TITLE
[PYTHON-1162] Allow passing ssl context for Eventlet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Unreleased
 Features
 --------
 * Allow passing ssl context for Twisted (PYTHON-1161)
+* Allow passing ssl context for Eventlet (PYTHON-1162)
 * Cloud Twisted support (PYTHON-1163)
 
 3.20.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Unreleased
 Features
 --------
 * Allow passing ssl context for Twisted (PYTHON-1161)
-* Allow passing ssl context for Eventlet (PYTHON-1162)
+* ssl context and cloud support for Eventlet (PYTHON-1162)
 * Cloud Twisted support (PYTHON-1163)
 
 3.20.0

--- a/build.yaml
+++ b/build.yaml
@@ -227,6 +227,7 @@ build:
           "tests/integration/standard/test_metrics.py"
           "tests/integration/standard/test_query.py"
           "tests/integration/simulacron/test_endpoint.py"
+          "tests/integration/long/test_ssl.py"
         )
         EVENT_LOOP_MANAGER=$EVENT_LOOP_MANAGER CCM_ARGS="$CCM_ARGS" CASSANDRA_VERSION=$CCM_CASSANDRA_VERSION MAPPED_CASSANDRA_VERSION=$MAPPED_CASSANDRA_VERSION VERIFY_CYTHON=$FORCE_CYTHON nosetests -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=standard_results.xml ${EVENT_LOOP_TESTS[@]} || true
         exit 0

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -78,12 +78,12 @@ from cassandra.datastax import cloud as dscloud
 try:
     from cassandra.io.twistedreactor import TwistedConnection
 except ImportError:
-    TwistedConnection = type(None)
+    TwistedConnection = None
 
 try:
     from cassandra.io.eventletreactor import EventletConnection
 except ImportError:
-    EventletConnection = type(None)
+    EventletConnection = None
 
 try:
     from weakref import WeakSet
@@ -925,10 +925,9 @@ class Cluster(object):
                 raise ValueError("contact_points, endpoint_factory, ssl_context, and ssl_options "
                                  "cannot be specified with a cloud configuration")
 
-            cloud_config = dscloud.get_cloud_config(
-                cloud,
-                create_pyopenssl_context=issubclass(self.connection_class, (TwistedConnection, EventletConnection))
-            )
+            uses_twisted = TwistedConnection and issubclass(self.connection_class, TwistedConnection)
+            uses_eventlet = EventletConnection and issubclass(self.connection_class, EventletConnection)
+            cloud_config = dscloud.get_cloud_config(cloud, create_pyopenssl_context=uses_twisted or uses_eventlet)
 
             ssl_context = cloud_config.ssl_context
             ssl_options = {'check_hostname': True}

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -37,16 +37,6 @@ from threading import Lock, RLock, Thread, Event
 import weakref
 from weakref import WeakValueDictionary
 
-try:
-    from cassandra.io.twistedreactor import TwistedConnection
-except ImportError:
-    TwistedConnection = None
-
-try:
-    from weakref import WeakSet
-except ImportError:
-    from cassandra.util import WeakSet  # NOQA
-
 from cassandra import (ConsistencyLevel, AuthenticationFailed,
                        OperationTimedOut, UnsupportedOperation,
                        SchemaTargetType, DriverException, ProtocolVersion,
@@ -84,6 +74,21 @@ from cassandra.query import (SimpleStatement, PreparedStatement, BoundStatement,
 from cassandra.timestamps import MonotonicTimestampGenerator
 from cassandra.compat import Mapping
 from cassandra.datastax import cloud as dscloud
+
+try:
+    from cassandra.io.twistedreactor import TwistedConnection
+except ImportError:
+    TwistedConnection = None
+
+try:
+    from cassandra.io.eventletreactor import EventletConnection
+except ImportError:
+    EventletConnection = None
+
+try:
+    from weakref import WeakSet
+except ImportError:
+    from cassandra.util import WeakSet  # NOQA
 
 
 def _is_eventlet_monkey_patched():
@@ -922,7 +927,7 @@ class Cluster(object):
 
             cloud_config = dscloud.get_cloud_config(
                 cloud,
-                create_pyopenssl_context=self.connection_class is TwistedConnection
+                create_pyopenssl_context=self.connection_class in [TwistedConnection, EventletConnection]
             )
 
             ssl_context = cloud_config.ssl_context

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -78,12 +78,12 @@ from cassandra.datastax import cloud as dscloud
 try:
     from cassandra.io.twistedreactor import TwistedConnection
 except ImportError:
-    TwistedConnection = None
+    TwistedConnection = type(None)
 
 try:
     from cassandra.io.eventletreactor import EventletConnection
 except ImportError:
-    EventletConnection = None
+    EventletConnection = type(None)
 
 try:
     from weakref import WeakSet

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -927,7 +927,7 @@ class Cluster(object):
 
             cloud_config = dscloud.get_cloud_config(
                 cloud,
-                create_pyopenssl_context=self.connection_class in [TwistedConnection, EventletConnection]
+                create_pyopenssl_context=issubclass(self.connection_class, (TwistedConnection, EventletConnection))
             )
 
             ssl_context = cloud_config.ssl_context

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -615,6 +615,15 @@ class Connection(object):
         else:
             return conn
 
+    def _wrap_socket_from_context(self):
+        self._socket = self.ssl_context.wrap_socket(self._socket, **(self.ssl_options or {}))
+
+    def _initiate_connection(self, sockaddr):
+        self._socket.connect(sockaddr)
+
+    def _match_hostname(self):
+        ssl.match_hostname(self._socket.getpeercert(), self.endpoint.address)
+
     def _get_socket_addresses(self):
         address, port = self.endpoint.resolve()
 
@@ -634,17 +643,16 @@ class Connection(object):
             try:
                 self._socket = self._socket_impl.socket(af, socktype, proto)
                 if self.ssl_context:
-                    self._socket = self.ssl_context.wrap_socket(self._socket,
-                                                                **(self.ssl_options or {}))
+                    self._wrap_socket_from_context()
                 elif self.ssl_options:
                     if not self._ssl_impl:
                         raise RuntimeError("This version of Python was not compiled with SSL support")
                     self._socket = self._ssl_impl.wrap_socket(self._socket, **self.ssl_options)
                 self._socket.settimeout(self.connect_timeout)
-                self._socket.connect(sockaddr)
+                self._initiate_connection(sockaddr)
                 self._socket.settimeout(None)
                 if self._check_hostname:
-                    ssl.match_hostname(self._socket.getpeercert(), self.endpoint.address)
+                    self._match_hostname()
                 sockerr = None
                 break
             except socket.error as err:

--- a/cassandra/datastax/cloud/__init__.py
+++ b/cassandra/datastax/cloud/__init__.py
@@ -15,8 +15,10 @@
 import os
 import logging
 import json
+import sys
 import tempfile
 import shutil
+import six
 from six.moves.urllib.request import urlopen
 
 _HAS_SSL = True
@@ -177,8 +179,12 @@ def _ssl_context_from_cert(ca_cert_location, cert_location, key_location):
 def _pyopenssl_context_from_cert(ca_cert_location, cert_location, key_location):
     try:
         from OpenSSL import SSL
-    except ImportError:
-        return None
+    except ImportError as e:
+        six.reraise(
+            ImportError,
+            ImportError("PyOpenSSL must be installed to connect to Apollo with the Eventlet or Twisted event loops"),
+            sys.exc_info()[2]
+        )
     ssl_context = SSL.Context(SSL.TLSv1_METHOD)
     ssl_context.set_verify(SSL.VERIFY_PEER, callback=lambda _1, _2, _3, _4, ok: ok)
     ssl_context.use_certificate_file(cert_location)

--- a/cassandra/io/eventletreactor.py
+++ b/cassandra/io/eventletreactor.py
@@ -29,8 +29,9 @@ from cassandra.connection import Connection, ConnectionShutdown, Timer, TimerMan
 try:
     from eventlet.green.OpenSSL import SSL
     _PYOPENSSL = True
-except ImportError as no_pyopenssl_error:
+except ImportError as e:
     _PYOPENSSL = False
+    no_pyopenssl_error = e
 
 
 log = logging.getLogger(__name__)
@@ -40,7 +41,7 @@ def _check_pyopenssl():
     if not _PYOPENSSL:
         raise ImportError(
             "{}, pyOpenSSL must be installed to enable "
-            "SSL support with the Twisted event loop".format(str(no_pyopenssl_error))
+            "SSL support with the Eventlet event loop".format(str(no_pyopenssl_error))
         )
 
 

--- a/docs/cloud.rst
+++ b/docs/cloud.rst
@@ -34,5 +34,4 @@ Limitations
 
 Event loops
 ^^^^^^^^^^^
-Evenlet isn't supported yet. Eventlet still uses the old way to configure
-SSL (ssl_options), which is not compatible with the secure connect bundle provided by Apollo.
+Evenlet isn't yet supported for python 3.7+ due to an `issue in Eventlet <https://github.com/eventlet/eventlet/issues/526>`_.

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -78,10 +78,10 @@ It might be also useful to learn about the different levels of identity verifica
 
 * `Using SSL in DSE drivers <https://docs.datastax.com/en/dse/6.7/dse-dev/datastax_enterprise/appDevGuide/sslDrivers.html>`_
 
-SSL with Twisted
-^^^^^^^^^^^^^^^^
-Twisted uses an alternative SSL implementation called pyOpenSSL, so if your `Cluster`'s connection class is
-:class:`~cassandra.io.twistedreactor.TwistedConnection`, you must pass a
+SSL with Twisted or Eventlet
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Twisted and Eventlet both use an alternative SSL implementation called pyOpenSSL, so if your `Cluster`'s connection class is
+:class:`~cassandra.io.twistedreactor.TwistedConnection` or :class:`~cassandra.io.eventletreactor.EventletConnection`, you must pass a
 `pyOpenSSL context <https://www.pyopenssl.org/en/stable/api/ssl.html#context-objects>`_ instead.
 An example is provided in these docs, and more details can be found in the
 `documentation <https://www.pyopenssl.org/en/stable/api/ssl.html#context-objects>`_.
@@ -269,6 +269,10 @@ for more details about ``SSLContext`` configuration.
         ssl_options={'check_hostname': True}
     )
     session = cluster.connect()
+
+
+Connecting using Eventlet would look similar except instead of importing and using ``TwistedConnection``, you would
+import and use ``EventletConnection``, including the appropriate monkey-patching.
 
 Versions 3.16.0 and lower
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -42,7 +42,7 @@ DRIVER_KEYFILE_ENCRYPTED = os.path.abspath("tests/integration/long/ssl/driver_en
 DRIVER_CERTFILE = os.path.abspath("tests/integration/long/ssl/driver.pem")
 DRIVER_CERTFILE_BAD = os.path.abspath("tests/integration/long/ssl/python_driver_bad.pem")
 
-USES_PYOPENSSL = "twisted" in EVENT_LOOP_MANAGER
+USES_PYOPENSSL = "twisted" in EVENT_LOOP_MANAGER or "eventlet" in EVENT_LOOP_MANAGER
 if "twisted" in EVENT_LOOP_MANAGER:
     import OpenSSL
     ssl_version = OpenSSL.SSL.TLSv1_METHOD


### PR DESCRIPTION
The reason for the instance checks in the eventlet code is that eventlet will monkeypatch the built in ssl module to use pyOpenSSL under the hood. We want to utilize that if we're relying strictly on ssl_options, but if we're passing an SSLContext, we must use the pyOpenSSL APIs.