### PR TITLE
CASSANDRA-15663 Add 'default' to a list of reserved keywords

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -49,7 +49,7 @@ log = logging.getLogger(__name__)
 cql_keywords = set((
     'add', 'aggregate', 'all', 'allow', 'alter', 'and', 'apply', 'as', 'asc', 'ascii', 'authorize', 'batch', 'begin',
     'bigint', 'blob', 'boolean', 'by', 'called', 'clustering', 'columnfamily', 'compact', 'contains', 'count',
-    'counter', 'create', 'custom', 'date', 'decimal', 'delete', 'desc', 'describe', 'deterministic', 'distinct', 'double', 'drop',
+    'counter', 'create', 'custom', 'date', 'decimal', 'default', 'delete', 'desc', 'describe', 'deterministic', 'distinct', 'double', 'drop',
     'entries', 'execute', 'exists', 'filtering', 'finalfunc', 'float', 'from', 'frozen', 'full', 'function',
     'functions', 'grant', 'if', 'in', 'index', 'inet', 'infinity', 'initcond', 'input', 'insert', 'int', 'into', 'is', 'json',
     'key', 'keys', 'keyspace', 'keyspaces', 'language', 'limit', 'list', 'login', 'map', 'materialized', 'modify', 'monotonic', 'nan', 'nologin',


### PR DESCRIPTION
Bug (reproducible in 3.11, 4.0):

```
cqlsh> CREATE KEYSPACE test1 WITH replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND durable_writes = true;
cqlsh> CREATE TABLE test1."default" (id text PRIMARY KEY, data text, etag text);
cqlsh> DESCRIBE TABLE test1.default ;

CREATE TABLE test1.default (
    id text PRIMARY KEY,
    data text,
    etag text
) WITH additional_write_policy = '99p'
    AND bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
    AND comment = ''
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
    AND crc_check_chance = 1.0
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND read_repair = 'BLOCKING'
    AND speculative_retry = '99p';

cqlsh> drop table test1."default";
cqlsh> CREATE TABLE test1.default (
   ...     id text PRIMARY KEY,
   ...     data text,
   ...     etag text
   ... ) WITH additional_write_policy = '99p'
   ...     AND bloom_filter_fp_chance = 0.01
   ...     AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
   ...     AND comment = ''
   ...     AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
   ...     AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
   ...     AND crc_check_chance = 1.0
   ...     AND default_time_to_live = 0
   ...     AND gc_grace_seconds = 864000
   ...     AND max_index_interval = 2048
   ...     AND memtable_flush_period_in_ms = 0
   ...     AND min_index_interval = 128
   ...     AND read_repair = 'BLOCKING'
   ...     AND speculative_retry = '99p';
SyntaxException: line 1:19 no viable alternative at input 'default' (CREATE TABLE test1.[default]...)
```

With this patch:

```
cqlsh>  CREATE TABLE test1."default" (id text PRIMARY KEY, data text, etag text);
cqlsh>  DESCRIBE TABLE test1."default" ;

CREATE TABLE test1."default" (
    id text PRIMARY KEY,
    data text,
    etag text
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
    AND comment = ''
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
    AND crc_check_chance = 1.0
    AND dclocal_read_repair_chance = 0.0
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND read_repair_chance = 0.0
    AND speculative_retry = '99p';

cqlsh> drop table test1."default";
cqlsh> CREATE TABLE test1."default" (
    id text PRIMARY KEY,
    data text,
    etag text
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'NONE'}
    AND comment = ''
    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy', 'max_threshold': '32', 'min_threshold': '4'}
    AND compression = {'chunk_length_in_kb': '16', 'class': 'org.apache.cassandra.io.compress.LZ4Compressor'}
    AND crc_check_chance = 1.0
    AND dclocal_read_repair_chance = 0.0
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND read_repair_chance = 0.0
    AND speculative_retry = '99p';
<no error>
```