### PR TITLE
PYTHON-1226 Remove all user-facing references to Apollo or Constellation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -146,7 +146,7 @@ October 28, 2019
 
 Features
 --------
-* DataStax Apollo (Astra) Support (PYTHON-1074)
+* DataStax Astra Support (PYTHON-1074)
 * Use 4.0 schema parser in 4 alpha and snapshot builds (PYTHON-1158)
 
 Bug Fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -146,7 +146,7 @@ October 28, 2019
 
 Features
 --------
-* DataStax Apollo Support (PYTHON-1074)
+* DataStax Apollo (Astra) Support (PYTHON-1074)
 * Use 4.0 schema parser in 4 alpha and snapshot builds (PYTHON-1158)
 
 Bug Fixes

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Features
 * Configurable `load balancing <http://datastax.github.io/python-driver/api/cassandra/policies.html#load-balancing>`_ and `retry policies <http://datastax.github.io/python-driver/api/cassandra/policies.html#retrying-failed-operations>`_
 * `Concurrent execution utilities <http://datastax.github.io/python-driver/api/cassandra/concurrent.html>`_
 * `Object mapper <http://datastax.github.io/python-driver/object_mapper.html>`_
-* `Connecting to DataStax Apollo database (cloud) <https://docs.datastax.com/en/developer/python-driver/latest/cloud/>`_
+* `Connecting to DataStax Astra database (cloud) <https://docs.datastax.com/en/developer/python-driver/latest/cloud/>`_
 * DSE Graph execution API
 * DSE Geometric type serialization
 * DSE PlainText and GSSAPI authentication

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -3469,7 +3469,7 @@ class ControlConnection(object):
         self._protocol_version = self._cluster.protocol_version
         self._set_new_connection(self._reconnect_internal())
 
-        self._cluster.metadata.dbaas = self._connection._product_type == dscloud.PRODUCT_APOLLO
+        self._cluster.metadata.dbaas = self._connection._product_type == dscloud.DATASTAX_CLOUD_PRODUCT_TYPE
 
     def _set_new_connection(self, conn):
         """

--- a/cassandra/datastax/cloud/__init__.py
+++ b/cassandra/datastax/cloud/__init__.py
@@ -41,7 +41,7 @@ log = logging.getLogger(__name__)
 
 __all__ = ['get_cloud_config']
 
-PRODUCT_APOLLO = "DATASTAX_APOLLO"
+DATASTAX_CLOUD_PRODUCT_TYPE = "DATASTAX_APOLLO"
 
 
 class CloudConfig(object):

--- a/cassandra/datastax/cloud/__init__.py
+++ b/cassandra/datastax/cloud/__init__.py
@@ -138,7 +138,7 @@ def read_metadata_info(config, cloud_config):
     except Exception as e:
         log.exception(e)
         raise DriverException("Unable to connect to the metadata service at %s. "
-                              "Check the cluster status in the Constellation cloud console. " % url)
+                              "Check the cluster status in the cloud console. " % url)
 
     if response.code != 200:
         raise DriverException(("Error while fetching the metadata at: %s. "
@@ -183,7 +183,7 @@ def _pyopenssl_context_from_cert(ca_cert_location, cert_location, key_location):
     except ImportError as e:
         six.reraise(
             ImportError,
-            ImportError("PyOpenSSL must be installed to connect to Apollo with the Eventlet or Twisted event loops"),
+            ImportError("PyOpenSSL must be installed to connect to Astra with the Eventlet or Twisted event loops"),
             sys.exc_info()[2]
         )
     ssl_context = SSL.Context(SSL.TLSv1_METHOD)

--- a/docs/cloud.rst
+++ b/docs/cloud.rst
@@ -2,9 +2,9 @@ Cloud
 -----
 Connecting
 ==========
-To connect to a DataStax Apollo cluster:
+To connect to a DataStax Astra cluster:
 
-1. Download the secure connect bundle from your Apollo account.
+1. Download the secure connect bundle from your Astra account.
 2. Connect to your cluster with
 
 .. code-block:: python
@@ -19,9 +19,9 @@ To connect to a DataStax Apollo cluster:
     cluster = Cluster(cloud=cloud_config, auth_provider=auth_provider)
     session = cluster.connect()
 
-Apollo Differences
+Astra Differences
 ==================
-In most circumstances, the client code for interacting with an Apollo cluster will be the same as interacting with any other Cassandra cluster. The exceptions being:
+In most circumstances, the client code for interacting with an Astra cluster will be the same as interacting with any other Cassandra cluster. The exceptions being:
 
 * A cloud configuration must be passed to a :class:`~.Cluster` instance via the `cloud` attribute (as demonstrated above).
 * An SSL connection will be established automatically. Manual SSL configuration is not allowed, and using `ssl_context` or `ssl_options` will result in an exception.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,7 @@ Contents
     Some discussion on the driver's approach to working with timestamp, date, time types
 
 :doc:`cloud`
-    A guide to connecting to Datastax Apollo
+    A guide to connecting to Datastax Astra
 
 :doc:`geo_types`
     Working with DSE geometry types


### PR DESCRIPTION
Just to verify, we DON'T plan on changing this particular flag or references to it?
https://github.com/datastax/python-driver/blob/master/cassandra/datastax/cloud/__init__.py#L44