### PR TITLE
PYTHON-700: Support port discovery for C* 4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,8 @@ Unreleased
 
 Features
 --------
-Transient Replication Support (PYTHON-1207)
+* Transient Replication Support (PYTHON-1207)
+* Support system.peers_v2 and port discovery for C* 4.0 (PYTHON-700)
 
 Bug Fixes
 ---------

--- a/build.yaml
+++ b/build.yaml
@@ -21,7 +21,7 @@ schedules:
     matrix:
       exclude:
         - python: [3.4, 3.6, 3.7, 3.8]
-        - cassandra: ['2.1', '3.0', '4.0', 'test-dse']
+        - cassandra: ['2.1', '3.0', 'test-dse']
 
   commit_branches:
     schedule: per_commit
@@ -34,7 +34,7 @@ schedules:
     matrix:
       exclude:
         - python: [3.4, 3.6, 3.7, 3.8]
-        - cassandra: ['2.1', '3.0', '4.0', 'test-dse']
+        - cassandra: ['2.1', '3.0', 'test-dse']
 
   commit_branches_dev:
     schedule: per_commit
@@ -184,9 +184,11 @@ build:
       pip install --upgrade pip
       pip install -U setuptools
 
+      pip install git+ssh://git@github.com/riptano/ccm-private.git@cassandra-7544-native-ports-with-dse-fix
+
       # Remove this pyyaml installation when removing Python 3.4 support
       pip install PyYAML==5.2
-      pip install $HOME/ccm
+      #pip install $HOME/ccm
 
       if [ -n "$CCM_IS_DSE" ]; then
         pip install -r test-datastax-requirements.txt

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -64,7 +64,7 @@ from cassandra.protocol import (QueryMessage, ResultMessage,
                                 RESULT_KIND_SET_KEYSPACE, RESULT_KIND_ROWS,
                                 RESULT_KIND_SCHEMA_CHANGE, ProtocolHandler,
                                 RESULT_KIND_VOID)
