### PR TITLE
Test 68

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -125,7 +125,7 @@ def _get_cass_version_from_dse(dse_version):
             cass_ver = '4.0.0.2349'
         else:
             cass_ver = '4.0.0.' + ''.join(dse_version.split('.'))
-    elif dse_version.startswith('6.7'):
+    elif Version(dse_version) >= Version('6.7'):
         if dse_version == '6.7.0':
             cass_ver = "4.0.0.67"
         else:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -472,7 +472,13 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, 
         if CCM_CLUSTER:
             log.debug("Using external CCM cluster {0}".format(CCM_CLUSTER.name))
         else:
-            log.debug("Using unnamed external cluster")
+            ccm_path = os.getenv("CCM_PATH", None)
+            ccm_name = os.getenv("CCM_NAME", None)
+            if ccm_path and ccm_name:
+                CCM_CLUSTER = CCMClusterFactory.load(ccm_path, ccm_name)
+                log.debug("Using external CCM cluster {0}".format(CCM_CLUSTER.name))
+            else:
+                log.debug("Using unnamed external cluster")
         if set_keyspace and start:
             setup_keyspace(ipformat=ipformat, wait=False)
         return

--- a/tests/integration/cqlengine/query/test_named.py
+++ b/tests/integration/cqlengine/query/test_named.py
@@ -335,7 +335,7 @@ class TestNamedWithMV(BasicSharedKeyspaceUnitTestCase):
                         SELECT * FROM {0}.scores
                         WHERE game IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL
                         PRIMARY KEY (game, score, user, year, month, day)
-                        WITH CLUSTERING ORDER BY (score DESC)""".format(ks)
+                        WITH CLUSTERING ORDER BY (score DESC, user DESC, year DESC, month DESC, day DESC)""".format(ks)
 
         self.session.execute(create_mv_alltime)
 

--- a/tests/integration/long/test_failure_types.py
+++ b/tests/integration/long/test_failure_types.py
@@ -16,6 +16,8 @@ import logging
 import sys
 import traceback
 import time
+
+from ccmlib.dse_cluster import DseCluster
 from mock import Mock
 
 from cassandra.policies import HostFilterPolicy, RoundRobinPolicy
@@ -29,7 +31,7 @@ from cassandra.query import SimpleStatement
 from tests.integration import (
     use_singledc, PROTOCOL_VERSION, get_cluster, setup_keyspace, remove_cluster,
     get_node, start_cluster_wait_for_up, requiresmallclockgranularity,
-)
+    local)
 
 
 try:
