### PR TITLE
Fix version parsing when two dashes in server version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+3.20.1
+======
+November 6, 2019
+
+Bug Fixes
+---------
+* ValueError: too many values to unpack (expected 2)" when there are two dashes in server version number (PYTHON-1172)
+
 3.20.0
 ======
 October 28, 2019

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -1246,7 +1246,7 @@ class Version(object):
     def __init__(self, version):
         self._version = version
         if '-' in version:
-            version_without_prerelease, self.prerelease = version.split('-')
+            version_without_prerelease, self.prerelease = version.split('-', 1)
         else:
             version_without_prerelease = version
         parts = list(reversed(version_without_prerelease.split('.')))

--- a/tests/unit/test_util_types.py
+++ b/tests/unit/test_util_types.py
@@ -292,3 +292,5 @@ class VersionTests(unittest.TestCase):
         self.assertTrue(Version('4.0.0.build6-SNAPSHOT') > Version('4.0.0.build5-SNAPSHOT'))
         self.assertTrue(Version('4.0-SNAPSHOT2') > Version('4.0-SNAPSHOT1'))
         self.assertTrue(Version('4.0-SNAPSHOT2') > Version('4.0.0-SNAPSHOT1'))
+
+        self.assertTrue(Version('4.0.0-alpha1-SNAPSHOT') > Version('4.0.0-SNAPSHOT'))


### PR DESCRIPTION
PYTHON-1172.

Need to be able to parse versions like: 4.0.0-alpha2-SNAPSHOT