-from cassandra.metadata import Metadata, protect_name, murmur3
+from cassandra.metadata import Metadata, protect_name, murmur3, _NodeInfo
 from cassandra.policies import (TokenAwarePolicy, DCAwareRoundRobinPolicy, SimpleConvictionPolicy,
                                 ExponentialReconnectionPolicy, HostDistance,
                                 RetryPolicy, IdentityTranslator, NoSpeculativeExecutionPlan,
@@ -581,7 +581,7 @@ class Cluster(object):
     contact_points = ['127.0.0.1']
     """
     The list of contact points to try connecting for cluster discovery. A
-    contact point can be a string (ip, hostname) or a
+    contact point can be a string (ip or hostname), a tuple (ip/hostname, port) or a
     :class:`.connection.EndPoint` instance.
 
     Defaults to loopback interface.
@@ -1152,20 +1152,24 @@ class Cluster(object):
         self.endpoint_factory = endpoint_factory or DefaultEndPointFactory(port=self.port)
         self.endpoint_factory.configure(self)
 
-        raw_contact_points = [cp for cp in self.contact_points if not isinstance(cp, EndPoint)]
+        raw_contact_points = []
+        for cp in [cp for cp in self.contact_points if not isinstance(cp, EndPoint)]:
+            raw_contact_points.append(cp if isinstance(cp, tuple) else (cp, port))
+
         self.endpoints_resolved = [cp for cp in self.contact_points if isinstance(cp, EndPoint)]
         self._endpoint_map_for_insights = {repr(ep): '{ip}:{port}'.format(ip=ep.address, port=ep.port)
                                            for ep in self.endpoints_resolved}
 
-        strs_resolved_map = _resolve_contact_points_to_string_map(raw_contact_points, port)
+        strs_resolved_map = _resolve_contact_points_to_string_map(raw_contact_points)
         self.endpoints_resolved.extend(list(chain(
             *[
-                [DefaultEndPoint(x, port) for x in xs if x is not None]
+                [DefaultEndPoint(ip, port) for ip, port in xs if ip is not None]
                 for xs in strs_resolved_map.values() if xs is not None
             ]
         )))
+
         self._endpoint_map_for_insights.update(
-            {key: ['{ip}:{port}'.format(ip=ip, port=port) for ip in value]
+            {key: ['{ip}:{port}'.format(ip=ip, port=port) for ip, port in value]
              for key, value in strs_resolved_map.items() if value is not None}
         )
 
@@ -3420,7 +3424,16 @@ class ControlConnection(object):
     _SELECT_SCHEMA_PEERS_TEMPLATE = "SELECT peer, host_id, {nt_col_name}, schema_version FROM system.peers"
     _SELECT_SCHEMA_LOCAL = "SELECT schema_version FROM system.local WHERE key='local'"
 
+    _SELECT_PEERS_V2 = "SELECT * FROM system.peers_v2"
+    _SELECT_PEERS_NO_TOKENS_V2 = "SELECT host_id, peer, peer_port, data_center, rack, native_address, native_port, release_version, schema_version FROM system.peers_v2"
+    _SELECT_SCHEMA_PEERS_V2 = "SELECT host_id, peer, peer_port, native_address, native_port, schema_version FROM system.peers_v2"
+
     _MINIMUM_NATIVE_ADDRESS_DSE_VERSION = Version("6.0.0")
+
+    class PeersQueryType(object):
+        """internal Enum for _peers_query"""
+        PEERS = 0
+        PEERS_SCHEMA = 1
 
     _is_shutdown = False
     _timeout = None
@@ -3432,6 +3445,8 @@ class ControlConnection(object):
 
     _schema_meta_enabled = True
     _token_meta_enabled = True
+
+    _uses_peers_v2 = True
 
     # for testing purposes
     _time = time
@@ -3547,13 +3562,25 @@ class ControlConnection(object):
                 "SCHEMA_CHANGE": partial(_watch_callback, self_weakref, '_handle_schema_change')
             }, register_timeout=self._timeout)
 
-            sel_peers = self._peers_query_for_version(connection, self._SELECT_PEERS_NO_TOKENS_TEMPLATE)
+            sel_peers = self._get_peers_query(self.PeersQueryType.PEERS, connection)
             sel_local = self._SELECT_LOCAL if self._token_meta_enabled else self._SELECT_LOCAL_NO_TOKENS
             peers_query = QueryMessage(query=sel_peers, consistency_level=ConsistencyLevel.ONE)
             local_query = QueryMessage(query=sel_local, consistency_level=ConsistencyLevel.ONE)
-            shared_results = connection.wait_for_responses(
-                peers_query, local_query, timeout=self._timeout)
+            (peers_success, peers_result), (local_success, local_result) = connection.wait_for_responses(
+                peers_query, local_query, timeout=self._timeout, fail_on_error=False)
 
+            if not local_success:
+                raise local_result
+
+            if not peers_success:
+                # error with the peers v2 query, fallback to peers v1
+                self._uses_peers_v2 = False
+                sel_peers = self._get_peers_query(self.PeersQueryType.PEERS, connection)
+                peers_query = QueryMessage(query=sel_peers, consistency_level=ConsistencyLevel.ONE)
+                peers_result = connection.wait_for_response(
+                    peers_query, timeout=self._timeout)
+
+            shared_results = (peers_result, local_result)
             self._refresh_node_list_and_token_map(connection, preloaded_results=shared_results)
             self._refresh_schema(connection, preloaded_results=shared_results, schema_agreement_wait=-1)
         except Exception:
@@ -3675,20 +3702,18 @@ class ControlConnection(object):
 
     def _refresh_node_list_and_token_map(self, connection, preloaded_results=None,
                                          force_token_rebuild=False):
-
         if preloaded_results:
             log.debug("[control connection] Refreshing node list and token map using preloaded results")
             peers_result = preloaded_results[0]
             local_result = preloaded_results[1]
         else:
             cl = ConsistencyLevel.ONE
+            sel_peers = self._get_peers_query(self.PeersQueryType.PEERS, connection)
             if not self._token_meta_enabled:
                 log.debug("[control connection] Refreshing node list without token map")
-                sel_peers = self._peers_query_for_version(connection, self._SELECT_PEERS_NO_TOKENS_TEMPLATE)
                 sel_local = self._SELECT_LOCAL_NO_TOKENS
             else:
                 log.debug("[control connection] Refreshing node list and token map")
-                sel_peers = self._SELECT_PEERS
                 sel_local = self._SELECT_LOCAL
             peers_query = QueryMessage(query=sel_peers, consistency_level=cl)
             local_query = QueryMessage(query=sel_local, consistency_level=cl)
@@ -3718,13 +3743,17 @@ class ControlConnection(object):
                 self._update_location_info(host, datacenter, rack)
                 host.host_id = local_row.get("host_id")
                 host.listen_address = local_row.get("listen_address")
-                host.broadcast_address = local_row.get("broadcast_address")
+                host.listen_port = local_row.get("listen_port")
+                host.broadcast_address = _NodeInfo.get_broadcast_address(local_row)
+                host.broadcast_port = _NodeInfo.get_broadcast_port(local_row)
 
-                host.broadcast_rpc_address = self._address_from_row(local_row)
+                host.broadcast_rpc_address = _NodeInfo.get_broadcast_rpc_address(local_row)
+                host.broadcast_rpc_port = _NodeInfo.get_broadcast_rpc_port(local_row)
                 if host.broadcast_rpc_address is None:
                     if self._token_meta_enabled:
                         # local rpc_address is not available, use the connection endpoint
                         host.broadcast_rpc_address = connection.endpoint.address
+                        host.broadcast_rpc_port = connection.endpoint.port
                     else:
                         # local rpc_address has not been queried yet, try to fetch it
                         # separately, which might fail because C* < 2.1.6 doesn't have rpc_address
@@ -3737,9 +3766,11 @@ class ControlConnection(object):
                             row = dict_factory(
                                 local_rpc_address_result.column_names,
                                 local_rpc_address_result.parsed_rows)
-                            host.broadcast_rpc_address = row[0]['rpc_address']
+                            host.broadcast_rpc_address = _NodeInfo.get_broadcast_rpc_address(row[0])
+                            host.broadcast_rpc_port = _NodeInfo.get_broadcast_rpc_port(row[0])
                         else:
                             host.broadcast_rpc_address = connection.endpoint.address
+                            host.broadcast_rpc_port = connection.endpoint.port
 
                 host.release_version = local_row.get("release_version")
                 host.dse_version = local_row.get("dse_version")
@@ -3777,8 +3808,10 @@ class ControlConnection(object):
                 should_rebuild_token_map |= self._update_location_info(host, datacenter, rack)
 
             host.host_id = row.get("host_id")
-            host.broadcast_address = row.get("peer")
-            host.broadcast_rpc_address = self._address_from_row(row)
+            host.broadcast_address = _NodeInfo.get_broadcast_address(row)
+            host.broadcast_port = _NodeInfo.get_broadcast_port(row)
+            host.broadcast_rpc_address = _NodeInfo.get_broadcast_rpc_address(row)
+            host.broadcast_rpc_port = _NodeInfo.get_broadcast_rpc_port(row)
             host.release_version = row.get("release_version")
             host.dse_version = row.get("dse_version")
             host.dse_workload = row.get("workload")
@@ -3834,7 +3867,8 @@ class ControlConnection(object):
 
     def _handle_topology_change(self, event):
         change_type = event["change_type"]
-        host = self._cluster.metadata.get_host(event["address"][0])
+        addr, port = event["address"]
+        host = self._cluster.metadata.get_host(addr, port)
         if change_type == "NEW_NODE" or change_type == "MOVED_NODE":
             if self._topology_event_refresh_window >= 0:
                 delay = self._delay_for_event_type('topology_change', self._topology_event_refresh_window)
@@ -3844,7 +3878,8 @@ class ControlConnection(object):
 
     def _handle_status_change(self, event):
         change_type = event["change_type"]
-        host = self._cluster.metadata.get_host(event["address"][0])
+        addr, port = event["address"]
+        host = self._cluster.metadata.get_host(addr, port)
         if change_type == "UP":
             delay = self._delay_for_event_type('status_change', self._status_event_refresh_window)
             if host is None:
@@ -3898,7 +3933,7 @@ class ControlConnection(object):
             elapsed = 0
             cl = ConsistencyLevel.ONE
             schema_mismatches = None
-            select_peers_query = self._peers_query_for_version(connection, self._SELECT_SCHEMA_PEERS_TEMPLATE)
+            select_peers_query = self._get_peers_query(self.PeersQueryType.PEERS_SCHEMA, connection)
 
             while elapsed < total_timeout:
                 peers_query = QueryMessage(query=select_peers_query, consistency_level=cl)
@@ -3955,43 +3990,50 @@ class ControlConnection(object):
 
         return dict((version, list(nodes)) for version, nodes in six.iteritems(versions))
 
-    def _address_from_row(self, row):
+    def _get_peers_query(self, peers_query_type, connection=None):
         """
-        Parse the broadcast rpc address from a row and return it untranslated.
-        """
-        addr = None
-        if "rpc_address" in row:
-            addr = row.get("rpc_address")  # peers and local
-        if "native_transport_address" in row:
-            addr = row.get("native_transport_address")
-        if not addr or addr in ["0.0.0.0", "::"]:
-            addr = row.get("peer")
-        return addr
+        Determine the peers query to use.
 
-    def _peers_query_for_version(self, connection, peers_query_template):
-        """
+        :param peers_query_type: Should be one of PeersQueryType enum.
+
+        If _uses_peers_v2 is True, return the proper peers_v2 query (no templating).
+        Else, apply the logic below to choose the peers v1 address column name:
+
         Given a connection:
 
         - find the server product version running on the connection's host,
         - use that to choose the column name for the transport address (see APOLLO-1130), and
         - use that column name in the provided peers query template.
-
-        The provided template should be a string with a format replacement
-        field named nt_col_name.
         """
-        host_release_version = self._cluster.metadata.get_host(connection.endpoint).release_version
-        host_dse_version = self._cluster.metadata.get_host(connection.endpoint).dse_version
-        uses_native_address_query = (
-            host_dse_version and Version(host_dse_version) >= self._MINIMUM_NATIVE_ADDRESS_DSE_VERSION)
+        if peers_query_type not in (self.PeersQueryType.PEERS, self.PeersQueryType.PEERS_SCHEMA):
+            raise ValueError("Invalid peers query type: %s" % peers_query_type)
 
-        if uses_native_address_query:
-            select_peers_query = peers_query_template.format(nt_col_name="native_transport_address")
-        elif host_release_version:
-                select_peers_query = peers_query_template.format(nt_col_name="rpc_address")
+        if self._uses_peers_v2:
+            if peers_query_type == self.PeersQueryType.PEERS:
+                query = self._SELECT_PEERS_V2 if self._token_meta_enabled else self._SELECT_PEERS_NO_TOKENS_V2
+            else:
+                query = self._SELECT_SCHEMA_PEERS_V2
         else:
-            select_peers_query = self._SELECT_PEERS
+            if peers_query_type == self.PeersQueryType.PEERS and self._token_meta_enabled:
+                query = self._SELECT_PEERS
+            else:
+                query_template = (self._SELECT_SCHEMA_PEERS_TEMPLATE
+                                  if peers_query_type == self.PeersQueryType.PEERS_SCHEMA
+                                  else self._SELECT_PEERS_NO_TOKENS_TEMPLATE)
 
-        return select_peers_query
+                host_release_version = self._cluster.metadata.get_host(connection.endpoint).release_version
+                host_dse_version = self._cluster.metadata.get_host(connection.endpoint).dse_version
+                uses_native_address_query = (
+                    host_dse_version and Version(host_dse_version) >= self._MINIMUM_NATIVE_ADDRESS_DSE_VERSION)
+
+                if uses_native_address_query:
+                    query = query_template.format(nt_col_name="native_transport_address")
+                elif host_release_version:
+                    query = query_template.format(nt_col_name="rpc_address")
+                else:
+                    query = self._SELECT_PEERS
+
+        return query
 
     def _signal_error(self):
         with self._lock:
@@ -4181,7 +4223,7 @@ class ResponseFuture(object):
 
     coordinator_host = None
     """
-    The host from which we recieved a response
+    The host from which we received a response
     """
 
     attempted_hosts = None

--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -55,21 +55,60 @@ class Host(object):
 
     broadcast_address = None
     """
-    broadcast address configured for the node, *if available* ('peer' in system.peers table).
-    This is not present in the ``system.local`` table for older versions of Cassandra. It is also not queried if
-    :attr:`~.Cluster.token_metadata_enabled` is ``False``.
+    broadcast address configured for the node, *if available*:
+
+    'system.local.broadcast_address' or 'system.peers.peer' (Cassandra 2-3)
+    'system.local.broadcast_address' or 'system.peers_v2.peer' (Cassandra 4)
+
+    This is not present in the ``system.local`` table for older versions of Cassandra. It
+    is also not queried if :attr:`~.Cluster.token_metadata_enabled` is ``False``.
+    """
+
+    broadcast_port = None
+    """
+    broadcast port configured for the node, *if available*:
+
+    'system.local.broadcast_port' or 'system.peers_v2.peer_port' (Cassandra 4)
+
+    It is also not queried if :attr:`~.Cluster.token_metadata_enabled` is ``False``.
     """
 
     broadcast_rpc_address = None
     """
-    The broadcast rpc address of the node (`native_address` or `rpc_address`).
+    The broadcast rpc address of the node:
+
+    'system.local.rpc_address' or 'system.peers.rpc_address' (Cassandra 3)
+    'system.local.rpc_address' or 'system.peers.native_transport_address (DSE  6+)'
+    'system.local.rpc_address' or 'system.peers_v2.native_address (Cassandra 4)'
+    """
+
+    broadcast_rpc_port = None
+    """
+    The broadcast rpc port of the node, *if available*:
+    
+    'system.local.rpc_port' or 'system.peers.native_transport_port' (DSE 6+)
+    'system.local.rpc_port' or 'system.peers_v2.native_port' (Cassandra 4)
     """
 
     listen_address = None
     """
-    listen address configured for the node, *if available*. This is only available in the ``system.local`` table for newer
-    versions of Cassandra. It is also not queried if :attr:`~.Cluster.token_metadata_enabled` is ``False``.
-    Usually the same as ``broadcast_address`` unless configured differently in cassandra.yaml.
+    listen address configured for the node, *if available*:
+
+    'system.local.listen_address'
+
+    This is only available in the ``system.local`` table for newer versions of Cassandra. It is also not
+    queried if :attr:`~.Cluster.token_metadata_enabled` is ``False``. Usually the same as ``broadcast_address``
+    unless configured differently in cassandra.yaml.
+    """
+
+    listen_port = None
+    """
+    listen port configured for the node, *if available*:
+
+    'system.local.listen_port'
+
+    This is only available in the ``system.local`` table for newer versions of Cassandra. It is also not
+    queried if :attr:`~.Cluster.token_metadata_enabled` is ``False``.
     """
 
     conviction_policy = None

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -189,17 +189,17 @@ def _addrinfo_to_ip_strings(addrinfo):
     extracts the IP address from the sockaddr portion of the result.
 
     Since this is meant to be used in conjunction with _addrinfo_or_none,
-    this will pass None and EndPont instances through unaffected.
+    this will pass None and EndPoint instances through unaffected.
     """
     if addrinfo is None:
         return None
-    return [entry[4][0] for entry in addrinfo]
+    return [(entry[4][0], entry[4][1]) for entry in addrinfo]
 
 
-def _resolve_contact_points_to_string_map(contact_points, port):
+def _resolve_contact_points_to_string_map(contact_points):
     return OrderedDict(
-        (cp, _addrinfo_to_ip_strings(_addrinfo_or_none(cp, port)))
-        for cp in contact_points
+        ('{cp}:{port}'.format(cp=cp, port=port), _addrinfo_to_ip_strings(_addrinfo_or_none(cp, port)))
+        for cp, port in contact_points
     )
 
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -200,6 +200,8 @@ else:
 
 
 ALLOW_BETA_PROTOCOL = False
+
+
 def get_default_protocol():
     if CASSANDRA_VERSION >= Version('4.0-a'):
         if DSE_VERSION:
@@ -340,6 +342,7 @@ requiresmallclockgranularity = unittest.skipIf("Windows" in platform.system() or
                                                "This test is not suitible for environments with large clock granularity")
 requiressimulacron = unittest.skipIf(SIMULACRON_JAR is None or CASSANDRA_VERSION < Version("2.1"), "Simulacron jar hasn't been specified or C* version is 2.0")
 requirecassandra = unittest.skipIf(DSE_VERSION, "Cassandra required")
+notdse = unittest.skipIf(DSE_VERSION, "DSE not supported")
 requiredse = unittest.skipUnless(DSE_VERSION, "DSE required")
 requirescloudproxy = unittest.skipIf(CLOUD_PROXY_PATH is None, "Cloud Proxy path hasn't been specified")
 
@@ -368,6 +371,9 @@ def check_socket_listening(itf, timeout=60):
     return False
 
 
+USE_SINGLE_INTERFACE = os.getenv('USE_SINGLE_INTERFACE', False)
+
+
 def get_cluster():
     return CCM_CLUSTER
 
@@ -380,8 +386,8 @@ def use_multidc(dc_list, workloads=[]):
     use_cluster(MULTIDC_CLUSTER_NAME, dc_list, start=True, workloads=workloads)
 
 
-def use_singledc(start=True, workloads=[]):
-    use_cluster(CLUSTER_NAME, [3], start=start, workloads=workloads)
+def use_singledc(start=True, workloads=[], use_single_interface=USE_SINGLE_INTERFACE):
+    use_cluster(CLUSTER_NAME, [3], start=start, workloads=workloads, use_single_interface=use_single_interface)
 
 
 def use_single_node(start=True, workloads=[], configuration_options={}, dse_options={}):
@@ -446,7 +452,7 @@ def start_cluster_wait_for_up(cluster):
 
 
 def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, set_keyspace=True, ccm_options=None,
-                configuration_options={}, dse_options={}):
+                configuration_options={}, dse_options={}, use_single_interface=USE_SINGLE_INTERFACE):
     dse_cluster = True if DSE_VERSION else False
     if not workloads:
         workloads = []
