### PR TITLE
Test 40

### DIFF
--- a/tests/integration/advanced/__init__.py
+++ b/tests/integration/advanced/__init__.py
@@ -25,10 +25,8 @@ from os.path import expanduser
 
 from ccmlib import common
 
-from cassandra.cluster import Cluster
-
-from tests.integration import PROTOCOL_VERSION, get_server_versions, BasicKeyspaceUnitTestCase, \
-    drop_keyspace_shutdown_cluster, get_node, USE_CASS_EXTERNAL, set_default_cass_ip
+from tests.integration import get_server_versions, BasicKeyspaceUnitTestCase, \
+    drop_keyspace_shutdown_cluster, get_node, USE_CASS_EXTERNAL, TestCluster
 from tests.integration import use_singledc, use_single_node, wait_for_node_socket, CASSANDRA_IP
 
 home = expanduser('~')
@@ -97,7 +95,6 @@ def use_cluster_with_graph(num_nodes):
     when started all at once.
     """
     if USE_CASS_EXTERNAL:
-        set_default_cass_ip()
         return
 
     # Create the cluster but don't start it.
@@ -109,7 +106,7 @@ def use_cluster_with_graph(num_nodes):
     # Wait for spark master to start up
     spark_master_http = ("localhost", 7080)
     common.check_socket_listening(spark_master_http, timeout=60)
-    tmp_cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+    tmp_cluster = TestCluster()
 
     # Start up remaining nodes.
     try:
@@ -137,7 +134,7 @@ class BasicGeometricUnitTestCase(BasicKeyspaceUnitTestCase):
 
     @classmethod
     def common_dse_setup(cls, rf, keyspace_creation=True):
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls.ks_name = cls.__name__.lower()
         if keyspace_creation:

--- a/tests/integration/advanced/graph/__init__.py
+++ b/tests/integration/advanced/graph/__init__.py
@@ -160,14 +160,13 @@ class BasicGraphUnitTestCase(BasicKeyspaceUnitTestCase):
             )
         )
 
-        self.cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                               execution_profiles={
-                                   EXEC_PROFILE_GRAPH_DEFAULT: ep_graphson1,
-                                   EXEC_PROFILE_GRAPH_ANALYTICS_DEFAULT: ep_analytics,
-                                   "graphson1": ep_graphson1,
-                                   "graphson2": ep_graphson2,
-                                   "graphson3": ep_graphson3
-                               })
+        self.cluster = TestCluster(execution_profiles={
+            EXEC_PROFILE_GRAPH_DEFAULT: ep_graphson1,
+            EXEC_PROFILE_GRAPH_ANALYTICS_DEFAULT: ep_analytics,
+            "graphson1": ep_graphson1,
+            "graphson2": ep_graphson2,
+            "graphson3": ep_graphson3
+        })
 
         self.session = self.cluster.connect()
         self.ks_name = self._testMethodName.lower()
@@ -276,14 +275,13 @@ class GraphUnitTestCase(BasicKeyspaceUnitTestCase):
             )
         )
 
-        self.cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                               execution_profiles={
-                                   EXEC_PROFILE_GRAPH_DEFAULT: ep_graphson1,
-                                   EXEC_PROFILE_GRAPH_ANALYTICS_DEFAULT: ep_analytics,
-                                   "graphson1": ep_graphson1,
-                                   "graphson2": ep_graphson2,
-                                   "graphson3": ep_graphson3
-                               })
+        self.cluster = TestCluster(execution_profiles={
+            EXEC_PROFILE_GRAPH_DEFAULT: ep_graphson1,
+            EXEC_PROFILE_GRAPH_ANALYTICS_DEFAULT: ep_analytics,
+            "graphson1": ep_graphson1,
+            "graphson2": ep_graphson2,
+            "graphson3": ep_graphson3
+        })
 
         self.session = self.cluster.connect()
         self.ks_name = self._testMethodName.lower()
@@ -362,7 +360,7 @@ class BasicSharedGraphUnitTestCase(BasicKeyspaceUnitTestCase):
 
     @classmethod
     def session_setup(cls):
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls.ks_name = cls.__name__.lower()
         cls.cass_version, cls.cql_version = get_server_versions()

--- a/tests/integration/advanced/graph/test_graph.py
+++ b/tests/integration/advanced/graph/test_graph.py
@@ -19,12 +19,13 @@ from cassandra import OperationTimedOut, InvalidRequest
 from cassandra.protocol import SyntaxException
 from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.cluster import NoHostAvailable
-from cassandra.cluster import EXEC_PROFILE_GRAPH_DEFAULT, GraphExecutionProfile, Cluster
+from cassandra.cluster import EXEC_PROFILE_GRAPH_DEFAULT, GraphExecutionProfile,
 from cassandra.graph import single_object_row_factory, Vertex, graph_object_row_factory, \
     graph_graphson2_row_factory, graph_graphson3_row_factory
 from cassandra.util import SortedSet
 
-from tests.integration import PROTOCOL_VERSION, DSE_VERSION, greaterthanorequaldse51, greaterthanorequaldse68, requiredse
+from tests.integration import DSE_VERSION, greaterthanorequaldse51, greaterthanorequaldse68, \
+    requiredse, TestCluster
 from tests.integration.advanced.graph import BasicGraphUnitTestCase, GraphUnitTestCase, \
     GraphProtocol, ClassicGraphSchema, CoreGraphSchema, use_single_node_with_graph
 
@@ -149,8 +150,7 @@ class GraphProfileTests(BasicGraphUnitTestCase):
         exec_short_timeout.graph_options.graph_name = self.graph_name
 
         # Add a single execution policy on cluster creation
-        local_cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                                execution_profiles={"exec_dif_factory": exec_dif_factory})
+        local_cluster = TestCluster(execution_profiles={"exec_dif_factory": exec_dif_factory})
         local_session = local_cluster.connect()
         self.addCleanup(local_cluster.shutdown)
 

--- a/tests/integration/advanced/test_adv_metadata.py
+++ b/tests/integration/advanced/test_adv_metadata.py
@@ -14,12 +14,11 @@
 
 from packaging.version import Version
 
-from cassandra.cluster import Cluster
 from tests.integration import (BasicExistingKeyspaceUnitTestCase, BasicSharedKeyspaceUnitTestCase,
                                BasicSharedKeyspaceUnitTestCaseRF1,
                                greaterthanorequaldse51, greaterthanorequaldse60,
                                greaterthanorequaldse68, use_single_node,
-                               DSE_VERSION, requiredse, PROTOCOL_VERSION)
+                               DSE_VERSION, requiredse, TestCluster)
 
 try:
     import unittest2 as unittest
@@ -393,4 +392,4 @@ class GraphMetadataSchemaErrorTests(BasicExistingKeyspaceUnitTestCase):
         """ % (self.ks_name,))
 
         self.session.execute('TRUNCATE system_schema.vertices')
-        Cluster(protocol_version=PROTOCOL_VERSION).connect().shutdown()
+        TestCluster().connect().shutdown()

--- a/tests/integration/advanced/test_auth.py
+++ b/tests/integration/advanced/test_auth.py
@@ -26,11 +26,11 @@ from packaging.version import Version
 
 from cassandra.auth import (DSEGSSAPIAuthProvider, DSEPlainTextAuthProvider,
                       SaslAuthProvider, TransitionalModePlainTextAuthProvider)
-from cassandra.cluster import EXEC_PROFILE_GRAPH_DEFAULT, Cluster, NoHostAvailable
+from cassandra.cluster import EXEC_PROFILE_GRAPH_DEFAULT, NoHostAvailable
 from cassandra.protocol import Unauthorized
 from cassandra.query import SimpleStatement
 from tests.integration import (get_cluster, greaterthanorequaldse51,
-                               remove_cluster, requiredse, DSE_VERSION)
+                               remove_cluster, requiredse, DSE_VERSION, TestCluster)
 from tests.integration.advanced import ADS_HOME, use_single_node_with_graph
 from tests.integration.advanced.graph import reset_graph, ClassicGraphFixtures
 
@@ -157,7 +157,7 @@ class BasicDseAuthTest(unittest.TestCase):
         Runs a simple system query with the auth_provided specified.
         """
         os.environ['KRB5_CONFIG'] = self.krb_conf
-        self.cluster = Cluster(auth_provider=auth_provider)
+        self.cluster = TestCluster(auth_provider=auth_provider)
         self.session = self.cluster.connect()
         query = query if query else "SELECT * FROM system.local"
         statement = SimpleStatement(query)
@@ -320,7 +320,7 @@ class BasicDseAuthTest(unittest.TestCase):
         os.environ['KRB5_CONFIG'] = self.krb_conf
         self.refresh_kerberos_tickets(self.cassandra_keytab, "cassandra@DATASTAX.COM", self.krb_conf)
         auth_provider = DSEGSSAPIAuthProvider(service='dse', qops=["auth"], principal='cassandra@DATASTAX.COM')
-        cluster = Cluster(auth_provider=auth_provider)
+        cluster = TestCluster(auth_provider=auth_provider)
         session = cluster.connect()
 
         session.execute("REVOKE PROXY.LOGIN ON ROLE '{0}' FROM '{1}'".format('charlie@DATASTAX.COM', 'bob@DATASTAX.COM'))
@@ -338,7 +338,7 @@ class BasicDseAuthTest(unittest.TestCase):
         os.environ['KRB5_CONFIG'] = self.krb_conf
         self.refresh_kerberos_tickets(self.cassandra_keytab, "cassandra@DATASTAX.COM", self.krb_conf)
         auth_provider = DSEGSSAPIAuthProvider(service='dse', qops=["auth"], principal='cassandra@DATASTAX.COM')
-        cluster = Cluster(auth_provider=auth_provider)
+        cluster = TestCluster(auth_provider=auth_provider)
         session = cluster.connect()
 
         stmts = [
@@ -403,7 +403,7 @@ class BaseDseProxyAuthTest(unittest.TestCase):
         # Create users and test keyspace
         self.user_role = 'user1'
         self.server_role = 'server'
-        self.root_cluster = Cluster(auth_provider=DSEPlainTextAuthProvider('cassandra', 'cassandra'))
+        self.root_cluster = TestCluster(auth_provider=DSEPlainTextAuthProvider('cassandra', 'cassandra'))
         self.root_session = self.root_cluster.connect()
 
         stmts = [
@@ -469,7 +469,7 @@ class DseProxyAuthTest(BaseDseProxyAuthTest):
         return sasl_options
 
     def connect_and_query(self, auth_provider, execute_as=None, query="SELECT * FROM testproxy.testproxy"):
-        self.cluster = Cluster(auth_provider=auth_provider)
+        self.cluster = TestCluster(auth_provider=auth_provider)
         self.session = self.cluster.connect()
         rs = self.session.execute(query, execute_as=execute_as)
         return rs

--- a/tests/integration/advanced/test_cont_paging.py
+++ b/tests/integration/advanced/test_cont_paging.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from tests.integration import use_singledc, greaterthanorequaldse51, BasicSharedKeyspaceUnitTestCaseRF3WM, \
-    DSE_VERSION, ProtocolVersion, greaterthanorequaldse60, requiredse
+    DSE_VERSION, ProtocolVersion, greaterthanorequaldse60, requiredse, TestCluster
 
 import logging
 log = logging.getLogger(__name__)
@@ -28,7 +28,7 @@ from six.moves import range
 from packaging.version import Version
 import time
 
-from cassandra.cluster import Cluster, ExecutionProfile, ContinuousPagingOptions
+from cassandra.cluster import ExecutionProfile, ContinuousPagingOptions
 from cassandra.concurrent import execute_concurrent
 from cassandra.query import SimpleStatement
 
@@ -64,7 +64,7 @@ class BaseContPagingTests():
     @classmethod
     def create_cluster(cls):
 
-        cls.cluster_with_profiles = Cluster(protocol_version=cls.protocol_version, execution_profiles=cls.execution_profiles)
+        cls.cluster_with_profiles = TestCluster(protocol_version=cls.protocol_version, execution_profiles=cls.execution_profiles)
 
         cls.session_with_profiles = cls.cluster_with_profiles.connect(wait_for_all_pools=True)
         statements_and_params = zip(

--- a/tests/integration/advanced/test_cqlengine_where_operators.py
+++ b/tests/integration/advanced/test_cqlengine_where_operators.py
@@ -20,13 +20,12 @@ except ImportError:
 import os
 import time
 
-from cassandra.cluster import Cluster
 from cassandra.cqlengine import columns, connection, models
 from cassandra.cqlengine.management import (CQLENG_ALLOW_SCHEMA_MANAGEMENT,
                                       create_keyspace_simple, drop_table,
                                       sync_table)
 from cassandra.cqlengine.statements import IsNotNull
-from tests.integration import DSE_VERSION, requiredse, CASSANDRA_IP, greaterthanorequaldse60
+from tests.integration import DSE_VERSION, requiredse, CASSANDRA_IP, greaterthanorequaldse60, TestCluster
 from tests.integration.advanced import use_single_node_with_graph_and_solr
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
 
@@ -65,7 +64,7 @@ class IsNotNullTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if DSE_VERSION:
-            cls.cluster = Cluster()
+            cls.cluster = TestCluster()
 
     @greaterthanorequaldse60
     def test_is_not_null_execution(self):
@@ -81,7 +80,7 @@ class IsNotNullTests(unittest.TestCase):
 
         @test_category cqlengine
         """
