### PR TITLE
Move session id creation before insights reporter starts

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2538,6 +2538,8 @@ class Session(object):
                 msg += " using keyspace '%s'" % self.keyspace
             raise NoHostAvailable(msg, [h.address for h in hosts])
 
+        self.session_id = uuid.uuid4()
+
         cc_host = self.cluster.get_control_connection_host()
         valid_insights_version = (cc_host and version_supports_insights(cc_host.dse_version))
         if self.cluster.monitor_reporting_enabled and valid_insights_version:
@@ -2551,7 +2553,6 @@ class Session(object):
                           'not supported by server version {v} on '
                           'ControlConnection host {c}'.format(v=cc_host.release_version, c=cc_host))
 
-        self.session_id = uuid.uuid4()
         log.debug('Started Session with client_id {} and session_id {}'.format(self.cluster.client_id,
                                                                                self.session_id))
 


### PR DESCRIPTION
When the insights reporter retrieves the startup data, it captures the session id. Since this runs in a separate thread, the session id is usually created by the time this capture actually runs. But it's a race, and sessionId can occassionally be captured as None.