@@ -553,7 +559,7 @@ def use_cluster(cluster_name, nodes, ipformat=None, start=True, workloads=None, 
                             })
                 common.switch_cluster(path, cluster_name)
                 CCM_CLUSTER.set_configuration_options(configuration_options)
-                CCM_CLUSTER.populate(nodes, ipformat=ipformat)
+                CCM_CLUSTER.populate(nodes, ipformat=ipformat, use_single_interface=use_single_interface)
 
     try:
         jvm_args = []

--- a/tests/integration/advanced/test_auth.py
+++ b/tests/integration/advanced/test_auth.py
@@ -50,16 +50,17 @@ def teardown_module():
 
 def wait_role_manager_setup_then_execute(session, statements):
     for s in statements:
-        e = None
+        exc = None
         for attempt in range(3):
             try:
                 session.execute(s)
                 break
             except Exception as e:
+                exc = e
                 time.sleep(5)
         else:  # if we didn't reach `break`
-            if e is not None:
-                raise e
+            if exc is not None:
+                raise exc
 
 
 @attr('long')

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -42,7 +42,7 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
                                get_supported_protocol_versions, greaterthancass20,
                                greaterthancass21, assert_startswith, greaterthanorequalcass40,
                                greaterthanorequaldse67, lessthancass40,