@@ -40,6 +42,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
+@local
 def setup_module():
     """
     We need some custom setup for this module. All unit tests in this module

--- a/tests/integration/long/test_failure_types.py
+++ b/tests/integration/long/test_failure_types.py
@@ -55,7 +55,7 @@ def setup_module():
         use_singledc(start=False)
         ccm_cluster = get_cluster()
         ccm_cluster.stop()
-        config_options = {'tombstone_failure_threshold': 2000, 'tombstone_warn_threshold': 1000}
+        config_options = {'guardrails.tombstone_failure_threshold': 2000, 'guardrails.tombstone_warn_threshold': 1000}
         ccm_cluster.set_configuration_options(config_options)
         start_cluster_wait_for_up(ccm_cluster)
         setup_keyspace()
@@ -255,7 +255,7 @@ class ClientExceptionTests(unittest.TestCase):
         parameters = [(x,) for x in range(3000)]
         self.execute_concurrent_args_helper(self.session, statement, parameters)
 
-        statement = self.session.prepare("DELETE v1 FROM test3rf.test2 WHERE k = 1 AND v0 =?")
+        statement = self.session.prepare("DELETE FROM test3rf.test2 WHERE k = 1 AND v0 =?")
         parameters = [(x,) for x in range(2001)]
         self.execute_concurrent_args_helper(self.session, statement, parameters)
 

--- a/tests/integration/standard/test_control_connection.py
+++ b/tests/integration/standard/test_control_connection.py
@@ -14,6 +14,7 @@
 #
 #
 #
+from cassandra import InvalidRequest
 
 try:
     import unittest2 as unittest
@@ -43,7 +44,7 @@ class ControlConnectionTests(unittest.TestCase):
     def tearDown(self):
         try:
             self.session.execute("DROP KEYSPACE keyspacetodrop ")
-        except (ConfigurationException):
+        except (ConfigurationException, InvalidRequest):
             # we already removed the keyspace.
             pass
         self.cluster.shutdown()

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -2467,22 +2467,6 @@ class GroupPerHost(BasicSharedKeyspaceUnitTestCase):
 class VirtualKeypaceTest(BasicSharedKeyspaceUnitTestCase):
     virtual_ks_names = ('system_virtual_schema', 'system_views')
 
-    virtual_ks_structure = {
-        # keyspaces
-        'system_virtual_schema': {
-            # tables: columns. columns are a set because we're comparing unordered
-            'keyspaces': {'keyspace_name'},
-            'tables': {'comment', 'keyspace_name', 'table_name'},
-            'columns': {'clustering_order', 'column_name', 'column_name_bytes',
-                        'keyspace_name', 'kind', 'position', 'table_name',
-                        'type'}
-        },
-        'system_views': {
-            'sstable_tasks': {'keyspace_name', 'kind', 'progress',
-                              'table_name', 'task_id', 'total', 'unit'}
-        }
-    }
-
     def test_existing_keyspaces_have_correct_virtual_tags(self):
         for name, ks in self.cluster.metadata.keyspaces.items():
             if name in self.virtual_ks_names:
@@ -2519,5 +2503,7 @@ class VirtualKeypaceTest(BasicSharedKeyspaceUnitTestCase):
                     tab.columns.keys()
                 )
 
-        self.assertDictEqual(ingested_virtual_ks_structure,
-                             self.virtual_ks_structure)
+        # Identify a couple known values to verify we parsed the structure correctly
+        self.assertIn('table_name', ingested_virtual_ks_structure['system_virtual_schema']['tables'])
+        self.assertIn('type', ingested_virtual_ks_structure['system_virtual_schema']['columns'])
+        self.assertIn('total', ingested_virtual_ks_structure['system_views']['sstable_tasks'])

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -723,7 +723,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         try:
             self.assertNotIn("mv1", cluster2.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views)
-            self.session.execute("CREATE MATERIALIZED VIEW {0}.mv1 AS SELECT b FROM {0}.{1} WHERE b IS NOT NULL PRIMARY KEY (a, b)"
+            self.session.execute("CREATE MATERIALIZED VIEW {0}.mv1 AS SELECT a, b FROM {0}.{1} WHERE b IS NOT NULL PRIMARY KEY (a, b)"
                                  .format(self.keyspace_name, self.function_table_name))
             self.assertNotIn("mv1", cluster2.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views)
 
@@ -745,7 +745,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         cluster3.connect()
         try:
             self.assertNotIn("mv2", cluster3.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views)
-            self.session.execute("CREATE MATERIALIZED VIEW {0}.mv2 AS SELECT b FROM {0}.{1} WHERE b IS NOT NULL PRIMARY KEY (a, b)"
+            self.session.execute("CREATE MATERIALIZED VIEW {0}.mv2 AS SELECT a, b FROM {0}.{1} WHERE b IS NOT NULL PRIMARY KEY (a, b)"
                                  .format(self.keyspace_name, self.function_table_name))
             self.assertNotIn("mv2", cluster3.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views)
             cluster3.refresh_materialized_view_metadata(self.keyspace_name, 'mv2')
@@ -2094,7 +2094,7 @@ class Materia3lizedViewMetadataTestSimple(BasicSharedKeyspaceUnitTestCase):
         self.assertDictEqual({}, self.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views)
         self.assertDictEqual({}, self.cluster.metadata.keyspaces[self.keyspace_name].views)
 
-        self.session.execute("CREATE MATERIALIZED VIEW {0}.mv1 AS SELECT c FROM {0}.{1} WHERE c IS NOT NULL PRIMARY KEY (pk, c)".format(self.keyspace_name, self.function_table_name))
+        self.session.execute("CREATE MATERIALIZED VIEW {0}.mv1 AS SELECT pk, c FROM {0}.{1} WHERE c IS NOT NULL PRIMARY KEY (pk, c)".format(self.keyspace_name, self.function_table_name))
 
 
 @greaterthanorequalcass30
@@ -2237,7 +2237,7 @@ class MaterializedViewMetadataTestComplex(BasicSegregatedKeyspaceUnitTestCase):
                         SELECT * FROM {0}.scores
                         WHERE game IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL
                         PRIMARY KEY (game, score, user, year, month, day)
-                        WITH CLUSTERING ORDER BY (score DESC)""".format(self.keyspace_name)
+                        WITH CLUSTERING ORDER BY (score DESC, user ASC, year ASC, month ASC, day ASC)""".format(self.keyspace_name)
 
         self.session.execute(create_mv)
 

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -1193,25 +1193,25 @@ class MaterializedViewQueryTest(BasicSharedKeyspaceUnitTestCase):
                         SELECT * FROM {0}.scores
                         WHERE game IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL
                         PRIMARY KEY (game, score, user, year, month, day)
-                        WITH CLUSTERING ORDER BY (score DESC)""".format(self.keyspace_name)
+                        WITH CLUSTERING ORDER BY (score DESC, user ASC, year ASC, month ASC, day ASC)""".format(self.keyspace_name)
 
         create_mv_dailyhigh = """CREATE MATERIALIZED VIEW {0}.dailyhigh AS
                         SELECT * FROM {0}.scores
                         WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND day IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL
                         PRIMARY KEY ((game, year, month, day), score, user)
