### PR TITLE
Add changes to build aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,6 @@
 dist: xenial
-sudo: false
-
 language: python
-python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "pypy2.7-6.0"
-  - "pypy3.5"
+os: linux
 
 env:
   - CASS_DRIVER_NO_CYTHON=1
@@ -24,6 +16,7 @@ addons:
     - libev-dev
 
 install:
+  - pip install --upgrade setuptools
   - pip install tox-travis
   - if [[ $TRAVIS_PYTHON_VERSION != pypy3.5 ]]; then pip install lz4; fi
 
@@ -31,3 +24,38 @@ script:
   - tox
   - tox -e gevent_loop
   - tox -e eventlet_loop
+  - python setup.py bdist_wheel
+jobs:
+  include:
+    - arch: amd64
+      python: "pypy2.7-6.0"
+
+    - arch: amd64
+      python: "pypy3.5"
+
+    - arch: amd64
+      python: "3.5"
+
+    - arch: amd64
+      python: "2.7"
+
+    - arch: amd64
+      python: "3.6"
+
+    - arch: amd64
+      python: "3.7"
+
+    - arch: arm64
+      python: "3.8"
+    
+    - arch: arm64
+      python: "3.5"
+    
+    - arch: arm64
+      python: "3.6"
+
+    - arch: arm64
+      python: "3.7"
+
+    - arch: arm64
+      python: "2.7"

--- a/diff.out
+++ b/diff.out
@@ -1,0 +1,79 @@
+diff --git a/.travis.yml b/.travis.yml
+index b485e212..a23cbed8 100644
+--- a/.travis.yml
++++ b/.travis.yml
+@@ -1,14 +1,6 @@
+ dist: xenial
+-sudo: false
+-
+ language: python
+-python:
+-  - "2.7"
+-  - "3.5"
+-  - "3.6"
+-  - "3.7"
+-  - "pypy2.7-6.0"
+-  - "pypy3.5"
++os: linux
+ 
+ env:
+   - CASS_DRIVER_NO_CYTHON=1
+@@ -24,6 +16,7 @@ addons:
+     - libev-dev
+ 
+ install:
++  - pip install --upgrade setuptools
+   - pip install tox-travis
+   - if [[ $TRAVIS_PYTHON_VERSION != pypy3.5 ]]; then pip install lz4; fi
+ 
+@@ -31,3 +24,38 @@ script:
+   - tox
+   - tox -e gevent_loop
+   - tox -e eventlet_loop
++  - python setup.py bdist_wheel
++jobs:
++  include:
++    - arch: amd64
++      python: "pypy2.7-6.0"
++
++    - arch: amd64
++      python: "pypy3.5"
++
++    - arch: amd64
++      python: "3.5"
++
++    - arch: amd64
++      python: "2.7"
++
++    - arch: amd64
++      python: "3.6"
++
++    - arch: amd64
++      python: "3.7"
++
++    - arch: arm64
++      python: "3.8"
++    
++    - arch: arm64
++      python: "3.5"
++    
++    - arch: arm64
++      python: "3.6"
++
++    - arch: arm64
++      python: "3.7"
++
++    - arch: arm64
++      python: "2.7"
+diff --git a/tox.ini b/tox.ini
+index d883a1f9..6d94e112 100644
+--- a/tox.ini
++++ b/tox.ini
+@@ -12,6 +12,7 @@ deps = nose
+        pure-sasl
+        kerberos
+        futurist
++       greenlet>=0.4.14,<0.4.17
+ lz4_dependency = py27,py35,py36,py37,py38: lz4
+ 
+ [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps = nose
        pure-sasl
        kerberos
        futurist
+       greenlet>=0.4.14,<0.4.17
 
 lz4_dependency = py27,py35,py36,py37,py38: lz4
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps = nose
        pure-sasl
        kerberos
        futurist
+
 lz4_dependency = py27,py35,py36,py37,py38: lz4
 
 [testenv]


### PR DESCRIPTION
This PR addresses the issue to build aarch64 wheels. To address this issue, I updated `travis.yml` to include `aarch64`. 

Also there were two additional errors (https://travis-ci.com/github/tbbharaj/python-driver/builds/229569631) I encountered when I triggered master build w/o any changes.
1. On python: pypy2.7-6.0:
   Ref: https://travis-ci.com/github/tbbharaj/python-driver/jobs/515470491

```
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-9Ah7r6/lz4/
371The command "if [[ $TRAVIS_PYTHON_VERSION != pypy3.5 ]]; then pip install lz4; fi" failed and exited with 1 during .
```

2. On Python: 3.7
    Ref: https://travis-ci.com/github/tbbharaj/python-driver/jobs/515470490

```
ERROR: InvocationError for command /home/travis/build/tbbharaj/python-driver/.tox/gevent_loop/bin/nosetests --verbosity=2 --no-path-adjustment /home/travis/build/tbbharaj/python-driver/tests/unit/io/test_geventreactor.py (exited with code -11 (SIGSEGV)) (exited with code -11)
939___________________________________ summary ____________________________________
940ERROR:   gevent_loop: commands failed
941The command "tox -e gevent_loop" exited with 1.
```

To fix above two errors, I made following changes:
1. Update setup tools in `travis.yml` to fix build error in `python setup.py egg_info`, 
2. Update greenlet version in `tox.ini` to fix build error in `tox -e gevent_loop`

Successful build log: https://travis-ci.com/github/tbbharaj/python-driver/builds/229656900

If there are any questions/comments - I'd be happy fix things as needed.

Thank you
Tanveen