-                               TestCluster)
+                               TestCluster, DSE_VERSION)
 
 
 log = logging.getLogger(__name__)
@@ -52,11 +52,12 @@ def setup_module():
     use_singledc()
 
 
-class HostMetatDataTests(BasicExistingKeyspaceUnitTestCase):
+class HostMetaDataTests(BasicExistingKeyspaceUnitTestCase):
     @local
-    def test_broadcast_listen_address(self):
+    def test_host_addresses(self):
         """
-        Check to ensure that the broadcast, rpc_address, listen adresss and host are is populated correctly
+        Check to ensure that the broadcast_address, broadcast_rpc_address,
+        listen adresss, ports and host are is populated correctly.
 
         @since 3.3
         @jira_ticket PYTHON-332
@@ -69,6 +70,11 @@ class HostMetatDataTests(BasicExistingKeyspaceUnitTestCase):
             self.assertIsNotNone(host.broadcast_address)
             self.assertIsNotNone(host.broadcast_rpc_address)
             self.assertIsNotNone(host.host_id)
+
+            if not DSE_VERSION and CASSANDRA_VERSION >= Version('4-a'):
+                self.assertIsNotNone(host.broadcast_port)
+                self.assertIsNotNone(host.broadcast_rpc_port)
+
         con = self.cluster.control_connection.get_connections()[0]
         local_host = con.host
 

--- a/tests/integration/standard/test_single_interface.py
+++ b/tests/integration/standard/test_single_interface.py
@@ -1,0 +1,77 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest  # noqa
+
+import six
+
+from cassandra import ConsistencyLevel
+from cassandra.query import SimpleStatement
+
+from packaging.version import Version
+from tests.integration import use_singledc, PROTOCOL_VERSION, \
+    remove_cluster, greaterthanorequalcass40, notdse, \
+    CASSANDRA_VERSION, DSE_VERSION, TestCluster
+
+
+def setup_module():
+    if not DSE_VERSION and CASSANDRA_VERSION >= Version('4-a'):
+        remove_cluster()
+        use_singledc(use_single_interface=True)
+
+def teardown_module():
+    remove_cluster()
+
+
+@notdse
+@greaterthanorequalcass40
+class SingleInterfaceTest(unittest.TestCase):
+
+    def setUp(self):
+        self.cluster = TestCluster()
+        self.session = self.cluster.connect()
+
+    def tearDown(self):
+        if self.cluster is not None:
+            self.cluster.shutdown()
+
+    def test_single_interface(self):
+        """
+        Test that we can connect to a multiple hosts bound to a single interface.
+        """
+        hosts = self.cluster.metadata._hosts
+        broadcast_rpc_ports = []
+        broadcast_ports = []
+        self.assertEqual(len(hosts), 3)
+        for endpoint, host in six.iteritems(hosts):
+
+            self.assertEqual(endpoint.address, host.broadcast_rpc_address)
+            self.assertEqual(endpoint.port, host.broadcast_rpc_port)
+
+            if host.broadcast_rpc_port in broadcast_rpc_ports:
+                self.fail("Duplicate broadcast_rpc_port")
+            broadcast_rpc_ports.append(host.broadcast_rpc_port)
+            if host.broadcast_port in broadcast_ports:
+                self.fail("Duplicate broadcast_port")
+            broadcast_ports.append(host.broadcast_port)
+
+        for _ in range(1, 100):
+            self.session.execute(SimpleStatement("select * from system_distributed.view_build_status",
+                                                 consistency_level=ConsistencyLevel.ALL))
+
+        for pool in self.session.get_pools():
+            self.assertEquals(1, pool.get_state()['open_count'])

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -90,6 +90,17 @@ class ExceptionTypeTest(unittest.TestCase):
 
 class ClusterTest(unittest.TestCase):
 
+    def test_tuple_for_contact_points(self):
+        cluster = Cluster(contact_points=[('localhost', 9045), ('127.0.0.2', 9046), '127.0.0.3'], port=9999)
+        for cp in cluster.endpoints_resolved:
+            if cp.address in ('::1', '127.0.0.1'):
+                self.assertEqual(cp.port, 9045)
+            elif cp.address == '127.0.0.2':
+                self.assertEqual(cp.port, 9046)
+            else:
+                self.assertEqual(cp.address, '127.0.0.3')
+                self.assertEqual(cp.port, 9999)
+
     def test_invalid_contact_point_types(self):
         with self.assertRaises(ValueError):
             Cluster(contact_points=[None], protocol_version=4, connect_timeout=1)


### PR DESCRIPTION
This PR adds these features:
* The ability to specify a contact point as tuple: ('127.0.0.1', 9042) (so specifying the port by CP without having to create an explicit DefaultEndPoint. The main reason for this is that the OSS ccm (and Apple) is already using this. It was easy to support it anyway.
* system.peers_v2 support. I Implemented it the same way than the java-driver... we try to use it when we connect and initialize the control connection... otherwise we fallback to peers v1.
* With peersv2, ports are discovered per-host.

Next major: I want to be able to run the entire test suite using a single interface. e.g when testing C* 4.0+  (ticket to create). Too many changes were required at the moment since we use strings everywhere for node ip etc. and that would have been another mess to merge back in the 4.x branch.

