### PR TITLE
Disable pull requests on weekly jobs

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -50,6 +50,7 @@ schedules:
 
   release_test:
     schedule: per_commit
+    disable_pull_requests: true
     branches:
       include: [/release-.+/]
     env_vars: |
@@ -57,6 +58,7 @@ schedules:
 
   weekly_master:
     schedule: 0 10 * * 6
+    disable_pull_requests: true
     branches:
       include: [master]
     env_vars: |
@@ -68,6 +70,7 @@ schedules:
 
   weekly_gevent:
     schedule: 0 14 * * 6
+    disable_pull_requests: true
     branches:
       include: [master]
     env_vars: |
@@ -79,6 +82,7 @@ schedules:
 
   weekly_eventlet:
     schedule: 0 18 * * 6
+    disable_pull_requests: true
     branches:
       include: [master]
     env_vars: |
@@ -90,6 +94,7 @@ schedules:
 
   weekly_asyncio:
     schedule: 0 22 * * 6
+    disable_pull_requests: true
     branches:
       include: [master]
     env_vars: |
@@ -101,6 +106,7 @@ schedules:
 
   weekly_async:
     schedule: 0 10 * * 7
+    disable_pull_requests: true
     branches:
       include: [master]
     env_vars: |
@@ -112,6 +118,7 @@ schedules:
 
   weekly_twister:
     schedule: 0 14 * * 7
+    disable_pull_requests: true
     branches:
       include: [master]
     env_vars: |


### PR DESCRIPTION
Python weekly jobs are also targeting PRs (with name master), for example:
- https://jenkins-drivers.build.dsinternal.org/view/python-driver/job/datastax.python-driver.PR.1009.weekly_async/
- https://jenkins-drivers.build.dsinternal.org/view/python-driver/job/datastax.python-driver.PR.1009.weekly_async/
