### PR TITLE
Changes from test failures

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -2538,6 +2538,8 @@ class Session(object):
                 msg += " using keyspace '%s'" % self.keyspace
             raise NoHostAvailable(msg, [h.address for h in hosts])
 
+        self.session_id = uuid.uuid4()
+
         cc_host = self.cluster.get_control_connection_host()
         valid_insights_version = (cc_host and version_supports_insights(cc_host.dse_version))
         if self.cluster.monitor_reporting_enabled and valid_insights_version:
@@ -2551,7 +2553,6 @@ class Session(object):
                           'not supported by server version {v} on '
                           'ControlConnection host {c}'.format(v=cc_host.release_version, c=cc_host))
 
-        self.session_id = uuid.uuid4()
         log.debug('Started Session with client_id {} and session_id {}'.format(self.cluster.client_id,
                                                                                self.session_id))
 

--- a/tests/integration/cqlengine/model/test_model.py
+++ b/tests/integration/cqlengine/model/test_model.py
@@ -259,10 +259,13 @@ class TestDeprecationWarning(unittest.TestCase):
             rows[-1]
             rows[-1:]
 
-            self.assertEqual(len(w), 4)
-            self.assertIn("__table_name_case_sensitive__ will be removed in 4.0.", str(w[0].message))
-            self.assertIn("__table_name_case_sensitive__ will be removed in 4.0.", str(w[1].message))
+            # Asyncio complains loudly about old syntax on python 3.7+, so get rid of all of those
+            relevant_warnings = [warn for warn in w if "with (yield from lock)" not in str(warn.message)]
+
+            self.assertEqual(len(relevant_warnings), 4)
+            self.assertIn("__table_name_case_sensitive__ will be removed in 4.0.", str(relevant_warnings[0].message))
+            self.assertIn("__table_name_case_sensitive__ will be removed in 4.0.", str(relevant_warnings[1].message))
             self.assertIn("ModelQuerySet indexing with negative indices support will be removed in 4.0.",
-                          str(w[2].message))
+                          str(relevant_warnings[2].message))
             self.assertIn("ModelQuerySet slicing with negative indices support will be removed in 4.0.",
-                          str(w[3].message))
+                          str(relevant_warnings[3].message))


### PR DESCRIPTION
Move session id creation before insights reporter starts. When the insights reporter retrieves the startup data, it captures the session id. Since this runs in a separate thread, the session id is usually created by the time this capture actually runs. But it's a race, and sessionId can occassionally be captured as None.

Fix tests/integration/cqlengine/model/test_model.py:TestDeprecationWarning.test_deprecation_warnings: Asyncio throws warnings on python 2.7+ that aren't relevant to the test, so ignore them.