-        cluster = Cluster()
+        cluster = TestCluster()
         self.addCleanup(cluster.shutdown)
         session = cluster.connect()
 

--- a/tests/integration/advanced/test_unixsocketendpoint.py
+++ b/tests/integration/advanced/test_unixsocketendpoint.py
@@ -20,12 +20,12 @@ import time
 import subprocess
 import logging
 
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.connection import UnixSocketEndPoint
 from cassandra.policies import WhiteListRoundRobinPolicy, RoundRobinPolicy
 
 from tests import notwindows
-from tests.integration import use_single_node
+from tests.integration import use_single_node, TestCluster
 
 log = logging.getLogger()
 log.setLevel('DEBUG')
@@ -65,7 +65,7 @@ class UnixSocketTest(unittest.TestCase):
         lbp = UnixSocketWhiteListRoundRobinPolicy([UNIX_SOCKET_PATH])
         ep = ExecutionProfile(load_balancing_policy=lbp)
         endpoint = UnixSocketEndPoint(UNIX_SOCKET_PATH)
-        cls.cluster = Cluster([endpoint], execution_profiles={EXEC_PROFILE_DEFAULT: ep})
+        cls.cluster = TestCluster([endpoint], execution_profiles={EXEC_PROFILE_DEFAULT: ep})
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/integration/cloud/__init__.py
+++ b/tests/integration/cloud/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
+from cassandra.cluster import Cluster
 
 try:
     import unittest2 as unittest
@@ -19,8 +20,6 @@ except ImportError:
 
 import os
 import subprocess
-
-from cassandra.cluster import Cluster
 
 from tests.integration import CLOUD_PROXY_PATH, USE_CASS_EXTERNAL
 

--- a/tests/integration/cloud/test_cloud.py
+++ b/tests/integration/cloud/test_cloud.py
@@ -30,7 +30,7 @@ from cassandra.policies import TokenAwarePolicy, DCAwareRoundRobinPolicy, Consta
 
 from mock import patch
 
-from tests.integration import requirescloudproxy
+from tests.integration import requirescloudproxy, TestCluster
 from tests.util import wait_until_not_raised
 from tests.integration.cloud import CloudProxyCluster, CLOUD_PROXY_SERVER
 

--- a/tests/integration/cqlengine/__init__.py
+++ b/tests/integration/cqlengine/__init__.py
@@ -24,7 +24,8 @@ from cassandra.cqlengine import connection
 from cassandra.cqlengine.management import create_keyspace_simple, drop_keyspace, CQLENG_ALLOW_SCHEMA_MANAGEMENT
 import cassandra
 
-from tests.integration import get_server_versions, use_single_node, PROTOCOL_VERSION, CASSANDRA_IP, set_default_cass_ip
+from tests.integration import get_server_versions, use_single_node, PROTOCOL_VERSION, CASSANDRA_IP, ALLOW_BETA_PROTOCOL
+
 DEFAULT_KEYSPACE = 'cqlengine_test'
 
 
@@ -35,7 +36,6 @@ def setup_package():
     warnings.simplefilter('always')  # for testing warnings, make sure all are let through
     os.environ[CQLENG_ALLOW_SCHEMA_MANAGEMENT] = '1'
 
-    set_default_cass_ip()
     use_single_node()
 
     setup_connection(DEFAULT_KEYSPACE)
@@ -55,6 +55,7 @@ def setup_connection(keyspace_name):
     connection.setup([CASSANDRA_IP],
                      consistency=ConsistencyLevel.ONE,
                      protocol_version=PROTOCOL_VERSION,
+                     allow_beta_protocol_version=ALLOW_BETA_PROTOCOL,
                      default_keyspace=keyspace_name)
 
 

--- a/tests/integration/cqlengine/advanced/test_cont_paging.py
+++ b/tests/integration/cqlengine/advanced/test_cont_paging.py
@@ -21,13 +21,13 @@ except ImportError:
 
 from packaging.version import Version
 
-from cassandra.cluster import (EXEC_PROFILE_DEFAULT, Cluster,
+from cassandra.cluster import (EXEC_PROFILE_DEFAULT,
                          ContinuousPagingOptions, ExecutionProfile,
                          ProtocolVersion)
 from cassandra.cqlengine import columns, connection, models
 from cassandra.cqlengine.management import drop_table, sync_table
 from tests.integration import (DSE_VERSION, greaterthanorequaldse51,
-                               greaterthanorequaldse60, requiredse)
+                               greaterthanorequaldse60, requiredse, TestCluster)
 
 
 class TestMultiKeyModel(models.Model):
@@ -76,8 +76,8 @@ class BasicConcurrentTests():
     def _create_cluster_with_cp_options(cls, name, cp_options):
         execution_profiles = {EXEC_PROFILE_DEFAULT:
                                   ExecutionProfile(continuous_paging_options=cp_options)}
-        cls.cluster_default = Cluster(protocol_version=cls.protocol_version,
-                                      execution_profiles=execution_profiles)
+        cls.cluster_default = TestCluster(protocol_version=cls.protocol_version,
+                                          execution_profiles=execution_profiles)
         cls.session_default = cls.cluster_default.connect(wait_for_all_pools=True)
         connection.register_connection(name, default=True, session=cls.session_default)
         cls.connections.add(name)

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -22,11 +22,11 @@ from cassandra import ConsistencyLevel
 from cassandra.cqlengine.models import Model
 from cassandra.cqlengine import columns, connection, models
 from cassandra.cqlengine.management import sync_table
-from cassandra.cluster import Cluster, ExecutionProfile, _clusters_for_shutdown, _ConfigMode, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, _clusters_for_shutdown, _ConfigMode, EXEC_PROFILE_DEFAULT
 from cassandra.policies import RoundRobinPolicy
 from cassandra.query import dict_factory
 
-from tests.integration import CASSANDRA_IP, PROTOCOL_VERSION, execute_with_long_wait_retry, local
+from tests.integration import CASSANDRA_IP, PROTOCOL_VERSION, execute_with_long_wait_retry, local, TestCluster
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine import DEFAULT_KEYSPACE, setup_connection
 
@@ -76,7 +76,7 @@ class SeveralConnectionsTest(BaseCassEngTestCase):
         cls.keyspace1 = 'ctest1'
         cls.keyspace2 = 'ctest2'
         super(SeveralConnectionsTest, cls).setUpClass()
-        cls.setup_cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.setup_cluster = TestCluster()
         cls.setup_session = cls.setup_cluster.connect()
         ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}}".format(cls.keyspace1, 1)
         execute_with_long_wait_retry(cls.setup_session, ddl)
@@ -93,7 +93,7 @@ class SeveralConnectionsTest(BaseCassEngTestCase):
         models.DEFAULT_KEYSPACE
 
     def setUp(self):
-        self.c = Cluster(protocol_version=PROTOCOL_VERSION)
+        self.c = TestCluster()
         self.session1 = self.c.connect(keyspace=self.keyspace1)
         self.session1.row_factory = dict_factory
         self.session2 = self.c.connect(keyspace=self.keyspace2)
@@ -149,7 +149,7 @@ class ConnectionInitTest(unittest.TestCase):
         self.assertEqual(conn.cluster._config_mode, _ConfigMode.LEGACY)
 
     def test_connection_from_session_with_execution_profile(self):
-        cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
+        cluster = TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
         session = cluster.connect()
         connection.default()
         connection.set_session(session)
@@ -157,7 +157,7 @@ class ConnectionInitTest(unittest.TestCase):
         self.assertEqual(conn.cluster._config_mode, _ConfigMode.PROFILES)
 
     def test_connection_from_session_with_legacy_settings(self):
-        cluster = Cluster(load_balancing_policy=RoundRobinPolicy())
+        cluster = TestCluster(load_balancing_policy=RoundRobinPolicy())
         session = cluster.connect()
         session.row_factory = dict_factory
         connection.set_session(session)
@@ -165,7 +165,7 @@ class ConnectionInitTest(unittest.TestCase):
         self.assertEqual(conn.cluster._config_mode, _ConfigMode.LEGACY)
 
     def test_uncommitted_session_uses_legacy(self):
-        cluster = Cluster()
+        cluster = TestCluster()
         session = cluster.connect()
         session.row_factory = dict_factory
         connection.set_session(session)
@@ -186,7 +186,7 @@ class ConnectionInitTest(unittest.TestCase):
         self.assertEqual(ConnectionModel.objects(key=0)[0].some_data, 'text0')
 
     def test_execution_profile_insert_query(self):
-        cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
+        cluster = TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
         session = cluster.connect()
         connection.default()
         connection.set_session(session)

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -23,7 +23,7 @@ from uuid import uuid4
 from packaging.version import Version
 import uuid
 
-from cassandra.cluster import Cluster, Session
+from cassandra.cluster import Session
 from cassandra import InvalidRequest
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from cassandra.cqlengine.connection import NOT_SET
@@ -42,7 +42,7 @@ from cassandra.cqlengine import operators
 from cassandra.util import uuid_from_time
 from cassandra.cqlengine.connection import get_session
 from tests.integration import PROTOCOL_VERSION, CASSANDRA_VERSION, greaterthancass20, greaterthancass21, \
-    greaterthanorequalcass30
+    greaterthanorequalcass30, TestCluster
 from tests.integration.cqlengine import execute_count, DEFAULT_KEYSPACE
 
 
@@ -775,7 +775,7 @@ class TestQuerySetValidation(BaseQuerySetUsage):
         with self.assertRaises(InvalidRequest):
             list(CustomIndexedTestModel.objects.filter(description__gte='test'))
 
-        with Cluster().connect() as session:
+        with TestCluster().connect() as session:
             session.execute("CREATE INDEX custom_index_cqlengine ON {}.{} (description)".
                             format(DEFAULT_KEYSPACE, CustomIndexedTestModel._table_name))
 

--- a/tests/integration/cqlengine/statements/test_base_statement.py
+++ b/tests/integration/cqlengine/statements/test_base_statement.py
@@ -20,7 +20,6 @@ from uuid import uuid4
 import six
 
 from cassandra.query import FETCH_SIZE_UNSET
