### PR TITLE
Twisted SSL context and cloud support

### DIFF
--- a/cassandra/io/twistedreactor.py
+++ b/cassandra/io/twistedreactor.py
@@ -16,16 +16,26 @@ Module that implements an event loop based on twisted
 ( https://twistedmatrix.com ).
 """
 import atexit
-from functools import partial
 import logging
-from threading import Thread, Lock
 import time
-from twisted.internet import reactor, protocol
+from functools import partial
+from threading import Thread, Lock
 import weakref
+
+from twisted.internet import reactor, protocol
+from twisted.internet.endpoints import connectProtocol, TCP4ClientEndpoint, SSL4ClientEndpoint
+from twisted.internet.interfaces import IOpenSSLClientConnectionCreator
+from twisted.python.failure import Failure
+from zope.interface import implementer
 
 from cassandra.connection import Connection, ConnectionShutdown, Timer, TimerManager
 
-
+try:
+    from OpenSSL import SSL
+    _HAS_SSL = True
+except ImportError as e:
+    _HAS_SSL = False
+    import_exception = e
 log = logging.getLogger(__name__)
 
 
@@ -42,8 +52,8 @@ class TwistedConnectionProtocol(protocol.Protocol):
     made events.
     """
 
-    def __init__(self):
-        self.connection = None
+    def __init__(self, connection):
+        self.connection = connection
 
     def dataReceived(self, data):
         """
@@ -55,6 +65,7 @@ class TwistedConnectionProtocol(protocol.Protocol):
         """
         self.connection._iobuf.write(data)
         self.connection.handle_read()
+
     def connectionMade(self):
         """
         Callback function that is called when a connection has succeeded.
@@ -62,55 +73,11 @@ class TwistedConnectionProtocol(protocol.Protocol):
         Reaches back to the Connection object and confirms that the connection
         is ready.
         """
-        try:
-            # Non SSL connection
-            self.connection = self.transport.connector.factory.conn
-        except AttributeError:
-            # SSL connection
-            self.connection = self.transport.connector.factory.wrappedFactory.conn
-
         self.connection.client_connection_made(self.transport)
 
     def connectionLost(self, reason):
         # reason is a Failure instance
         self.connection.defunct(reason.value)
-
-
-class TwistedConnectionClientFactory(protocol.ClientFactory):
-
-    def __init__(self, connection):
-        # ClientFactory does not define __init__() in parent classes
-        # and does not inherit from object.
-        self.conn = connection
-
-    def buildProtocol(self, addr):
-        """
-        Twisted function that defines which kind of protocol to use
-        in the ClientFactory.
-        """
-        return TwistedConnectionProtocol()
-
-    def clientConnectionFailed(self, connector, reason):
-        """
-        Overridden twisted callback which is called when the
-        connection attempt fails.
-        """
-        log.debug("Connect failed: %s", reason)
-        self.conn.defunct(reason.value)
-
-    def clientConnectionLost(self, connector, reason):
-        """
-        Overridden twisted callback which is called when the
-        connection goes away (cleanly or otherwise).
-
-        It should be safe to call defunct() here instead of just close, because
-        we can assume that if the connection was closed cleanly, there are no
-        requests to error out. If this assumption turns out to be false, we
-        can call close() instead of defunct() when "reason" is an appropriate
-        type.
-        """
-        log.debug("Connect lost: %s", reason)
-        self.conn.defunct(reason.value)
 
 
 class TwistedLoop(object):
@@ -166,47 +133,46 @@ class TwistedLoop(object):
         self._schedule_timeout(self._timers.next_timeout)
 
 
-try:
-    from twisted.internet import ssl
-    import OpenSSL.crypto
-    from OpenSSL.crypto import load_certificate, FILETYPE_PEM
+@implementer(IOpenSSLClientConnectionCreator)
+class SSLCreator(object):
+    def __init__(self, host, ssl_context, ssl_options, check_hostname, timeout):
+        self.host = host
+        self.ssl_options = ssl_options
+        self.check_hostname = check_hostname
+        self.timeout = timeout
 
-    class _SSLContextFactory(ssl.ClientContextFactory):
-        def __init__(self, ssl_options, check_hostname, host):
-            self.ssl_options = ssl_options
-            self.check_hostname = check_hostname
-            self.host = host
-
-        def getContext(self):
-            # This version has to be OpenSSL.SSL.DESIRED_VERSION
-            # instead of ssl.DESIRED_VERSION as in other loops
-            self.method = self.ssl_options["ssl_version"]
-            context = ssl.ClientContextFactory.getContext(self)
+        if ssl_context:
+            self.context = ssl_context
+        else:
+            self.context = SSL.Context(SSL.TLSv1_METHOD)
             if "certfile" in self.ssl_options:
-                context.use_certificate_file(self.ssl_options["certfile"])
+                self.context.use_certificate_file(self.ssl_options["certfile"])
             if "keyfile" in self.ssl_options:
-                context.use_privatekey_file(self.ssl_options["keyfile"])
+                self.context.use_privatekey_file(self.ssl_options["keyfile"])
             if "ca_certs" in self.ssl_options:
-                x509 = load_certificate(FILETYPE_PEM, open(self.ssl_options["ca_certs"]).read())
-                store = context.get_cert_store()
-                store.add_cert(x509)
+                self.context.load_verify_locations(self.ssl_options["ca_certs"])
             if "cert_reqs" in self.ssl_options:
-                # This expects OpenSSL.SSL.VERIFY_NONE/OpenSSL.SSL.VERIFY_PEER
-                # or OpenSSL.SSL.VERIFY_FAIL_IF_NO_PEER_CERT
-                context.set_verify(self.ssl_options["cert_reqs"],
-                                   callback=self.verify_callback)
-            return context
+                self.context.set_verify(
+                    self.ssl_options["cert_reqs"],
+                    callback=self.verify_callback
+                )
+        self.context.set_info_callback(self.info_callback)
 
-        def verify_callback(self, connection, x509, errnum, errdepth, ok):
-            if ok:
-                if self.check_hostname and self.host != x509.get_subject().commonName:
-                    return False
-            return ok
+    def verify_callback(self, connection, x509, errnum, errdepth, ok):
+        return ok
 
-    _HAS_SSL = True
+    def info_callback(self, connection, where, ret):
+        if where & SSL.SSL_CB_HANDSHAKE_DONE:
+            if self.check_hostname and self.host != connection.get_peer_certificate().get_subject().commonName:
+                transport = connection.get_app_data()
+                transport.failVerification(Failure(Exception("Hostname verification failed")))
 
-except ImportError as e:
-    _HAS_SSL = False
+    def clientConnectionForTLS(self, tlsProtocol):
+        connection = SSL.Connection(self.context, None)
+        connection.set_app_data(tlsProtocol)
+        if self.ssl_options and "server_hostname" in self.ssl_options:
+            connection.set_tlsext_host_name(self.ssl_options['server_hostname'].encode('ascii'))
+        return connection
 
 
 class TwistedConnection(Connection):
@@ -246,29 +212,48 @@ class TwistedConnection(Connection):
         reactor.callFromThread(self.add_connection)
         self._loop.maybe_start()
 
+    def _check_pyopenssl(self):
+        if self.ssl_options:
+            if not _HAS_SSL:
+                raise ImportError(
+                    str(import_exception) +
+                    ', pyOpenSSL must be installed to enable SSL support with the Twisted event loop'
+                )
+
     def add_connection(self):
         """
         Convenience function to connect and store the resulting
         connector.
         """
-        if self.ssl_options:
+        host, port = self.endpoint.resolve()
+        if self.ssl_context or self.ssl_options:
+            # Can't use optionsForClientTLS here because it *forces* hostname verification.
+            # Cool they enforce strong security, but we have to be able to turn it off
+            self._check_pyopenssl()
 
-            if not _HAS_SSL:
-                raise ImportError(
-                    str(e) +
-                    ', pyOpenSSL must be installed to enable SSL support with the Twisted event loop'
-                )
+            ssl_options = SSLCreator(
+                self.endpoint.address,
+                self.ssl_context if self.ssl_context else None,
+                self.ssl_options,
+                self._check_hostname,
+                self.connect_timeout,
+            )
 
-            self.connector = reactor.connectSSL(
-                host=self.endpoint.address, port=self.port,
-                factory=TwistedConnectionClientFactory(self),
-                contextFactory=_SSLContextFactory(self.ssl_options, self._check_hostname, self.endpoint.address),
-                timeout=self.connect_timeout)
+            point = SSL4ClientEndpoint(
+                reactor,
+                host,
+                port,
+                sslContextFactory=ssl_options,
+                timeout=self.connect_timeout,
+            )
         else:
-            self.connector = reactor.connectTCP(
-                host=self.endpoint.address, port=self.port,
-                factory=TwistedConnectionClientFactory(self),
-                timeout=self.connect_timeout)
+            point = TCP4ClientEndpoint(
+                reactor,
+                host,
+                port,
+                timeout=self.connect_timeout
+            )
+        connectProtocol(point, TwistedConnectionProtocol(self))
 
     def client_connection_made(self, transport):
         """
@@ -290,7 +275,7 @@ class TwistedConnection(Connection):
             self.is_closed = True
 
         log.debug("Closing connection (%s) to %s", id(self), self.endpoint)
-        reactor.callFromThread(self.connector.disconnect)
+        reactor.callFromThread(self.transport.connector.disconnect)
         log.debug("Closed socket to %s", self.endpoint)
 
         if not self.is_defunct:

--- a/docs/cloud.rst
+++ b/docs/cloud.rst
@@ -34,5 +34,5 @@ Limitations
 
 Event loops
 ^^^^^^^^^^^
-Twisted and Evenlet aren't supported yet. These event loops are still using the old way to configure
+Evenlet isn't supported yet. Eventlet still uses the old way to configure
 SSL (ssl_options), which is not compatible with the secure connect bundle provided by Apollo.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -15,3 +15,4 @@ cython>=0.20,<0.30
 packaging
 futurist; python_version >= '3.7'
 asynctest; python_version > '3.4'
+pyopenssl

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,7 +7,7 @@ unittest2
 pytz
 sure
 pure-sasl
-twisted; python_version >= '3.5'
+twisted[tls]; python_version >= '3.5'
 twisted[tls]==19.2.1; python_version < '3.5'
 gevent>=1.0
 eventlet
@@ -15,4 +15,3 @@ cython>=0.20,<0.30
 packaging
 futurist; python_version >= '3.7'
 asynctest; python_version > '3.4'
-pyopenssl

--- a/tests/integration/advanced/cloud/test_cloud.py
+++ b/tests/integration/advanced/cloud/test_cloud.py
@@ -107,7 +107,7 @@ class CloudTests(CloudProxyCluster):
         with patch('cassandra.datastax.cloud.parse_metadata_info', wraps=self._bad_hostname_metadata):
             with self.assertRaises(NoHostAvailable) as e:
                 self.connect(self.creds)
-            self.assertIn("hostname", str(e.exception))
+            self.assertIn("hostname", str(e.exception).lower())
 
     def test_error_when_bundle_doesnt_exist(self):
         try:

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -19,8 +19,12 @@ except ImportError:
 
 import os, sys, traceback, logging, ssl, time, math, uuid
 from cassandra.cluster import Cluster, NoHostAvailable
+from cassandra.connection import DefaultEndPoint
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
+
+from OpenSSL import SSL, crypto
+
 from tests.integration import PROTOCOL_VERSION, get_cluster, remove_cluster, use_single_node, EVENT_LOOP_MANAGER
 
 log = logging.getLogger(__name__)
@@ -28,26 +32,30 @@ log = logging.getLogger(__name__)
 DEFAULT_PASSWORD = "pythondriver"
 
 # Server keystore trust store locations
-SERVER_KEYSTORE_PATH = "tests/integration/long/ssl/.keystore"
-SERVER_TRUSTSTORE_PATH = "tests/integration/long/ssl/.truststore"
+SERVER_KEYSTORE_PATH = os.path.abspath("tests/integration/long/ssl/.keystore")
+SERVER_TRUSTSTORE_PATH = os.path.abspath("tests/integration/long/ssl/.truststore")
 
 # Client specific keys/certs
-CLIENT_CA_CERTS = 'tests/integration/long/ssl/cassandra.pem'
-DRIVER_KEYFILE = "tests/integration/long/ssl/driver.key"
-DRIVER_KEYFILE_ENCRYPTED = "tests/integration/long/ssl/driver_encrypted.key"
-DRIVER_CERTFILE = "tests/integration/long/ssl/driver.pem"
-DRIVER_CERTFILE_BAD = "tests/integration/long/ssl/python_driver_bad.pem"
+CLIENT_CA_CERTS = os.path.abspath("tests/integration/long/ssl/cassandra.pem")
+DRIVER_KEYFILE = os.path.abspath("tests/integration/long/ssl/driver.key")
+DRIVER_KEYFILE_ENCRYPTED = os.path.abspath("tests/integration/long/ssl/driver_encrypted.key")
+DRIVER_CERTFILE = os.path.abspath("tests/integration/long/ssl/driver.pem")
+DRIVER_CERTFILE_BAD = os.path.abspath("tests/integration/long/ssl/python_driver_bad.pem")
 
+USES_PYOPENSSL = "twisted" in EVENT_LOOP_MANAGER
 if "twisted" in EVENT_LOOP_MANAGER:
     import OpenSSL
     ssl_version = OpenSSL.SSL.TLSv1_METHOD
-    verify_certs = {'cert_reqs': OpenSSL.SSL.VERIFY_PEER,
+    verify_certs = {'cert_reqs': SSL.VERIFY_PEER,
                     'check_hostname': True}
-
 else:
     ssl_version = ssl.PROTOCOL_TLSv1
     verify_certs = {'cert_reqs': ssl.CERT_REQUIRED,
                     'check_hostname': True}
+
+
+def verify_callback(connection, x509, errnum, errdepth, ok):
+    return ok
 
 
 def setup_cluster_ssl(client_auth=False):
@@ -60,20 +68,15 @@ def setup_cluster_ssl(client_auth=False):
     ccm_cluster = get_cluster()
     ccm_cluster.stop()
 
-    # Fetch the absolute path to the keystore for ccm.
-    abs_path_server_keystore_path = os.path.abspath(SERVER_KEYSTORE_PATH)
-
     # Configure ccm to use ssl.
-
     config_options = {'client_encryption_options': {'enabled': True,
-                                                    'keystore': abs_path_server_keystore_path,
+                                                    'keystore': SERVER_KEYSTORE_PATH,
                                                     'keystore_password': DEFAULT_PASSWORD}}
 
     if(client_auth):
-        abs_path_server_truststore_path = os.path.abspath(SERVER_TRUSTSTORE_PATH)
         client_encyrption_options = config_options['client_encryption_options']
         client_encyrption_options['require_client_auth'] = True
-        client_encyrption_options['truststore'] = abs_path_server_truststore_path
+        client_encyrption_options['truststore'] = SERVER_TRUSTSTORE_PATH
         client_encyrption_options['truststore_password'] = DEFAULT_PASSWORD
 
     ccm_cluster.set_configuration_options(config_options)
@@ -83,6 +86,7 @@ def setup_cluster_ssl(client_auth=False):
 def validate_ssl_options(**kwargs):
         ssl_options = kwargs.get('ssl_options', None)
         ssl_context = kwargs.get('ssl_context', None)
+        hostname = kwargs.get('hostname', '127.0.0.1')
 
         # find absolute path to client CA_CERTS
         tries = 0
@@ -90,8 +94,12 @@ def validate_ssl_options(**kwargs):
             if tries > 5:
                 raise RuntimeError("Failed to connect to SSL cluster after 5 attempts")
             try:
-                cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                                  ssl_options=ssl_options, ssl_context=ssl_context)
+                cluster = Cluster(
+                    contact_points=[DefaultEndPoint(hostname)],
+                    protocol_version=PROTOCOL_VERSION,
+                    ssl_options=ssl_options,
+                    ssl_context=ssl_context
+                )
                 session = cluster.connect(wait_for_all_pools=True)
                 break
             except Exception:
@@ -145,8 +153,7 @@ class SSLConnectionTests(unittest.TestCase):
         """
 
         # find absolute path to client CA_CERTS
-        abs_path_ca_cert_path = os.path.abspath(CLIENT_CA_CERTS)
-        ssl_options = {'ca_certs': abs_path_ca_cert_path,'ssl_version': ssl_version}
+        ssl_options = {'ca_certs': CLIENT_CA_CERTS,'ssl_version': ssl_version}
         validate_ssl_options(ssl_options=ssl_options)
 
     def test_can_connect_with_ssl_long_running(self):
@@ -200,9 +207,7 @@ class SSLConnectionTests(unittest.TestCase):
         @test_category connection:ssl
         """
 
-        # find absolute path to client CA_CERTS
-        abs_path_ca_cert_path = os.path.abspath(CLIENT_CA_CERTS)
-        ssl_options = {'ca_certs': abs_path_ca_cert_path,
+        ssl_options = {'ca_certs': CLIENT_CA_CERTS,
                        'ssl_version': ssl_version}
         ssl_options.update(verify_certs)
 
@@ -235,14 +240,10 @@ class SSLConnectionAuthTests(unittest.TestCase):
         @test_category connection:ssl
         """
 
-        # Need to get absolute paths for certs/key
-        abs_path_ca_cert_path = os.path.abspath(CLIENT_CA_CERTS)
-        abs_driver_keyfile = os.path.abspath(DRIVER_KEYFILE)
-        abs_driver_certfile = os.path.abspath(DRIVER_CERTFILE)
-        ssl_options = {'ca_certs': abs_path_ca_cert_path,
+        ssl_options = {'ca_certs': CLIENT_CA_CERTS,
                        'ssl_version': ssl_version,
-                       'keyfile': abs_driver_keyfile,
-                       'certfile': abs_driver_certfile}
+                       'keyfile': DRIVER_KEYFILE,
+                       'certfile': DRIVER_CERTFILE}
         validate_ssl_options(ssl_options=ssl_options)
 
     def test_can_connect_with_ssl_client_auth_host_name(self):
@@ -260,15 +261,10 @@ class SSLConnectionAuthTests(unittest.TestCase):
         @test_category connection:ssl
         """
 
-        # Need to get absolute paths for certs/key
-        abs_path_ca_cert_path = os.path.abspath(CLIENT_CA_CERTS)
-        abs_driver_keyfile = os.path.abspath(DRIVER_KEYFILE)
-        abs_driver_certfile = os.path.abspath(DRIVER_CERTFILE)
-
-        ssl_options = {'ca_certs': abs_path_ca_cert_path,
+        ssl_options = {'ca_certs': CLIENT_CA_CERTS,
                        'ssl_version': ssl_version,
-                       'keyfile': abs_driver_keyfile,
-                       'certfile': abs_driver_certfile}
+                       'keyfile': DRIVER_KEYFILE,
+                       'certfile': DRIVER_CERTFILE}
         ssl_options.update(verify_certs)
 
         validate_ssl_options(ssl_options=ssl_options)
@@ -286,10 +282,13 @@ class SSLConnectionAuthTests(unittest.TestCase):
         @test_category connection:ssl
         """
 
-        abs_path_ca_cert_path = os.path.abspath(CLIENT_CA_CERTS)
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, ssl_options={'ca_certs': abs_path_ca_cert_path,
+        cluster = Cluster(protocol_version=PROTOCOL_VERSION, ssl_options={'ca_certs': CLIENT_CA_CERTS,
                                                                           'ssl_version': ssl_version})
         # attempt to connect and expect an exception
+        if "twisted" in EVENT_LOOP_MANAGER:
+            exc = SSL.Error
+        else:
+            exc = NoHostAvailable
 
         with self.assertRaises(NoHostAvailable) as context:
             cluster.connect()
@@ -309,18 +308,23 @@ class SSLConnectionAuthTests(unittest.TestCase):
         @test_category connection:ssl
         """
 
-        # Setup absolute paths to key/cert files
-        abs_path_ca_cert_path = os.path.abspath(CLIENT_CA_CERTS)
-        abs_driver_keyfile = os.path.abspath(DRIVER_KEYFILE)
-        abs_driver_certfile = os.path.abspath(DRIVER_CERTFILE_BAD)
-
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, ssl_options={'ca_certs': abs_path_ca_cert_path,
+        cluster = Cluster(protocol_version=PROTOCOL_VERSION, ssl_options={'ca_certs': CLIENT_CA_CERTS,
                                                                           'ssl_version': ssl_version,
-                                                                          'keyfile': abs_driver_keyfile,
-                                                                          'certfile': abs_driver_certfile})
+                                                                          'keyfile': DRIVER_KEYFILE,
+                                                                          'certfile': DRIVER_CERTFILE_BAD})
         with self.assertRaises(NoHostAvailable) as context:
             cluster.connect()
         cluster.shutdown()
+
+    def test_cannot_connect_with_invalid_hostname(self):
+        ssl_options = {'ca_certs': CLIENT_CA_CERTS,
+                       'ssl_version': ssl_version,
+                       'keyfile': DRIVER_KEYFILE,
+                       'certfile': DRIVER_CERTFILE}
+        ssl_options.update(verify_certs)
+
+        with self.assertRaises(Exception):
+            validate_ssl_options(ssl_options=ssl_options, hostname='localhost')
 
 
 class SSLSocketErrorTests(unittest.TestCase):
@@ -345,8 +349,7 @@ class SSLSocketErrorTests(unittest.TestCase):
 
         @test_category connection:ssl
         """
-        abs_path_ca_cert_path = os.path.abspath(CLIENT_CA_CERTS)
-        ssl_options = {'ca_certs': abs_path_ca_cert_path,
+        ssl_options = {'ca_certs': CLIENT_CA_CERTS,
                        'ssl_version': ssl_version}
         cluster = Cluster(protocol_version=PROTOCOL_VERSION, ssl_options=ssl_options)
         session = cluster.connect(wait_for_all_pools=True)
@@ -367,7 +370,6 @@ class SSLSocketErrorTests(unittest.TestCase):
 
 
 class SSLConnectionWithSSLContextTests(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         setup_cluster_ssl()
@@ -388,9 +390,13 @@ class SSLConnectionWithSSLContextTests(unittest.TestCase):
 
         @test_category connection:ssl
         """
-        abs_path_ca_cert_path = os.path.abspath(CLIENT_CA_CERTS)
-        ssl_context = ssl.SSLContext(ssl_version)
-        ssl_context.load_verify_locations(abs_path_ca_cert_path)
+        if USES_PYOPENSSL:
+            ssl_context = SSL.Context(SSL.TLSv1_METHOD)
+            ssl_context.load_verify_locations(CLIENT_CA_CERTS)
+        else:
+            ssl_context = ssl.SSLContext(ssl_version)
+            ssl_context.load_verify_locations(CLIENT_CA_CERTS)
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
         validate_ssl_options(ssl_context=ssl_context)
 
     def test_can_connect_with_ssl_client_auth_password_private_key(self):
@@ -406,8 +412,70 @@ class SSLConnectionWithSSLContextTests(unittest.TestCase):
         """
         abs_driver_keyfile = os.path.abspath(DRIVER_KEYFILE_ENCRYPTED)
         abs_driver_certfile = os.path.abspath(DRIVER_CERTFILE)
-        ssl_context = ssl.SSLContext(ssl_version)
-        ssl_context.load_cert_chain(certfile=abs_driver_certfile,
-                                    keyfile=abs_driver_keyfile,
-                                    password='cassandra')
-        validate_ssl_options(ssl_context=ssl_context)
+        ssl_options = {}
+
+        if USES_PYOPENSSL:
+            ssl_context = SSL.Context(SSL.TLSv1_METHOD)
+            ssl_context.use_certificate_file(abs_driver_certfile)
+            with open(abs_driver_keyfile) as keyfile:
+                key = crypto.load_privatekey(crypto.FILETYPE_PEM, keyfile.read(), b'cassandra')
+            ssl_context.use_privatekey(key)
+            ssl_context.set_verify(SSL.VERIFY_NONE, verify_callback)
+        else:
+            ssl_context = ssl.SSLContext(ssl_version)
+            ssl_context.load_cert_chain(certfile=abs_driver_certfile,
+                                        keyfile=abs_driver_keyfile,
+                                        password="cassandra")
+            ssl_context.verify_mode = ssl.CERT_NONE
+        validate_ssl_options(ssl_context=ssl_context, ssl_options=ssl_options)
+
+    def test_can_connect_with_ssl_conext_ca_host_match(self):
+        """
+        Test to validate that we are able to connect to a cluster using a SSLContext
+        using client auth, an encrypted keyfile, and host matching
+        """
+        ssl_options = {}
+        if USES_PYOPENSSL:
+            ssl_context = SSL.Context(SSL.TLSv1_METHOD)
+            ssl_context.use_certificate_file(DRIVER_CERTFILE)
+            with open(DRIVER_KEYFILE_ENCRYPTED) as keyfile:
+                key = crypto.load_privatekey(crypto.FILETYPE_PEM, keyfile.read(), b'cassandra')
+            ssl_context.use_privatekey(key)
+            ssl_context.load_verify_locations(CLIENT_CA_CERTS)
+            ssl_options["check_hostname"] = True
+        else:
+            ssl_context = ssl.SSLContext(ssl_version)
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_context.load_verify_locations(CLIENT_CA_CERTS)
+            ssl_context.load_cert_chain(
+                certfile=DRIVER_CERTFILE,
+                keyfile=DRIVER_KEYFILE_ENCRYPTED,
+                password="cassandra",
+            )
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_options["check_hostname"] = True
+        validate_ssl_options(ssl_context=ssl_context, ssl_options=ssl_options)
+
+    def test_cannot_connect_ssl_context_with_invalid_hostname(self):
+        ssl_options = {}
+        if USES_PYOPENSSL:
+            ssl_context = SSL.Context(SSL.TLSv1_METHOD)
+            ssl_context.use_certificate_file(DRIVER_CERTFILE)
+            with open(DRIVER_KEYFILE_ENCRYPTED) as keyfile:
+                key = crypto.load_privatekey(crypto.FILETYPE_PEM, keyfile.read(), b"cassandra")
+            ssl_context.use_privatekey(key)
+            ssl_context.load_verify_locations(CLIENT_CA_CERTS)
+            ssl_options["check_hostname"] = True
+        else:
+            ssl_context = ssl.SSLContext(ssl_version)
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_context.load_verify_locations(CLIENT_CA_CERTS)
+            ssl_context.load_cert_chain(
+                certfile=DRIVER_CERTFILE,
+                keyfile=DRIVER_KEYFILE_ENCRYPTED,
+                password="cassandra",
+            )
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_options["check_hostname"] = True
+        with self.assertRaises(Exception):
+            validate_ssl_options(ssl_context=ssl_context, ssl_options=ssl_options, hostname="localhost")


### PR DESCRIPTION
Might want to review the two commits separately.

Ran all tests (including long and cloud) using Twisted on a separate branch:
https://jenkins-drivers.build.dsinternal.org/job/riptano.python-driver.twisted-cloud.twisted_cloud/6/

The Unix socket test fails on twisted on master and this PR doesn't address that.

My reasoning behind the SSL context changes...

For the SSL verification, we need to:
1. Verify we have a valid certificate
2. Verify the hostname is correct

When we call `set_verify(VERIFY_PEER, callback)`, number 1 happens, but we still control what happens with the result:

> The return value of verify_callback controls the strategy of the further verification process. If verify_callback returns 0, the verification process is immediately stopped with "verification failed" state. If SSL_VERIFY_PEER is set, a verification failure alert is sent to the peer and the TLS/SSL handshake is terminated. If verify_callback returns 1, the verification process is continued. If verify_callback always returns 1, the TLS/SSL handshake will not be terminated with respect to verification failures and the connection will be established.

^ is from https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_verify.html

The documentation does also state that the callback can be a null pointer and a default one will be used, but I'm not sure how that's been translated into python and I haven't seen any python examples that just pass `None`, so I'm sticking with an us-defined callback for now. So regardless of any sort of hostname verification (number 2 that I listed above), we still need the `set_verify` call and the verification callback for number 1 to happen.

In the past, we also did do number 2 (ourselves manually) in this verification callback, and that's the most logical place to do it. But the fact that this verification callback was also tied to the verify method (e.g., SSL_VERIFY_PEER vs SSL_VERIFY_NONE in the same documentation above) made allowing a user-created SSL context problematic. We want to allow them to set the verify method, but disallow them from doing the hostname verification so we can do it ourselves. Doing our verification in `set_info_callback` was a convenient way to make that happen.
https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_info_callback.html
This is where Twisted normally does its hostname verification too:
https://github.com/twisted/twisted/blob/twisted-19.7.0/src/twisted/internet/_sslverify.py#L1205

So to summarize, we still need `set_verify` and the verification callback in order to ensure we have a valid certificate, but now we can do hostname verification in the `set_info_callback` so that we don't interfere with a user-provided ssl context.

