### PR TITLE
Python 1207 transient parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 ======
 Unreleased
 
+Features
+--------
+Transient Replication Support (PYTHON-1207)
+
 Bug Fixes
 ---------
 * Asyncore logging exception on shutdown (PYTHON-1228)


### PR DESCRIPTION
Converted replication factors from int's to strings to support the parsing of transient replications.