-from cassandra.cluster import Cluster, ConsistencyLevel
 from cassandra.cqlengine.statements import BaseCQLStatement
 from cassandra.cqlengine.management import sync_table, drop_table
 from cassandra.cqlengine.statements import InsertStatement, UpdateStatement, SelectStatement, DeleteStatement, \
@@ -30,7 +29,7 @@ from cassandra.cqlengine.columns import Column
 
 from tests.integration.cqlengine.base import BaseCassEngTestCase, TestQueryUpdateModel
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
-from tests.integration import greaterthanorequalcass3_10
+from tests.integration import greaterthanorequalcass3_10, TestCluster
 
 from cassandra.cqlengine.connection import execute
 
@@ -116,7 +115,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
 
         @test_category data_types:object_mapper
         """
-        cluster = Cluster()
+        cluster = TestCluster()
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
 

--- a/tests/integration/cqlengine/test_connections.py
+++ b/tests/integration/cqlengine/test_connections.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from cassandra import InvalidRequest
-from cassandra.cluster import Cluster
 from cassandra.cluster import NoHostAvailable
 from cassandra.cqlengine import columns, CQLEngineException
 from cassandra.cqlengine import connection as conn
@@ -23,7 +22,7 @@ from cassandra.cqlengine.query import ContextQuery, BatchQuery, ModelQuerySet
 from tests.integration.cqlengine import setup_connection, DEFAULT_KEYSPACE
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query import test_queryset
-from tests.integration import local, CASSANDRA_IP
+from tests.integration import local, CASSANDRA_IP, TestCluster
 
 
 class TestModel(Model):
@@ -227,7 +226,7 @@ class ManagementConnectionTests(BaseCassEngTestCase):
 
         @test_category object_mapper
         """
-        cluster = Cluster([CASSANDRA_IP])
+        cluster = TestCluster()
         session = cluster.connect()
         connection_name = 'from_session'
         conn.register_connection(connection_name, session=session)
@@ -258,7 +257,7 @@ class ManagementConnectionTests(BaseCassEngTestCase):
 
         @test_category object_mapper
         """
-        cluster = Cluster([CASSANDRA_IP])
+        cluster = TestCluster()
         session = cluster.connect()
         with self.assertRaises(CQLEngineException):
             conn.register_connection("bad_coonection1", session=session, consistency="not_null")

--- a/tests/integration/long/test_consistency.py
+++ b/tests/integration/long/test_consistency.py
@@ -19,10 +19,10 @@ import time
 import traceback
 
 from cassandra import ConsistencyLevel, OperationTimedOut, ReadTimeout, WriteTimeout, Unavailable
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.policies import TokenAwarePolicy, RoundRobinPolicy, DowngradingConsistencyRetryPolicy
 from cassandra.query import SimpleStatement
-from tests.integration import use_singledc, PROTOCOL_VERSION, execute_until_pass
+from tests.integration import use_singledc, execute_until_pass, TestCluster
 
 from tests.integration.long.utils import (
     force_stop, create_schema, wait_for_down, wait_for_up, start, CoordinatorStats
@@ -129,8 +129,9 @@ class ConsistencyTests(unittest.TestCase):
                 pass
 
     def _test_tokenaware_one_node_down(self, keyspace, rf, accepted):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(TokenAwarePolicy(RoundRobinPolicy()))})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(TokenAwarePolicy(RoundRobinPolicy()))}
+        )
         session = cluster.connect(wait_for_all_pools=True)
         wait_for_up(cluster, 1)
         wait_for_up(cluster, 2)
@@ -180,8 +181,9 @@ class ConsistencyTests(unittest.TestCase):
 
     def test_rfthree_tokenaware_none_down(self):
         keyspace = 'test_rfthree_tokenaware_none_down'
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(TokenAwarePolicy(RoundRobinPolicy()))})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(TokenAwarePolicy(RoundRobinPolicy()))}
+        )
         session = cluster.connect(wait_for_all_pools=True)
         wait_for_up(cluster, 1)
         wait_for_up(cluster, 2)
@@ -203,9 +205,10 @@ class ConsistencyTests(unittest.TestCase):
         cluster.shutdown()
 
     def _test_downgrading_cl(self, keyspace, rf, accepted):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(TokenAwarePolicy(RoundRobinPolicy()),
-                                                                                     DowngradingConsistencyRetryPolicy())})
+        cluster = TestCluster(execution_profiles={
+            EXEC_PROFILE_DEFAULT: ExecutionProfile(TokenAwarePolicy(RoundRobinPolicy()),
+                                                   DowngradingConsistencyRetryPolicy())
+        })
         session = cluster.connect(wait_for_all_pools=True)
 
         create_schema(cluster, session, keyspace, replication_factor=rf)
@@ -246,16 +249,18 @@ class ConsistencyTests(unittest.TestCase):
 
     def test_rfthree_roundrobin_downgradingcl(self):
         keyspace = 'test_rfthree_roundrobin_downgradingcl'
-        with Cluster(protocol_version=PROTOCOL_VERSION,
-                     execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(RoundRobinPolicy(),
-                                                                                DowngradingConsistencyRetryPolicy())}) as cluster:
+        with TestCluster(execution_profiles={
+            EXEC_PROFILE_DEFAULT: ExecutionProfile(RoundRobinPolicy(),
+                                                   DowngradingConsistencyRetryPolicy())
+        }) as cluster:
             self.rfthree_downgradingcl(cluster, keyspace, True)
 
     def test_rfthree_tokenaware_downgradingcl(self):
         keyspace = 'test_rfthree_tokenaware_downgradingcl'
-        with Cluster(protocol_version=PROTOCOL_VERSION,
-                     execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(TokenAwarePolicy(RoundRobinPolicy()),
-                                                                                DowngradingConsistencyRetryPolicy())}) as cluster:
+        with TestCluster(execution_profiles={
+            EXEC_PROFILE_DEFAULT: ExecutionProfile(TokenAwarePolicy(RoundRobinPolicy()),
+                                                   DowngradingConsistencyRetryPolicy())
+        }) as cluster:
             self.rfthree_downgradingcl(cluster, keyspace, False)
 
     def rfthree_downgradingcl(self, cluster, keyspace, roundrobin):
@@ -334,7 +339,7 @@ class ConnectivityTest(unittest.TestCase):
         all_contact_points = ["127.0.0.1", "127.0.0.2", "127.0.0.3"]
 
         # Connect up and find out which host will bet queries routed to to first
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         cluster.connect(wait_for_all_pools=True)
         hosts = cluster.metadata.all_hosts()
         address = hosts[0].address
@@ -344,13 +349,13 @@ class ConnectivityTest(unittest.TestCase):
         # We now register a cluster that has it's Control Connection NOT on the node that we are shutting down.
         # We do this so we don't miss the event
         contact_point = '127.0.0.{0}'.format(self.get_node_not_x(node_to_stop))
-        cluster = Cluster(contact_points=[contact_point], protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster(contact_points=[contact_point])
         cluster.connect(wait_for_all_pools=True)
         try:
             force_stop(node_to_stop)
             wait_for_down(cluster, node_to_stop)
             # Attempt a query against that node. It should complete
-            cluster2 = Cluster(contact_points=all_contact_points, protocol_version=PROTOCOL_VERSION)
+            cluster2 = TestCluster(contact_points=all_contact_points)
             session2 = cluster2.connect()
             session2.execute("SELECT * FROM system.local")
         finally:

--- a/tests/integration/long/test_failure_types.py
+++ b/tests/integration/long/test_failure_types.py
@@ -25,13 +25,13 @@ from cassandra import (
     ConsistencyLevel, OperationTimedOut, ReadTimeout, WriteTimeout, ReadFailure, WriteFailure,
     FunctionFailure, ProtocolVersion,
 )
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.query import SimpleStatement
 from tests.integration import (
     use_singledc, PROTOCOL_VERSION, get_cluster, setup_keyspace, remove_cluster,
     get_node, start_cluster_wait_for_up, requiresmallclockgranularity,
-    local, CASSANDRA_VERSION)
+    local, CASSANDRA_VERSION, TestCluster)
 
 
 try:
@@ -83,7 +83,7 @@ class ClientExceptionTests(unittest.TestCase):
             raise unittest.SkipTest(
                 "Native protocol 4,0+ is required for custom payloads, currently using %r"
                 % (PROTOCOL_VERSION,))
-        self.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        self.cluster = TestCluster()
         self.session = self.cluster.connect()
         self.nodes_currently_failing = []
         self.node1, self.node2, self.node3 = get_cluster().nodes.values()
@@ -332,8 +332,7 @@ class TimeoutTimerTest(unittest.TestCase):
         """
         Setup sessions and pause node1
         """
-        self.cluster = Cluster(
-            protocol_version=PROTOCOL_VERSION,
+        self.cluster = TestCluster(
             execution_profiles={
                 EXEC_PROFILE_DEFAULT: ExecutionProfile(
                     load_balancing_policy=HostFilterPolicy(

--- a/tests/integration/long/test_ipv6.py
+++ b/tests/integration/long/test_ipv6.py
@@ -15,11 +15,11 @@
 import os, socket, errno
 from ccmlib import common
 
-from cassandra.cluster import Cluster, NoHostAvailable
+from cassandra.cluster import NoHostAvailable
 from cassandra.io.asyncorereactor import AsyncoreConnection
 
 from tests import is_monkey_patched
-from tests.integration import use_cluster, remove_cluster, PROTOCOL_VERSION
+from tests.integration import use_cluster, remove_cluster, TestCluster
 
 if is_monkey_patched():
     LibevConnection = -1
@@ -75,8 +75,7 @@ class IPV6ConnectionTest(object):
     connection_class = None
 
     def test_connect(self):
-        cluster = Cluster(connection_class=self.connection_class, contact_points=['::1'], connect_timeout=10,
-                          protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster(connection_class=self.connection_class, contact_points=['::1'], connect_timeout=10)
         session = cluster.connect()
         future = session.execute_async("SELECT * FROM system.local")
         future.result()
@@ -84,16 +83,16 @@ class IPV6ConnectionTest(object):
         cluster.shutdown()
 
     def test_error(self):
-        cluster = Cluster(connection_class=self.connection_class, contact_points=['::1'], port=9043,
-                          connect_timeout=10, protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster(connection_class=self.connection_class, contact_points=['::1'], port=9043,
+                              connect_timeout=10)
         self.assertRaisesRegexp(NoHostAvailable, '\(\'Unable to connect.*%s.*::1\', 9043.*Connection refused.*'
                                 % errno.ECONNREFUSED, cluster.connect)
 
     def test_error_multiple(self):
         if len(socket.getaddrinfo('localhost', 9043, socket.AF_UNSPEC, socket.SOCK_STREAM)) < 2:
             raise unittest.SkipTest('localhost only resolves one address')
-        cluster = Cluster(connection_class=self.connection_class, contact_points=['localhost'], port=9043,
-                          connect_timeout=10, protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster(connection_class=self.connection_class, contact_points=['localhost'], port=9043,
+                              connect_timeout=10)
         self.assertRaisesRegexp(NoHostAvailable, '\(\'Unable to connect.*Tried connecting to \[\(.*\(.*\].*Last error',
                                 cluster.connect)
 

--- a/tests/integration/long/test_large_data.py
+++ b/tests/integration/long/test_large_data.py
@@ -21,10 +21,10 @@ from struct import pack
 import logging, sys, traceback, time
 
 from cassandra import ConsistencyLevel, OperationTimedOut, WriteTimeout
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.query import dict_factory
 from cassandra.query import SimpleStatement
-from tests.integration import use_singledc, PROTOCOL_VERSION
+from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
 from tests.integration.long.utils import create_schema
 
 try:
@@ -61,9 +61,9 @@ class LargeDataTests(unittest.TestCase):
         self.keyspace = 'large_data'
 
     def make_session_and_keyspace(self):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(request_timeout=20,
-                                                                                     row_factory=dict_factory)})
+        cluster = TestCluster(execution_profiles={
+            EXEC_PROFILE_DEFAULT: ExecutionProfile(request_timeout=20, row_factory=dict_factory)
+        })
         session = cluster.connect()
         create_schema(cluster, session, self.keyspace)
         return session

--- a/tests/integration/long/test_policies.py
+++ b/tests/integration/long/test_policies.py
@@ -18,9 +18,9 @@ except ImportError:
     import unittest  # noqa
 
 from cassandra import ConsistencyLevel, Unavailable
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 
-from tests.integration import use_cluster, get_cluster, get_node
+from tests.integration import use_cluster, get_cluster, get_node, TestCluster
 
 
 def setup_module():
@@ -47,7 +47,7 @@ class RetryPolicyTests(unittest.TestCase):
         ep = ExecutionProfile(consistency_level=ConsistencyLevel.ALL,
                               serial_consistency_level=ConsistencyLevel.SERIAL)
 
-        cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: ep})
+        cluster = TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ep})
         session = cluster.connect()
 
         session.execute("CREATE KEYSPACE test_retry_policy_cas WITH replication = {'class':'SimpleStrategy','replication_factor': 3};")

--- a/tests/integration/long/test_schema.py
+++ b/tests/integration/long/test_schema.py
@@ -15,10 +15,9 @@
 import logging
 
 from cassandra import ConsistencyLevel, AlreadyExists
-from cassandra.cluster import Cluster
 from cassandra.query import SimpleStatement
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, execute_until_pass
+from tests.integration import use_singledc, execute_until_pass, TestCluster
 
 import time
 
@@ -38,7 +37,7 @@ class SchemaTests(unittest.TestCase):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.cluster = TestCluster()
         cls.session = cls.cluster.connect(wait_for_all_pools=True)
 
     @classmethod
@@ -99,7 +98,7 @@ class SchemaTests(unittest.TestCase):
         Tests for any schema disagreements using the same keyspace multiple times
         """
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect(wait_for_all_pools=True)
 
         for i in range(30):
