### PR TITLE
Fix simple typo: versioni -> version

### DIFF
--- a/cassandra/__init__.py
+++ b/cassandra/__init__.py
@@ -181,7 +181,7 @@ class ProtocolVersion(object):
 
     MAX_SUPPORTED = max(SUPPORTED_VERSIONS)
     """
-    Maximum protocol versioni supported by this driver.
+    Maximum protocol version supported by this driver.
     """
 
     @classmethod


### PR DESCRIPTION
There is a small typo in cassandra/__init__.py.
Should read version rather than versioni.

