### PR TITLE
Fix broken link to map type documentation

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -933,7 +933,7 @@ class Map(BaseContainerColumn):
     """
     Stores a key -> value map (dictionary)
 
-    http://www.datastax.com/documentation/cql/3.1/cql/cql_using/use_map_t.html
+    https://docs.datastax.com/en/dse/6.7/cql/cql/cql_using/useMap.html
     """
 
     _python_type_hashable = False


### PR DESCRIPTION
This fixes the previous link which is broken.

On a side note, maybe there should be `latest` docs website.
```
https://docs.datastax.com/en/dse/latest/cql/cql/cql_using/useMap.html
```
Should redirect to:
```
https://docs.datastax.com/en/6.7/latest/cql/cql/cql_using/useMap.html
```

And when the next version is released, latest should be updated, without updating links in the code.