@@ -133,7 +132,7 @@ class SchemaTests(unittest.TestCase):
         @test_category schema
         """
         # This should yield a schema disagreement
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, max_schema_agreement_wait=0.001)
+        cluster = TestCluster(max_schema_agreement_wait=0.001)
         session = cluster.connect(wait_for_all_pools=True)
 
         rs = session.execute("CREATE KEYSPACE test_schema_disagreement WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")
@@ -146,7 +145,7 @@ class SchemaTests(unittest.TestCase):
         cluster.shutdown()
         
         # These should have schema agreement
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, max_schema_agreement_wait=100)
+        cluster = TestCluster(max_schema_agreement_wait=100)
         session = cluster.connect()
         rs = session.execute("CREATE KEYSPACE test_schema_disagreement WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")
         self.check_and_wait_for_agreement(session, rs, True)

--- a/tests/integration/long/test_topology_change.py
+++ b/tests/integration/long/test_topology_change.py
@@ -1,8 +1,7 @@
 from unittest import TestCase
 
-from cassandra.cluster import Cluster
 from cassandra.policies import HostStateListener
-from tests.integration import PROTOCOL_VERSION, get_node, use_cluster, local
+from tests.integration import get_node, use_cluster, local, TestCluster
 from tests.integration.long.utils import decommission
 from tests.util import wait_until
 
@@ -32,7 +31,7 @@ class TopologyChangeTests(TestCase):
         use_cluster("test_down_then_removed", [3], start=True)
 
         state_listener = StateListener()
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         self.addCleanup(cluster.shutdown)
         cluster.register_listener(state_listener)
         session = cluster.connect(wait_for_all_pools=True)

--- a/tests/integration/long/utils.py
+++ b/tests/integration/long/utils.py
@@ -93,7 +93,7 @@ def force_stop(node):
 
 
 def decommission(node):
-    if (DSE_VERSION and DSE_VERSION >= Version("5.1")) or CASSANDRA_VERSION >= Version("4.0"):
+    if (DSE_VERSION and DSE_VERSION >= Version("5.1")) or CASSANDRA_VERSION >= Version("4.0-a"):
         # CASSANDRA-12510
         get_node(node).decommission(force=True)
     else:

--- a/tests/integration/standard/test_authentication_misconfiguration.py
+++ b/tests/integration/standard/test_authentication_misconfiguration.py
@@ -14,8 +14,7 @@
 
 import unittest
 
-from cassandra.cluster import Cluster
-from tests.integration import CASSANDRA_IP, USE_CASS_EXTERNAL, use_cluster, PROTOCOL_VERSION
+from tests.integration import USE_CASS_EXTERNAL, use_cluster, TestCluster
 
 
 class MisconfiguredAuthenticationTests(unittest.TestCase):
@@ -34,7 +33,7 @@ class MisconfiguredAuthenticationTests(unittest.TestCase):
             cls.ccm_cluster = ccm_cluster
 
     def test_connect_no_auth_provider(self):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, contact_points=[CASSANDRA_IP])
+        cluster = TestCluster()
         cluster.connect()
         cluster.refresh_nodes()
         down_hosts = [host for host in cluster.metadata.all_hosts() if not host.is_up]

--- a/tests/integration/standard/test_client_warnings.py
+++ b/tests/integration/standard/test_client_warnings.py
@@ -19,9 +19,8 @@ except ImportError:
     import unittest
 
 from cassandra.query import BatchStatement
-from cassandra.cluster import Cluster
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, local
+from tests.integration import use_singledc, PROTOCOL_VERSION, local, TestCluster
 
 
 def setup_module():
@@ -35,7 +34,7 @@ class ClientWarningTests(unittest.TestCase):
         if PROTOCOL_VERSION < 4:
             return
 
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
 
         cls.session.execute("CREATE TABLE IF NOT EXISTS test1rf.client_warning (k int, v0 int, v1 int, PRIMARY KEY (k, v0))")

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -27,7 +27,7 @@ import warnings
 from packaging.version import Version
 
 import cassandra
-from cassandra.cluster import Cluster, NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT, ControlConnection
+from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT, ControlConnection, Cluster
 from cassandra.concurrent import execute_concurrent
 from cassandra.policies import (RoundRobinPolicy, ExponentialReconnectionPolicy,
                                 RetryPolicy, SimpleConvictionPolicy, HostDistance,
@@ -40,10 +40,10 @@ from cassandra import connection
 from cassandra.connection import DefaultEndPoint
 
 from tests import notwindows
-from tests.integration import use_singledc, PROTOCOL_VERSION, get_server_versions, CASSANDRA_VERSION, \
+from tests.integration import use_singledc, get_server_versions, CASSANDRA_VERSION, \
     execute_until_pass, execute_with_long_wait_retry, get_node, MockLoggingHandler, get_unsupported_lower_protocol, \
     get_unsupported_upper_protocol, protocolv5, local, CASSANDRA_IP, greaterthanorequalcass30, lessthanorequalcass40, \
-    DSE_VERSION
+    DSE_VERSION, TestCluster, PROTOCOL_VERSION
 from tests.integration.util import assert_quiescent_pool_state
 import sys
 
@@ -81,8 +81,9 @@ class ClusterTests(unittest.TestCase):
         @test_category connection
         """
         ignored_host_policy = IgnoredHostPolicy(["127.0.0.2", "127.0.0.3"])
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=ignored_host_policy)})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=ignored_host_policy)}
+        )
         cluster.connect()
         for host in cluster.metadata.all_hosts():
             if str(host) == "127.0.0.1:9042":
@@ -102,7 +103,7 @@ class ClusterTests(unittest.TestCase):
 
         @test_category connection
         """
-        cluster = Cluster(contact_points=["localhost"], protocol_version=PROTOCOL_VERSION, connect_timeout=1)
+        cluster = TestCluster(contact_points=["localhost"], connect_timeout=1)
         self.assertTrue(DefaultEndPoint('127.0.0.1') in cluster.endpoints_resolved)
 
     @local
@@ -116,11 +117,14 @@ class ClusterTests(unittest.TestCase):
 
         @test_category connection
         """
-        cluster = Cluster(contact_points=["localhost", "127.0.0.1", "localhost", "localhost", "localhost"], protocol_version=PROTOCOL_VERSION, connect_timeout=1)
+        cluster = TestCluster(
+            contact_points=["localhost", "127.0.0.1", "localhost", "localhost", "localhost"],
+            connect_timeout=1
+        )
         cluster.connect(wait_for_all_pools=True)
         self.assertEqual(len(cluster.metadata.all_hosts()), 3)
         cluster.shutdown()
-        cluster = Cluster(contact_points=["127.0.0.1", "localhost"], protocol_version=PROTOCOL_VERSION, connect_timeout=1)
+        cluster = TestCluster(contact_points=["127.0.0.1", "localhost"], connect_timeout=1)
         cluster.connect(wait_for_all_pools=True)
         self.assertEqual(len(cluster.metadata.all_hosts()), 3)
         cluster.shutdown()
