### PR TITLE
Generate server_hostname in DefaultEndPoint class

### DIFF
--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -185,6 +185,7 @@ class DefaultEndPoint(EndPoint):
     def __init__(self, address, port=9042):
         self._address = address
         self._port = port
+        self._ssl_options = {'server_hostname': address}
 
     @property
     def address(self):
@@ -193,6 +194,10 @@ class DefaultEndPoint(EndPoint):
     @property
     def port(self):
         return self._port
+
+    @property
+    def ssl_options(self):
+        return self._ssl_options
 
     def resolve(self):
         return self._address, self._port

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -399,6 +399,17 @@ class SSLConnectionWithSSLContextTests(unittest.TestCase):
             ssl_context.verify_mode = ssl.CERT_REQUIRED
         validate_ssl_options(ssl_context=ssl_context)
 
+    def test_can_connect_with_sslcontext_default_context(self):
+        """
+        Test to validate that we are able to connect to a cluster using a SSLContext created from create_default_context().
+
+        @expected_result The client can connect via SSL and preform some basic operations
+
+        @test_category connection:ssl
+        """
+        ssl_context = ssl.create_default_context(cafile=CLIENT_CA_CERTS)
+        validate_ssl_options(ssl_context=ssl_context)
+
     def test_can_connect_with_ssl_client_auth_password_private_key(self):
         """
         Identical test to SSLConnectionAuthTests.test_can_connect_with_ssl_client_auth,


### PR DESCRIPTION
Currently, if a programmer wants to use this driver to initiate an SSL
connection while verifying that the certificate is valid for the current
host, they need to explicitly pass in the hostname in the Cluster's
ssl_options parameter.  This is both a violation of the Python SSL
module's design principles (which intend for the server_hostname to be
set at the point of socket creation), and also impractical for a Cluster
which includes more than one Cassandra node (because the user can only
specify one hostname, causing connections to the rest of the cluster to
fail).

This commit moves the logic for setting the server_hostname into the
DefaultEndPoint class, which is by necessity designed to be aware of the
address to which the server is connecting.  This allows hostname
checking to act correctly on each individual server in the pool, rather
than requiring the user to specify a static host.

Additionally, I've added a test to the SSL integration suite which
verifies that we can connect using ssl.create_default_context().  This
function is now the recommended way to configure SSL in python, because
it automatically turns on the security features that are generally
expected from an SSL connection (certificate validation which defaults
to the OS trust store, hostname verification, and a sane list of allowed
protocol versions and cipher suites).

I expect the new test to pass on python versions up to and including
3.6.  With the current server certificate, however, it fails on python
\>= 3.7 due to stricter hostname matching which requires that
certificates list any IP addresses they are valid for in SAN fields.  I
recommend that in a followup change you regenerate the certificate used
in these tests to properly include 127.0.0.1 in a SAN record.  For more
details, see https://bugs.python.org/issue34440 .