-                        WITH CLUSTERING ORDER BY (score DESC)""".format(self.keyspace_name)
+                        WITH CLUSTERING ORDER BY (score DESC, user ASC)""".format(self.keyspace_name)
 
         create_mv_monthlyhigh = """CREATE MATERIALIZED VIEW {0}.monthlyhigh AS
                         SELECT * FROM {0}.scores
                         WHERE game IS NOT NULL AND year IS NOT NULL AND month IS NOT NULL AND score IS NOT NULL AND user IS NOT NULL AND day IS NOT NULL
                         PRIMARY KEY ((game, year, month), score, user, day)
-                        WITH CLUSTERING ORDER BY (score DESC)""".format(self.keyspace_name)
+                        WITH CLUSTERING ORDER BY (score DESC, user ASC, day ASC)""".format(self.keyspace_name)
 
         create_mv_filtereduserhigh = """CREATE MATERIALIZED VIEW {0}.filtereduserhigh AS
                         SELECT * FROM {0}.scores
                         WHERE user in ('jbellis', 'pcmanus') AND game IS NOT NULL AND score IS NOT NULL AND year is NOT NULL AND day is not NULL and month IS NOT NULL
                         PRIMARY KEY (game, score, user, year, month, day)
-                        WITH CLUSTERING ORDER BY (score DESC)""".format(self.keyspace_name)
+                        WITH CLUSTERING ORDER BY (score DESC, user ASC, year ASC, month ASC, day ASC)""".format(self.keyspace_name)
 
         self.session.execute(create_mv_alltime)
         self.session.execute(create_mv_dailyhigh)


### PR DESCRIPTION
Major changes mentioned in commits but summarized here:
 * Materialized view tests: You now can't create a MV with clustering order by unless you specify ALL of the clustering columns. So tests are updated to do that.
 * DuplicateRpcTest: We used to be able to update system.peers, but that's not allowed anymore, so converted it to a simulacron test. Updated another test to use mocks for the same reason.
 * Updated virtual keyspace test to not verify exact structure since that will change between versions. Rather, verify a few known values that should exist in all versions to verify we parsed the structure correctly.
 * Tombstone settings have moved under guardrails, and delete entire row intead of just cells in tombstone tests due to DB-2426.
 * Added a few optional env vars to allow management of an external cluster
 * DSE version check stuff

I'll squash down to one commit when merging