@@ -144,7 +148,7 @@ class ClusterTests(unittest.TestCase):
         """
 
         get_node(1).pause()
-        cluster = Cluster(contact_points=['127.0.0.1'], protocol_version=PROTOCOL_VERSION, connect_timeout=1)
+        cluster = TestCluster(contact_points=['127.0.0.1'], connect_timeout=1)
 
         with self.assertRaisesRegexp(NoHostAvailable, "OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
             cluster.connect()
@@ -157,7 +161,7 @@ class ClusterTests(unittest.TestCase):
         Test basic connection and usage
         """
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
         result = execute_until_pass(session,
             """
@@ -213,20 +217,19 @@ class ClusterTests(unittest.TestCase):
         self.addCleanup(cleanup)
 
         # Test with empty list
-        self.cluster_to_shutdown = Cluster([], protocol_version=PROTOCOL_VERSION)
+        self.cluster_to_shutdown = TestCluster(contact_points=[])
         with self.assertRaises(NoHostAvailable):
             self.cluster_to_shutdown.connect()
         self.cluster_to_shutdown.shutdown()
 
         # Test with only invalid
-        self.cluster_to_shutdown = Cluster(('1.2.3.4',), protocol_version=PROTOCOL_VERSION)
+        self.cluster_to_shutdown = TestCluster(contact_points=('1.2.3.4',))
         with self.assertRaises(NoHostAvailable):
             self.cluster_to_shutdown.connect()
         self.cluster_to_shutdown.shutdown()
 
         # Test with valid and invalid hosts
-        self.cluster_to_shutdown = Cluster(("127.0.0.1", "127.0.0.2", "1.2.3.4"),
-                                           protocol_version=PROTOCOL_VERSION)
+        self.cluster_to_shutdown = TestCluster(contact_points=("127.0.0.1", "127.0.0.2", "1.2.3.4"))
         self.cluster_to_shutdown.connect()
         self.cluster_to_shutdown.shutdown()
 
@@ -298,7 +301,7 @@ class ClusterTests(unittest.TestCase):
         upper_bound = get_unsupported_upper_protocol()
         log.debug('got upper_bound of {}'.format(upper_bound))
         if upper_bound is not None:
-            cluster = Cluster(protocol_version=upper_bound)
+            cluster = TestCluster(protocol_version=upper_bound)
             with self.assertRaises(NoHostAvailable):
                 cluster.connect()
             cluster.shutdown()
@@ -306,7 +309,7 @@ class ClusterTests(unittest.TestCase):
         lower_bound = get_unsupported_lower_protocol()
         log.debug('got lower_bound of {}'.format(lower_bound))
         if lower_bound is not None:
-            cluster = Cluster(protocol_version=lower_bound)
+            cluster = TestCluster(protocol_version=lower_bound)
             with self.assertRaises(NoHostAvailable):
                 cluster.connect()
             cluster.shutdown()
@@ -316,7 +319,7 @@ class ClusterTests(unittest.TestCase):
         Ensure clusters that connect on a keyspace, do
         """
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
         result = session.execute(
             """
@@ -334,7 +337,7 @@ class ClusterTests(unittest.TestCase):
         cluster.shutdown()
 
     def test_set_keyspace_twice(self):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
         session.execute("USE system")
         session.execute("USE system")
@@ -345,7 +348,7 @@ class ClusterTests(unittest.TestCase):
         Ensure errors are not thrown when using non-default policies
         """
 
-        Cluster(
+        TestCluster(
             reconnection_policy=ExponentialReconnectionPolicy(1.0, 600.0),
             conviction_policy_factory=SimpleConvictionPolicy,
             protocol_version=PROTOCOL_VERSION
@@ -355,7 +358,7 @@ class ClusterTests(unittest.TestCase):
         """
         Ensure you cannot connect to a cluster that's been shutdown
         """
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         cluster.shutdown()
         self.assertRaises(Exception, cluster.connect)
 
@@ -364,7 +367,7 @@ class ClusterTests(unittest.TestCase):
         Ensure that auth_providers are always callable
         """
         self.assertRaises(TypeError, Cluster, auth_provider=1, protocol_version=1)
-        c = Cluster(protocol_version=1)
+        c = TestCluster(protocol_version=1)
         self.assertRaises(TypeError, setattr, c, 'auth_provider', 1)
 
     def test_v2_auth_provider(self):
@@ -373,7 +376,7 @@ class ClusterTests(unittest.TestCase):
         """
         bad_auth_provider = lambda x: {'username': 'foo', 'password': 'bar'}
         self.assertRaises(TypeError, Cluster, auth_provider=bad_auth_provider, protocol_version=2)
-        c = Cluster(protocol_version=2)
+        c = TestCluster(protocol_version=2)
         self.assertRaises(TypeError, setattr, c, 'auth_provider', bad_auth_provider)
 
     def test_conviction_policy_factory_is_callable(self):
@@ -389,8 +392,8 @@ class ClusterTests(unittest.TestCase):
         when a cluster cannot connect to given hosts
         """
 
-        cluster = Cluster(['127.1.2.9', '127.1.2.10'],
-                          protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster(contact_points=['127.1.2.9', '127.1.2.10'],
+                              protocol_version=PROTOCOL_VERSION)
         self.assertRaises(NoHostAvailable, cluster.connect)
 
     def test_cluster_settings(self):
@@ -400,7 +403,7 @@ class ClusterTests(unittest.TestCase):
         if PROTOCOL_VERSION >= 3:
             raise unittest.SkipTest("min/max requests and core/max conns aren't used with v3 protocol")
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
 
         min_requests_per_connection = cluster.get_min_requests_per_connection(HostDistance.LOCAL)
         self.assertEqual(cassandra.cluster.DEFAULT_MIN_REQUESTS, min_requests_per_connection)
@@ -423,7 +426,7 @@ class ClusterTests(unittest.TestCase):
         self.assertEqual(cluster.get_max_connections_per_host(HostDistance.LOCAL), max_connections_per_host + 1)
 
     def test_refresh_schema(self):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
 
         original_meta = cluster.metadata.keyspaces
@@ -435,7 +438,7 @@ class ClusterTests(unittest.TestCase):
         cluster.shutdown()
 
     def test_refresh_schema_keyspace(self):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
 
         original_meta = cluster.metadata.keyspaces
@@ -451,7 +454,7 @@ class ClusterTests(unittest.TestCase):
         cluster.shutdown()
 
     def test_refresh_schema_table(self):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
 
         original_meta = cluster.metadata.keyspaces
@@ -477,7 +480,7 @@ class ClusterTests(unittest.TestCase):
             raise unittest.SkipTest('UDTs are not specified in change events for protocol v2')
             # We may want to refresh types on keyspace change events in that case(?)
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
 
         keyspace_name = 'test1rf'
@@ -516,7 +519,7 @@ class ClusterTests(unittest.TestCase):
             agreement_timeout = 1
 
             # cluster agreement wait exceeded
-            c = Cluster(protocol_version=PROTOCOL_VERSION, max_schema_agreement_wait=agreement_timeout)
+            c = TestCluster(max_schema_agreement_wait=agreement_timeout)
             c.connect()
             self.assertTrue(c.metadata.keyspaces)
 
@@ -541,7 +544,7 @@ class ClusterTests(unittest.TestCase):
 
             refresh_threshold = 0.5
             # cluster agreement bypass
-            c = Cluster(protocol_version=PROTOCOL_VERSION, max_schema_agreement_wait=0)
+            c = TestCluster(max_schema_agreement_wait=0)
             start_time = time.time()
             s = c.connect()
             end_time = time.time()
@@ -572,7 +575,7 @@ class ClusterTests(unittest.TestCase):
         Ensure trace can be requested for async and non-async queries
         """
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
 
         result = session.execute( "SELECT * FROM system.local", trace=True)
@@ -618,7 +621,7 @@ class ClusterTests(unittest.TestCase):
 
         @test_category query
                 """
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         self.addCleanup(cluster.shutdown)
         session = cluster.connect()
 
@@ -660,7 +663,7 @@ class ClusterTests(unittest.TestCase):
 
         @test_category query
         """
-        with Cluster() as cluster:
+        with TestCluster() as cluster:
             session = cluster.connect()
             self.assertIsNone(session.execute("SELECT * from system.local WHERE key='madeup_key'").one())
 
@@ -669,7 +672,7 @@ class ClusterTests(unittest.TestCase):
         Ensure str(future) returns without error
         """
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cluster = TestCluster()
         session = cluster.connect()
 
         query = "SELECT * FROM system.local"
@@ -726,7 +729,7 @@ class ClusterTests(unittest.TestCase):
 
     def _warning_are_issued_when_auth(self, auth_provider):
         with MockLoggingHandler().set_module_name(connection.__name__) as mock_handler:
-            with Cluster(auth_provider=auth_provider) as cluster:
+            with TestCluster(auth_provider=auth_provider) as cluster:
                 session = cluster.connect()
                 self.assertIsNotNone(session.execute("SELECT * from system.local"))
 
@@ -740,8 +743,8 @@ class ClusterTests(unittest.TestCase):
 
     def test_idle_heartbeat(self):
         interval = 2
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, idle_heartbeat_interval=interval,
-                          monitor_reporting_enabled=False)
+        cluster = TestCluster(idle_heartbeat_interval=interval,
+                              monitor_reporting_enabled=False)
         if PROTOCOL_VERSION < 3:
             cluster.set_core_connections_per_host(HostDistance.LOCAL, 1)
         session = cluster.connect(wait_for_all_pools=True)
@@ -803,7 +806,7 @@ class ClusterTests(unittest.TestCase):
         self.assertTrue(Cluster.idle_heartbeat_interval)
 
         # heartbeat disabled with '0'
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, idle_heartbeat_interval=0)
+        cluster = TestCluster(idle_heartbeat_interval=0)
         self.assertEqual(cluster.idle_heartbeat_interval, 0)
         session = cluster.connect()
 
@@ -819,7 +822,7 @@ class ClusterTests(unittest.TestCase):
 
     def test_pool_management(self):
         # Ensure that in_flight and request_ids quiesce after cluster operations
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, idle_heartbeat_interval=0)  # no idle heartbeat here, pool management is tested in test_idle_heartbeat
+        cluster = TestCluster(idle_heartbeat_interval=0)  # no idle heartbeat here, pool management is tested in test_idle_heartbeat
         session = cluster.connect()
         session2 = cluster.connect()
 
@@ -863,7 +866,7 @@ class ClusterTests(unittest.TestCase):
                 RoundRobinPolicy(), lambda host: host.address == CASSANDRA_IP
             )
         )
-        with Cluster(execution_profiles={'node1': node1}, monitor_reporting_enabled=False) as cluster:
+        with TestCluster(execution_profiles={'node1': node1}, monitor_reporting_enabled=False) as cluster:
             session = cluster.connect(wait_for_all_pools=True)
 
             # default is DCA RR for all hosts
@@ -904,7 +907,7 @@ class ClusterTests(unittest.TestCase):
             self.assertTrue(session.execute(query, execution_profile='node1')[0].release_version)
 
     def test_setting_lbp_legacy(self):
-        cluster = Cluster()
+        cluster = TestCluster()
         self.addCleanup(cluster.shutdown)
         cluster.load_balancing_policy = RoundRobinPolicy()
         self.assertEqual(
@@ -932,7 +935,7 @@ class ClusterTests(unittest.TestCase):
         rr1 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         rr2 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         exec_profiles = {'rr1': rr1, 'rr2': rr2}
-        with Cluster(execution_profiles=exec_profiles) as cluster:
+        with TestCluster(execution_profiles=exec_profiles) as cluster:
             session = cluster.connect(wait_for_all_pools=True)
 
             # default is DCA RR for all hosts
@@ -959,7 +962,7 @@ class ClusterTests(unittest.TestCase):
         """
         query = "select release_version from system.local"
         ta1 = ExecutionProfile()
-        with Cluster() as cluster:
+        with TestCluster() as cluster:
             session = cluster.connect()
             cluster.add_execution_profile("ta1", ta1)
             rs = session.execute(query, execution_profile='ta1')
@@ -980,7 +983,7 @@ class ClusterTests(unittest.TestCase):
         query = "select release_version from system.local"
         rr1 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         exec_profiles = {'rr1': rr1}
-        with Cluster(execution_profiles=exec_profiles) as cluster:
+        with TestCluster(execution_profiles=exec_profiles) as cluster:
             session = cluster.connect(wait_for_all_pools=True)
             self.assertGreater(len(cluster.metadata.all_hosts()), 1, "We only have one host connected at this point")
 
@@ -1008,7 +1011,7 @@ class ClusterTests(unittest.TestCase):
         rr1 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         rr2 = ExecutionProfile(load_balancing_policy=RoundRobinPolicy())
         exec_profiles = {'rr1': rr1, 'rr2': rr2}
-        with Cluster(execution_profiles=exec_profiles) as cluster:
+        with TestCluster(execution_profiles=exec_profiles) as cluster:
             session = cluster.connect()
             with self.assertRaises(ValueError):
                 session.execute(query, execution_profile='rr3')
@@ -1035,7 +1038,7 @@ class ClusterTests(unittest.TestCase):
                 RoundRobinPolicy(), lambda host: host.address == "127.0.0.2"
             )
         )
-        with Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: node1, 'node2': node2}) as cluster:
+        with TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: node1, 'node2': node2}) as cluster:
             session = cluster.connect(wait_for_all_pools=True)
             pools = session.get_pool_state()
             # there are more hosts, but we connected to the ones in the lbp aggregate
@@ -1070,7 +1073,7 @@ class ClusterTests(unittest.TestCase):
                     RoundRobinPolicy(), lambda host: host.address == "127.0.0.1"
                 )
             )
-            with Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: node1}) as cluster:
+            with TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: node1}) as cluster:
                 session = cluster.connect(wait_for_all_pools=True)
                 pools = session.get_pool_state()
                 self.assertGreater(len(cluster.metadata.all_hosts()), 2)
@@ -1096,7 +1099,7 @@ class ClusterTests(unittest.TestCase):
 
     @notwindows
     def test_execute_query_timeout(self):
-        with Cluster() as cluster:
+        with TestCluster() as cluster:
             session = cluster.connect(wait_for_all_pools=True)
             query = "SELECT * FROM system.local"
 
@@ -1142,8 +1145,7 @@ class ClusterTests(unittest.TestCase):
         tap_profile = ExecutionProfile(
             load_balancing_policy=TokenAwarePolicy(RoundRobinPolicy())
         )
