### PR TITLE
ResultSet: handle empty non-final pages on ResultSet iteration

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -5141,6 +5141,7 @@ class ResultSet(object):
         if not self.response_future._continuous_paging_session:
             self.fetch_next_page()
             self._page_iter = iter(self._current_rows)
+            return self.next()
 
         return next(self._page_iter)
 

--- a/tests/unit/test_resultset.py
+++ b/tests/unit/test_resultset.py
@@ -41,6 +41,19 @@ class ResultSetTests(unittest.TestCase):
         type(response_future).has_more_pages = PropertyMock(side_effect=(True, True, False))  # after init to avoid side effects being consumed by init
         self.assertListEqual(list(itr), expected)
 
+    def test_iter_paged_with_empty_pages(self):
+        expected = list(range(10))
+        response_future = Mock(has_more_pages=True, _continuous_paging_session=None)
+        response_future.result.side_effect = [
+            ResultSet(Mock(), []),
+            ResultSet(Mock(), [0, 1, 2, 3, 4]),
+            ResultSet(Mock(), []),
+            ResultSet(Mock(), [5, 6, 7, 8, 9]),
+        ]
+        rs = ResultSet(response_future, [])
+        itr = iter(rs)
+        self.assertListEqual(list(itr), expected)
+
     def test_list_non_paged(self):
         # list access on RS for backwards-compatibility
         expected = list(range(10))


### PR DESCRIPTION
This commit provides a fix to the situation when iterating on a
ResultSet, the driver aborts the iteration if the server returns
an empty page even if there are next pages available.

Python driver is affected by the same problem as JAVA-2934
This fix is similar to https://github.com/datastax/java-driver/pull/1544