-        with Cluster(protocol_version=PROTOCOL_VERSION,
-                     execution_profiles={EXEC_PROFILE_DEFAULT: tap_profile}) as cluster:
+        with TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: tap_profile}) as cluster:
             session = cluster.connect(wait_for_all_pools=True)
             session.execute('''
                     CREATE TABLE test1rf.table_with_big_key (
@@ -1168,9 +1170,8 @@ class ClusterTests(unittest.TestCase):
         log = logging.getLogger(__name__)
         log.info("The only replica found was: {}".format(only_replica))
         available_hosts = [host for host in ["127.0.0.1", "127.0.0.2", "127.0.0.3"] if host != only_replica]
-        with Cluster(contact_points=available_hosts,
-                     protocol_version=PROTOCOL_VERSION,
-                     execution_profiles={EXEC_PROFILE_DEFAULT: hfp_profile}) as cluster:
+        with TestCluster(contact_points=available_hosts,
+                         execution_profiles={EXEC_PROFILE_DEFAULT: hfp_profile}) as cluster:
 
             session = cluster.connect(wait_for_all_pools=True)
             prepared = session.prepare("""SELECT * from test1rf.table_with_big_key
@@ -1196,10 +1197,10 @@ class ClusterTests(unittest.TestCase):
 
         @test_category connection
         """
-        nc_cluster = Cluster(protocol_version=PROTOCOL_VERSION, no_compact=True)
+        nc_cluster = TestCluster(no_compact=True)
         nc_session = nc_cluster.connect()
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION, no_compact=False)
+        cluster = TestCluster(no_compact=False)
         session = cluster.connect()
 
         self.addCleanup(cluster.shutdown)
@@ -1284,7 +1285,7 @@ class TestAddressTranslation(unittest.TestCase):
         @test_category metadata
         """
         lh_ad = LocalHostAdressTranslator({'127.0.0.1': '127.0.0.1', '127.0.0.2': '127.0.0.1', '127.0.0.3': '127.0.0.1'})
-        c = Cluster(address_translator=lh_ad)
+        c = TestCluster(address_translator=lh_ad)
         c.connect()
         self.assertEqual(len(c.metadata.all_hosts()), 1)
         c.shutdown()
@@ -1304,7 +1305,7 @@ class TestAddressTranslation(unittest.TestCase):
         """
         adder_map = {'127.0.0.1': '127.0.0.1', '127.0.0.2': '127.0.0.3', '127.0.0.3': '127.0.0.2'}
         lh_ad = LocalHostAdressTranslator(adder_map)
-        c = Cluster(address_translator=lh_ad)
+        c = TestCluster(address_translator=lh_ad)
         c.connect()
         for host in c.metadata.all_hosts():
             self.assertEqual(adder_map.get(host.address), host.broadcast_address)
@@ -1330,7 +1331,7 @@ class ContextManagementTest(unittest.TestCase):
 
         @test_category configuration
         """
-        with Cluster() as cluster:
+        with TestCluster() as cluster:
             self.assertFalse(cluster.is_shutdown)
         self.assertTrue(cluster.is_shutdown)
 
@@ -1344,7 +1345,7 @@ class ContextManagementTest(unittest.TestCase):
 
         @test_category configuration
         """
-        with Cluster(**self.cluster_kwargs) as cluster:
+        with TestCluster(**self.cluster_kwargs) as cluster:
             with cluster.connect() as session:
                 self.assertFalse(cluster.is_shutdown)
                 self.assertFalse(session.is_shutdown)
@@ -1362,7 +1363,7 @@ class ContextManagementTest(unittest.TestCase):
 
         @test_category configuration
         """
-        with Cluster(**self.cluster_kwargs) as cluster:
+        with TestCluster(**self.cluster_kwargs) as cluster:
             session = cluster.connect()
             self.assertFalse(cluster.is_shutdown)
             self.assertFalse(session.is_shutdown)
@@ -1380,7 +1381,7 @@ class ContextManagementTest(unittest.TestCase):
 
         @test_category configuration
         """
-        cluster = Cluster(**self.cluster_kwargs)
+        cluster = TestCluster(**self.cluster_kwargs)
         unmanaged_session = cluster.connect()
         with cluster.connect() as session:
             self.assertFalse(cluster.is_shutdown)
@@ -1411,7 +1412,7 @@ class HostStateTest(unittest.TestCase):
 
         @test_category connection
         """
-        with Cluster(protocol_version=PROTOCOL_VERSION) as cluster:
+        with TestCluster() as cluster:
             session = cluster.connect(wait_for_all_pools=True)
             random_host = cluster.metadata.all_hosts()[0]
             cluster.on_down(random_host, False)
@@ -1440,8 +1441,9 @@ class DontPrepareOnIgnoredHostsTest(unittest.TestCase):
 
     def test_prepare_on_ignored_hosts(self):
 
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=self.ignore_node_3_policy)})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=self.ignore_node_3_policy)}
+        )
         session = cluster.connect()
         cluster.reprepare_on_up, cluster.prepare_on_all_hosts = True, False
 
@@ -1486,7 +1488,7 @@ class BetaProtocolTest(unittest.TestCase):
         @test_category connection
         """
 
-        cluster = Cluster(protocol_version=cassandra.ProtocolVersion.MAX_SUPPORTED, allow_beta_protocol_version=False)
+        cluster = TestCluster(protocol_version=cassandra.ProtocolVersion.V5, allow_beta_protocol_version=False)
         try:
             with self.assertRaises(NoHostAvailable):
                 cluster.connect()
@@ -1504,9 +1506,9 @@ class BetaProtocolTest(unittest.TestCase):
 
         @test_category connection
         """
-        cluster = Cluster(protocol_version=cassandra.ProtocolVersion.MAX_SUPPORTED, allow_beta_protocol_version=True)
+        cluster = Cluster(protocol_version=cassandra.ProtocolVersion.V5, allow_beta_protocol_version=True)
         session = cluster.connect()
-        self.assertEqual(cluster.protocol_version, cassandra.ProtocolVersion.MAX_SUPPORTED)
+        self.assertEqual(cluster.protocol_version, cassandra.ProtocolVersion.V5)
         self.assertTrue(session.execute("select release_version from system.local")[0])
         cluster.shutdown()
 
@@ -1524,7 +1526,7 @@ class DeprecationWarningTest(unittest.TestCase):
         @test_category logs
         """
         with warnings.catch_warnings(record=True) as w:
-            Cluster(load_balancing_policy=RoundRobinPolicy())
+            TestCluster(load_balancing_policy=RoundRobinPolicy())
             self.assertEqual(len(w), 1)
             self.assertIn("Legacy execution parameters will be removed in 4.0. Consider using execution profiles.",
                           str(w[0].message))
@@ -1541,7 +1543,7 @@ class DeprecationWarningTest(unittest.TestCase):
         @test_category logs
         """
         with warnings.catch_warnings(record=True) as w:
-            cluster = Cluster()
+            cluster = TestCluster()
             cluster.set_meta_refresh_enabled(True)
             self.assertEqual(len(w), 1)
             self.assertIn("Cluster.set_meta_refresh_enabled is deprecated and will be removed in 4.0.",
@@ -1559,7 +1561,7 @@ class DeprecationWarningTest(unittest.TestCase):
         @test_category logs
         """
         with warnings.catch_warnings(record=True) as w:
-            cluster = Cluster()
+            cluster = TestCluster()
             session = cluster.connect()
             session.default_consistency_level = ConsistencyLevel.ONE
             self.assertEqual(len(w), 1)

--- a/tests/integration/standard/test_concurrent.py
+++ b/tests/integration/standard/test_concurrent.py
@@ -17,12 +17,12 @@ import sys, logging, traceback
 
 from cassandra import InvalidRequest, ConsistencyLevel, ReadTimeout, WriteTimeout, OperationTimedOut, \
     ReadFailure, WriteFailure
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.concurrent import execute_concurrent, execute_concurrent_with_args, ExecutionResult
 from cassandra.policies import HostDistance
 from cassandra.query import tuple_factory, SimpleStatement
 
-from tests.integration import use_singledc, PROTOCOL_VERSION
+from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
 
 from six import next
 
@@ -42,8 +42,7 @@ class ClusterTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.cluster = Cluster(
-            protocol_version=PROTOCOL_VERSION,
+        cls.cluster = TestCluster(
             execution_profiles = {
                 EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)
             }

--- a/tests/integration/standard/test_control_connection.py
+++ b/tests/integration/standard/test_control_connection.py
@@ -22,9 +22,8 @@ except ImportError:
     import unittest  # noqa
 
 
-from cassandra.cluster import Cluster
 from cassandra.protocol import ConfigurationException
-from tests.integration import use_singledc, PROTOCOL_VERSION
+from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
 from tests.integration.datatype_utils import update_datatypes
 
 
@@ -39,7 +38,7 @@ class ControlConnectionTests(unittest.TestCase):
             raise unittest.SkipTest(
                 "Native protocol 3,0+ is required for UDTs using %r"
                 % (PROTOCOL_VERSION,))
-        self.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        self.cluster = TestCluster()
 
     def tearDown(self):
         try:

--- a/tests/integration/standard/test_custom_cluster.py
+++ b/tests/integration/standard/test_custom_cluster.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from cassandra.cluster import Cluster, NoHostAvailable
-from tests.integration import use_singledc, get_cluster, remove_cluster,  local
+from cassandra.cluster import NoHostAvailable
+from tests.integration import use_singledc, get_cluster, remove_cluster, local, TestCluster
 from tests.util import wait_until, wait_until_not_raised
 
 try:
@@ -31,9 +31,9 @@ def setup_module():
     # can't use wait_for_binary_proto cause ccm tries on port 9042
     ccm_cluster.start(wait_for_binary_proto=False)
     # wait until all nodes are up
-    wait_until_not_raised(lambda: Cluster(['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
-    wait_until_not_raised(lambda: Cluster(['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
-    wait_until_not_raised(lambda: Cluster(['127.0.0.3'], port=9046).connect().shutdown(), 1, 20)
+    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
+    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.3'], port=9046).connect().shutdown(), 1, 20)
 
 
 def teardown_module():
@@ -50,11 +50,11 @@ class CustomClusterTests(unittest.TestCase):
 
         All hosts should be marked as up and we should be able to execute queries on it.
         """
-        cluster = Cluster()
+        cluster = TestCluster()
         with self.assertRaises(NoHostAvailable):
             cluster.connect()  # should fail on port 9042
 
-        cluster = Cluster(port=9046)
+        cluster = TestCluster(port=9046)
         session = cluster.connect(wait_for_all_pools=True)
 
         wait_until(lambda: len(cluster.metadata.all_hosts()) == 3, 1, 5)

--- a/tests/integration/standard/test_custom_payload.py
+++ b/tests/integration/standard/test_custom_payload.py
@@ -21,9 +21,9 @@ except ImportError:
 import six
 
 from cassandra.query import (SimpleStatement, BatchStatement, BatchType)
-from cassandra.cluster import Cluster
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, local
+from tests.integration import use_singledc, PROTOCOL_VERSION, local, TestCluster
+
 
 def setup_module():
     use_singledc()
@@ -38,7 +38,7 @@ class CustomPayloadTests(unittest.TestCase):
             raise unittest.SkipTest(
                 "Native protocol 4,0+ is required for custom payloads, currently using %r"
                 % (PROTOCOL_VERSION,))
-        self.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        self.cluster = TestCluster()
         self.session = self.cluster.connect()
 
     def tearDown(self):

--- a/tests/integration/standard/test_custom_protocol_handler.py
+++ b/tests/integration/standard/test_custom_protocol_handler.py
@@ -19,13 +19,13 @@ except ImportError:
 
 from cassandra.protocol import ProtocolHandler, ResultMessage, QueryMessage, UUIDType, read_int
 from cassandra.query import tuple_factory, SimpleStatement
-from cassandra.cluster import (Cluster, ResponseFuture, ExecutionProfile, EXEC_PROFILE_DEFAULT,
+from cassandra.cluster import (ResponseFuture, ExecutionProfile, EXEC_PROFILE_DEFAULT,
     ContinuousPagingOptions, NoHostAvailable)
 from cassandra import ProtocolVersion, ConsistencyLevel
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, drop_keyspace_shutdown_cluster, \
+from tests.integration import use_singledc, drop_keyspace_shutdown_cluster, \
     greaterthanorequalcass30, execute_with_long_wait_retry, greaterthanorequaldse51, greaterthanorequalcass3_10, \
-    greaterthanorequalcass31
+    greaterthanorequalcass31, TestCluster
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES
 from tests.integration.standard.utils import create_table_with_all_types, get_all_primitive_params
 from six import binary_type
@@ -43,7 +43,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE custserdes WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
         cls.session.set_keyspace("custserdes")
@@ -68,8 +68,9 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         """
 
         # Ensure that we get normal uuid back first
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
+        )
         session = cluster.connect(keyspace="custserdes")
 
         result = session.execute("SELECT schema_version FROM system.local")
@@ -105,8 +106,9 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         @test_category data_types:serialization
         """
         # Connect using a custom protocol handler that tracks the various types the result message is used with.
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
+        )
         session = cluster.connect(keyspace="custserdes")
         session.client_protocol_handler = CustomProtocolHandlerResultMessageTracked
 
@@ -133,7 +135,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
 
         @test_category connection
         """
-        cluster = Cluster(protocol_version=ProtocolVersion.V5, allow_beta_protocol_version=True)
+        cluster = TestCluster(protocol_version=ProtocolVersion.V5, allow_beta_protocol_version=True)
         session = cluster.connect()
 
         max_pages = 4
@@ -228,7 +230,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         return future
 
     def _protocol_divergence_fail_by_flag_uses_int(self, version, uses_int_query_flag, int_flag = True, beta=False):
-        cluster = Cluster(protocol_version=version, allow_beta_protocol_version=beta)
+        cluster = TestCluster(protocol_version=version, allow_beta_protocol_version=beta)
         session = cluster.connect()
 
         query_one = SimpleStatement("INSERT INTO test3rf.test (k, v) VALUES (1, 1)")

--- a/tests/integration/standard/test_cython_protocol_handlers.py
+++ b/tests/integration/standard/test_cython_protocol_handlers.py
@@ -9,18 +9,17 @@ except ImportError:
 
 from itertools import count
 
-from cassandra.query import tuple_factory
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.concurrent import execute_concurrent_with_args
-from cassandra.protocol import ProtocolHandler, LazyProtocolHandler, NumpyProtocolHandler
 from cassandra.cython_deps import HAVE_CYTHON, HAVE_NUMPY
+from cassandra.protocol import ProtocolHandler, LazyProtocolHandler, NumpyProtocolHandler
+from cassandra.query import tuple_factory
 from tests import VERIFY_CYTHON
-from tests.integration import use_singledc, PROTOCOL_VERSION, notprotocolv1, \
-    drop_keyspace_shutdown_cluster, BasicSharedKeyspaceUnitTestCase, greaterthancass21
+from tests.integration import use_singledc, notprotocolv1, \
+    drop_keyspace_shutdown_cluster, BasicSharedKeyspaceUnitTestCase, greaterthancass21, TestCluster
 from tests.integration.datatype_utils import update_datatypes
 from tests.integration.standard.utils import (
     create_table_with_all_types, get_all_primitive_params, get_primitive_datatypes)
-
 from tests.unit.cython.utils import cythontest, numpytest
 
 
@@ -35,7 +34,7 @@ class CythonProtocolHandlerTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE testspace WITH replication = "
                             "{ 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
@@ -66,8 +65,9 @@ class CythonProtocolHandlerTest(unittest.TestCase):
         Test Cython-based parser that returns an iterator, over multiple pages
         """
         # arrays = { 'a': arr1, 'b': arr2, ... }
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
+        )
         session = cluster.connect(keyspace="testspace")
         session.client_protocol_handler = LazyProtocolHandler
         session.default_fetch_size = 2
@@ -99,8 +99,9 @@ class CythonProtocolHandlerTest(unittest.TestCase):
         Test Numpy-based parser that returns a NumPy array
         """
         # arrays = { 'a': arr1, 'b': arr2, ... }
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
+        )
         session = cluster.connect(keyspace="testspace")
         session.client_protocol_handler = NumpyProtocolHandler
         session.default_fetch_size = 2
@@ -181,8 +182,9 @@ def get_data(protocol_handler):
     """
     Get data from the test table.
     """
-    cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                      execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)})
+    cluster = TestCluster(
+        execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
+    )
     session = cluster.connect(keyspace="testspace")
 
     # use our custom protocol handler

--- a/tests/integration/standard/test_dse.py
+++ b/tests/integration/standard/test_dse.py
@@ -16,11 +16,10 @@ import os
 
 from packaging.version import Version
 
-from cassandra.cluster import Cluster
 from tests import notwindows
 from tests.unit.cython.utils import notcython
 from tests.integration import (execute_until_pass,
-                               execute_with_long_wait_retry, use_cluster)
+                               execute_with_long_wait_retry, use_cluster, TestCluster)
 
 try:
     import unittest2 as unittest
@@ -60,8 +59,7 @@ class DseCCMClusterTest(unittest.TestCase):
         )
         use_cluster(cluster_name=cluster_name, nodes=[3], dse_options={})
 
-        cluster = Cluster(
-            allow_beta_protocol_version=(dse_version >= Version('6.7.0')))
+        cluster = TestCluster()
         session = cluster.connect()
         result = execute_until_pass(
             session,

--- a/tests/integration/standard/test_metrics.py
+++ b/tests/integration/standard/test_metrics.py
@@ -26,8 +26,8 @@ from cassandra.query import SimpleStatement
 from cassandra import ConsistencyLevel, WriteTimeout, Unavailable, ReadTimeout
 from cassandra.protocol import SyntaxException
 
-from cassandra.cluster import Cluster, NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT
-from tests.integration import get_cluster, get_node, use_singledc, PROTOCOL_VERSION, execute_until_pass
+from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from tests.integration import get_cluster, get_node, use_singledc, execute_until_pass, TestCluster
 from greplin import scales
 from tests.integration import BasicSharedKeyspaceUnitTestCaseRF3WM, BasicExistingKeyspaceUnitTestCase, local
 
@@ -42,16 +42,16 @@ class MetricsTests(unittest.TestCase):
 
     def setUp(self):
         contact_point = ['127.0.0.2']
-        self.cluster = Cluster(contact_points=contact_point, metrics_enabled=True, protocol_version=PROTOCOL_VERSION,
-                               execution_profiles=
+        self.cluster = TestCluster(contact_points=contact_point, metrics_enabled=True,
+                                   execution_profiles=
                                    {EXEC_PROFILE_DEFAULT:
                                        ExecutionProfile(
                                            load_balancing_policy=HostFilterPolicy(
-                                                RoundRobinPolicy(), lambda host: host.address in contact_point),
+                                               RoundRobinPolicy(), lambda host: host.address in contact_point),
                                            retry_policy=FallthroughRetryPolicy()
                                        )
                                    }
-                               )
+                                   )
         self.session = self.cluster.connect("test3rf", wait_for_all_pools=True)
 
     def tearDown(self):
@@ -203,8 +203,10 @@ class MetricsNamespaceTest(BasicSharedKeyspaceUnitTestCaseRF3WM):
         @test_category metrics
         """
 
-        cluster2 = Cluster(metrics_enabled=True, protocol_version=PROTOCOL_VERSION,
-                           execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())})
+        cluster2 = TestCluster(
+            metrics_enabled=True,
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())}
+        )
         cluster2.connect(self.ks_name, wait_for_all_pools=True)
 
         self.assertEqual(len(cluster2.metadata.all_hosts()), 3)
@@ -255,13 +257,17 @@ class MetricsNamespaceTest(BasicSharedKeyspaceUnitTestCaseRF3WM):
 
         @test_category metrics
         """
-        cluster2 = Cluster(metrics_enabled=True, protocol_version=PROTOCOL_VERSION,
-                           monitor_reporting_enabled=False,
-                           execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())})
+        cluster2 = TestCluster(
+            metrics_enabled=True,
+            monitor_reporting_enabled=False,
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())}
+        )
 
-        cluster3 = Cluster(metrics_enabled=True, protocol_version=PROTOCOL_VERSION,
-                           monitor_reporting_enabled=False,
-                           execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())})
+        cluster3 = TestCluster(
+            metrics_enabled=True,
+            monitor_reporting_enabled=False,
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())}
+        )
 
         # Ensure duplicate metric names are not allowed
         cluster2.metrics.set_stats_name("appcluster")

--- a/tests/integration/standard/test_policies.py
+++ b/tests/integration/standard/test_policies.py
@@ -17,13 +17,13 @@ try:
 except ImportError:
     import unittest  # noqa
 
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.policies import HostFilterPolicy, RoundRobinPolicy,  SimpleConvictionPolicy, \
     WhiteListRoundRobinPolicy
 from cassandra.pool import Host
 from cassandra.connection import DefaultEndPoint
 
-from tests.integration import PROTOCOL_VERSION, local, use_singledc
+from tests.integration import local, use_singledc, TestCluster
 
 from concurrent.futures import wait as wait_futures
 
@@ -55,9 +55,9 @@ class HostFilterPolicyTests(unittest.TestCase):
         hfp = ExecutionProfile(
             load_balancing_policy=HostFilterPolicy(RoundRobinPolicy(), predicate=predicate)
         )
-        cluster = Cluster((contact_point,), execution_profiles={EXEC_PROFILE_DEFAULT: hfp},
-                          protocol_version=PROTOCOL_VERSION, topology_event_refresh_window=0,
-                          status_event_refresh_window=0)
+        cluster = TestCluster(contact_points=(contact_point,), execution_profiles={EXEC_PROFILE_DEFAULT: hfp},
+                              topology_event_refresh_window=0,
+                              status_event_refresh_window=0)
         session = cluster.connect(wait_for_all_pools=True)
 
         queried_hosts = set()
@@ -84,7 +84,7 @@ class WhiteListRoundRobinPolicyTests(unittest.TestCase):
     def test_only_connects_to_subset(self):
         only_connect_hosts = {"127.0.0.1", "127.0.0.2"}
         white_list = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy(only_connect_hosts))
-        cluster = Cluster(execution_profiles={"white_list": white_list})
+        cluster = TestCluster(execution_profiles={"white_list": white_list})
         #cluster = Cluster(load_balancing_policy=WhiteListRoundRobinPolicy(only_connect_hosts))
         session = cluster.connect(wait_for_all_pools=True)
         queried_hosts = set()

--- a/tests/integration/standard/test_prepared_statements.py
+++ b/tests/integration/standard/test_prepared_statements.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from tests.integration import use_singledc, PROTOCOL_VERSION
+from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
 
 try:
     import unittest2 as unittest
@@ -22,7 +22,6 @@ except ImportError:
 from cassandra import InvalidRequest, DriverException
 
 from cassandra import ConsistencyLevel, ProtocolVersion
-from cassandra.cluster import Cluster
 from cassandra.query import PreparedStatement, UNSET_VALUE
 from tests.integration import (get_server_versions, greaterthanorequalcass40, greaterthanorequaldse50,
     requirecassandra, BasicSharedKeyspaceUnitTestCase)
@@ -44,8 +43,7 @@ class PreparedStatementTests(unittest.TestCase):
         cls.cass_version = get_server_versions()
 
     def setUp(self):
-        self.cluster = Cluster(metrics_enabled=True, protocol_version=PROTOCOL_VERSION,
-                               allow_beta_protocol_version=True)
+        self.cluster = TestCluster(metrics_enabled=True, allow_beta_protocol_version=True)
         self.session = self.cluster.connect()
 
     def tearDown(self):
@@ -517,7 +515,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.12
         @jira_ticket PYTHON-808
         """
-        one_cluster = Cluster(metrics_enabled=True, protocol_version=PROTOCOL_VERSION)
+        one_cluster = TestCluster(metrics_enabled=True)
         one_session = one_cluster.connect()
         self.addCleanup(one_cluster.shutdown)
 
@@ -557,7 +555,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.13
         @jira_ticket PYTHON-847
         """
-        cluster = Cluster(protocol_version=ProtocolVersion.V4)
+        cluster = TestCluster(protocol_version=ProtocolVersion.V4)
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 9)
@@ -571,7 +569,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.13
         @jira_ticket PYTHON-847
         """
-        cluster = Cluster(protocol_version=ProtocolVersion.V5)
+        cluster = TestCluster(protocol_version=ProtocolVersion.V5)
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 10)
@@ -586,7 +584,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.13
         @jira_ticket PYTHON-847
         """
-        cluster = Cluster(protocol_version=ProtocolVersion.DSE_V1)
+        cluster = TestCluster(protocol_version=ProtocolVersion.DSE_V1)
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 10)
@@ -601,7 +599,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.13
         @jira_ticket PYTHON-847
         """
-        cluster = Cluster(protocol_version=ProtocolVersion.DSE_V2)
+        cluster = TestCluster(protocol_version=ProtocolVersion.DSE_V2)
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 10)

--- a/tests/integration/standard/test_query_paging.py
+++ b/tests/integration/standard/test_query_paging.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from tests.integration import use_singledc, PROTOCOL_VERSION
+from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
 
 import logging
 log = logging.getLogger(__name__)
@@ -26,7 +26,7 @@ from six.moves import range
 from threading import Event
 
 from cassandra import ConsistencyLevel
-from cassandra.cluster import Cluster, EXEC_PROFILE_DEFAULT, ExecutionProfile
+from cassandra.cluster import EXEC_PROFILE_DEFAULT, ExecutionProfile
 from cassandra.concurrent import execute_concurrent, execute_concurrent_with_args
 from cassandra.policies import HostDistance
 from cassandra.query import SimpleStatement
@@ -44,8 +44,7 @@ class QueryPagingTests(unittest.TestCase):
                 "Protocol 2.0+ is required for Paging state, currently testing against %r"
                 % (PROTOCOL_VERSION,))
 
-        self.cluster = Cluster(
-            protocol_version=PROTOCOL_VERSION,
+        self.cluster = TestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(consistency_level=ConsistencyLevel.LOCAL_QUORUM)}
         )
         if PROTOCOL_VERSION < 3:

--- a/tests/integration/standard/test_routing.py
+++ b/tests/integration/standard/test_routing.py
@@ -21,9 +21,7 @@ from uuid import uuid1
 import logging
 log = logging.getLogger(__name__)
 
-from cassandra.cluster import Cluster
-
-from tests.integration import use_singledc, PROTOCOL_VERSION
+from tests.integration import use_singledc, TestCluster
 
 
 def setup_module():
@@ -38,7 +36,7 @@ class RoutingTests(unittest.TestCase):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.cluster = TestCluster()
         cls.session = cls.cluster.connect('test1rf')
 
     @classmethod

--- a/tests/integration/standard/test_row_factories.py
+++ b/tests/integration/standard/test_row_factories.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tests.integration import get_server_versions, use_singledc, PROTOCOL_VERSION, BasicSharedKeyspaceUnitTestCaseWFunctionTable, BasicSharedKeyspaceUnitTestCase, execute_until_pass
+from tests.integration import get_server_versions, use_singledc, \
+    BasicSharedKeyspaceUnitTestCaseWFunctionTable, BasicSharedKeyspaceUnitTestCase, execute_until_pass, TestCluster
 
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest # noqa
 
-from cassandra.cluster import Cluster, ResultSet, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ResultSet, ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.query import tuple_factory, named_tuple_factory, dict_factory, ordered_dict_factory
 from cassandra.util import OrderedDict
 
@@ -86,8 +87,9 @@ class RowFactoryTests(BasicSharedKeyspaceUnitTestCaseWFunctionTable):
         cls.select = "SELECT * FROM {0}.{1}".format(cls.ks_name, cls.ks_name)
 
     def _results_from_row_factory(self, row_factory):
-        cluster = Cluster(protocol_version=PROTOCOL_VERSION,
-                          execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=row_factory)})
+        cluster = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=row_factory)}
+        )
         with cluster:
             return cluster.connect().execute(self.select)
 
@@ -174,7 +176,7 @@ class NamedTupleFactoryAndNumericColNamesTests(unittest.TestCase):
     """
     @classmethod
     def setup_class(cls):
-        cls.cluster = Cluster(protocol_version=PROTOCOL_VERSION)
+        cls.cluster = TestCluster()
         cls.session = cls.cluster.connect()
         cls._cass_version, cls._cql_version = get_server_versions()
         ddl = '''
@@ -211,8 +213,9 @@ class NamedTupleFactoryAndNumericColNamesTests(unittest.TestCase):
         """
         can SELECT numeric column  using  dict_factory
         """
-        with Cluster(protocol_version=PROTOCOL_VERSION,
-                     execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}) as cluster:
+        with TestCluster(
+                execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
+        ) as cluster:
             try:
                 cluster.connect().execute('SELECT * FROM test1rf.table_num_col')
             except ValueError as e:

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -25,16 +25,16 @@ import six
 import cassandra
 from cassandra import InvalidRequest
 from cassandra import util
-from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.concurrent import execute_concurrent_with_args
 from cassandra.cqltypes import Int32Type, EMPTY
 from cassandra.query import dict_factory, ordered_dict_factory
 from cassandra.util import sortedset, Duration
 from tests.unit.cython.utils import cythontest
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, execute_until_pass, notprotocolv1, \
+from tests.integration import use_singledc, execute_until_pass, notprotocolv1, \
     BasicSharedKeyspaceUnitTestCase, greaterthancass21, lessthancass30, greaterthanorequaldse51, \
-    DSE_VERSION, greaterthanorequalcass3_10, requiredse
+    DSE_VERSION, greaterthanorequalcass3_10, requiredse, TestCluster
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES, COLLECTION_TYPES, PRIMITIVE_DATATYPES_KEYS, \
     get_sample, get_all_samples, get_collection_sample
 
@@ -136,7 +136,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         """
         Test insertion of all datatype primitives
         """
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name)
 
         # create table
@@ -217,7 +217,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         Test insertion of all collection types
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name)
         # use tuple encoding, to convert native python tuple into raw CQL
         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
@@ -449,7 +449,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name)
 
         # use this encoder in order to insert tuples
@@ -501,8 +501,9 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION,
-                    execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
+        c = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
+        )
         s = c.connect(self.keyspace_name)
 
         # set the encoder for tuples for the ability to write tuples
@@ -539,7 +540,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name)
         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
 
@@ -567,8 +568,9 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION,
-                    execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
+        c = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
+        )
         s = c.connect(self.keyspace_name)
 
         # set the encoder for tuples for the ability to write tuples
@@ -665,8 +667,9 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION,
-                    execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
+        c = TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
+        )
         s = c.connect(self.keyspace_name)
 
         # set the encoder for tuples for the ability to write tuples
@@ -1276,7 +1279,7 @@ class TypeTestsProtocol(BasicSharedKeyspaceUnitTestCase):
                 self.read_inserts_at_level(pvr)
 
     def read_inserts_at_level(self, proto_ver):
-        session = Cluster(protocol_version=proto_ver).connect(self.keyspace_name)
+        session = TestCluster(protocol_version=proto_ver).connect(self.keyspace_name)
         try:
             results = session.execute('select * from t')[0]
             self.assertEqual("[SortedSet([1, 2]), SortedSet([3, 5])]", str(results.v))
@@ -1294,7 +1297,7 @@ class TypeTestsProtocol(BasicSharedKeyspaceUnitTestCase):
             session.cluster.shutdown()
 
     def run_inserts_at_version(self, proto_ver):
-        session = Cluster(protocol_version=proto_ver).connect(self.keyspace_name)
+        session = TestCluster(protocol_version=proto_ver).connect(self.keyspace_name)
         try:
             p = session.prepare('insert into t (k, v) values (?, ?)')
             session.execute(p, (0, [{1, 2}, {3, 5}]))

--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -22,12 +22,12 @@ from functools import partial
 import six
 
 from cassandra import InvalidRequest
-from cassandra.cluster import Cluster, UserTypeDoesNotExist, ExecutionProfile, EXEC_PROFILE_DEFAULT
+from cassandra.cluster import UserTypeDoesNotExist, ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.query import dict_factory
 from cassandra.util import OrderedMap
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, execute_until_pass, \
-    BasicSegregatedKeyspaceUnitTestCase, greaterthancass20, lessthancass30, greaterthanorequalcass36
+from tests.integration import use_singledc, execute_until_pass, \
+    BasicSegregatedKeyspaceUnitTestCase, greaterthancass20, lessthancass30, greaterthanorequalcass36, TestCluster
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES, PRIMITIVE_DATATYPES_KEYS, \
     COLLECTION_TYPES, get_sample, get_collection_sample
 
@@ -79,7 +79,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the insertion of unprepared, registered UDTs
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         s.execute("CREATE TYPE user (age int, name text)")
@@ -123,7 +123,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the registration of UDTs before session creation
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(wait_for_all_pools=True)
 
         s.execute("""
@@ -144,7 +144,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         # now that types are defined, shutdown and re-create Cluster
         c.shutdown()
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
 
         User1 = namedtuple('user', ('age', 'name'))
         User2 = namedtuple('user', ('state', 'is_cool'))
@@ -181,7 +181,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the insertion of prepared, unregistered UDTs
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         s.execute("CREATE TYPE user (age int, name text)")
@@ -225,7 +225,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the insertion of prepared, registered UDTs
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         s.execute("CREATE TYPE user (age int, name text)")
@@ -275,7 +275,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the insertion of UDTs with null and empty string fields
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         s.execute("CREATE TYPE user (a text, b int, c uuid, d blob)")
@@ -305,7 +305,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test for ensuring extra-lengthy udts are properly inserted
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         max_test_length = 254
@@ -385,8 +385,9 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
             self.assertEqual(udt, result["v_{0}".format(i)])
 
     def _cluster_default_dict_factory(self):
-        return Cluster(protocol_version=PROTOCOL_VERSION,
-                       execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
+        return TestCluster(
+            execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
+        )
 
     def test_can_insert_nested_registered_udts(self):
         """
@@ -485,7 +486,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test for ensuring that an error is raised for operating on a nonexisting udt or an invalid keyspace
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
         User = namedtuple('user', ('age', 'name'))
 
@@ -505,7 +506,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test for inserting various types of PRIMITIVE_DATATYPES into UDT's
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         # create UDT
@@ -550,7 +551,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test for inserting various types of COLLECTION_TYPES into UDT's
         """
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         # create UDT
@@ -617,7 +618,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 3):
             raise unittest.SkipTest("Support for nested collections was introduced in Cassandra 2.1.3")
 
-        c = Cluster(protocol_version=PROTOCOL_VERSION)
+        c = TestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
 


### PR DESCRIPTION
From commit:
     - Add TestCluster class to integration tests to allow easier setting of default options and updated all call points
     - Removed setting __defaults__ on stuff
     - Changed a bunch of '4.0' checks to be '4.0-a'
     - Enabled materialized views, sasi, and transient replication in standard test startup options
     - Updated materialized views to specify not null for primary keys as required in 4.0
     - Added new protocol error message received from 4.0 in test_no_connection_refused_on_timeout
