### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/tests/integration/cqlengine/management/test_compaction_settings.py
+++ b/tests/integration/cqlengine/management/test_compaction_settings.py
@@ -83,7 +83,7 @@ class AlterTableTest(BaseCassEngTestCase):
 
         table_meta = _get_table_metadata(tmp)
 
-        self.assertRegexpMatches(table_meta.export_as_string(), '.*SizeTieredCompactionStrategy.*')
+        six.assertRegex(self, table_meta.export_as_string(), '.*SizeTieredCompactionStrategy.*')
 
     def test_alter_options(self):
 
@@ -97,11 +97,11 @@ class AlterTableTest(BaseCassEngTestCase):
         drop_table(AlterTable)
         sync_table(AlterTable)
         table_meta = _get_table_metadata(AlterTable)
-        self.assertRegexpMatches(table_meta.export_as_string(), ".*'sstable_size_in_mb': '64'.*")
+        six.assertRegex(self, table_meta.export_as_string(), ".*'sstable_size_in_mb': '64'.*")
         AlterTable.__options__['compaction']['sstable_size_in_mb'] = '128'
         sync_table(AlterTable)
         table_meta = _get_table_metadata(AlterTable)
-        self.assertRegexpMatches(table_meta.export_as_string(), ".*'sstable_size_in_mb': '128'.*")
+        six.assertRegex(self, table_meta.export_as_string(), ".*'sstable_size_in_mb': '128'.*")
 
 
 class OptionsTest(BaseCassEngTestCase):

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import unittest
 
+import six
 import mock
 import logging
 from packaging.version import Version
@@ -261,7 +262,7 @@ class TablePropertiesTests(BaseCassEngTestCase):
         option = 'no way will this ever be an option'
         try:
             ModelWithTableProperties.__options__[option] = 'what was I thinking?'
-            self.assertRaisesRegexp(KeyError, "Invalid table option.*%s.*" % option, sync_table, ModelWithTableProperties)
+            six.assertRaisesRegex(self, KeyError, "Invalid table option.*%s.*" % option, sync_table, ModelWithTableProperties)
         finally:
             ModelWithTableProperties.__options__.pop(option, None)
 

--- a/tests/integration/cqlengine/model/test_class_construction.py
+++ b/tests/integration/cqlengine/model/test_class_construction.py
@@ -15,6 +15,7 @@
 from uuid import uuid4
 import warnings
 
+import six
 from cassandra.cqlengine import columns, CQLEngineException
 from cassandra.cqlengine.models import Model, ModelException, ModelDefinitionException, ColumnQueryEvaluator
 from cassandra.cqlengine.query import ModelQuerySet, DMLQuery
@@ -91,7 +92,7 @@ class TestModelClassFunction(BaseCassEngTestCase):
         Tests that trying to create conflicting db column names will fail
         """
 
-        with self.assertRaisesRegexp(ModelException, r".*more than once$"):
+        with six.assertRaisesRegex(self, ModelException, r".*more than once$"):
             class BadNames(Model):
                 words = columns.Text(primary_key=True)
                 content = columns.Text(db_field='words')

--- a/tests/integration/cqlengine/test_batch_query.py
+++ b/tests/integration/cqlengine/test_batch_query.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import warnings
 
+import six
 import sure
 
 from cassandra.cqlengine import columns
@@ -223,7 +224,7 @@ class BatchQueryCallbacksTests(BaseCassEngTestCase):
                 batch.execute()
             batch.execute()
         self.assertEqual(len(w), 2)  # package filter setup to warn always
-        self.assertRegexpMatches(str(w[0].message), r"^Batch.*multiple.*")
+        six.assertRegex(self, str(w[0].message), r"^Batch.*multiple.*")
 
     def test_disable_multiple_callback_warning(self):
         """

--- a/tests/integration/long/test_ipv6.py
+++ b/tests/integration/long/test_ipv6.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os, socket, errno
+import six
 from ccmlib import common
 
 from cassandra.cluster import NoHostAvailable
@@ -82,7 +83,7 @@ class IPV6ConnectionTest(object):
     def test_error(self):
         cluster = TestCluster(connection_class=self.connection_class, contact_points=['::1'], port=9043,
                               connect_timeout=10)
-        self.assertRaisesRegexp(NoHostAvailable, '\(\'Unable to connect.*%s.*::1\', 9043.*Connection refused.*'
+        six.assertRaisesRegex(self, NoHostAvailable, '\(\'Unable to connect.*%s.*::1\', 9043.*Connection refused.*'
                                 % errno.ECONNREFUSED, cluster.connect)
 
     def test_error_multiple(self):
@@ -90,7 +91,7 @@ class IPV6ConnectionTest(object):
             raise unittest.SkipTest('localhost only resolves one address')
         cluster = TestCluster(connection_class=self.connection_class, contact_points=['localhost'], port=9043,
                               connect_timeout=10)
-        self.assertRaisesRegexp(NoHostAvailable, '\(\'Unable to connect.*Tried connecting to \[\(.*\(.*\].*Last error',
+        six.assertRaisesRegex(self, NoHostAvailable, '\(\'Unable to connect.*Tried connecting to \[\(.*\(.*\].*Last error',
                                 cluster.connect)
 
 

--- a/tests/integration/simulacron/test_connection.py
+++ b/tests/integration/simulacron/test_connection.py
@@ -14,6 +14,7 @@
 import unittest
 
 import logging
+import six
 import time
 
 from mock import Mock, patch
@@ -262,7 +263,7 @@ class ConnectionTests(SimulacronBase):
         prime_request(PrimeOptions(then={"result": "no_result", "delay_in_ms": never}))
         prime_request(RejectConnections("unbind"))
 
-        self.assertRaisesRegexp(OperationTimedOut, "Connection defunct by heartbeat", future.result)
+        six.assertRaisesRegex(self, OperationTimedOut, "Connection defunct by heartbeat", future.result)
 
     def test_close_when_query(self):
         """

--- a/tests/integration/standard/test_authentication.py
+++ b/tests/integration/standard/test_authentication.py
@@ -15,6 +15,7 @@
 import logging
 import time
 
+import six
 from cassandra.cluster import NoHostAvailable
 from cassandra.auth import PlainTextAuthProvider, SASLClient, SaslAuthProvider
 
@@ -112,7 +113,7 @@ class AuthenticationTests(unittest.TestCase):
     def test_connect_wrong_pwd(self):
         cluster = self.cluster_as('cassandra', 'wrong_pass')
         try:
-            self.assertRaisesRegexp(NoHostAvailable,
+            six.assertRaisesRegex(self, NoHostAvailable,
                                     '.*AuthenticationFailed.',
                                     cluster.connect)
             assert_quiescent_pool_state(self, cluster)
@@ -122,7 +123,7 @@ class AuthenticationTests(unittest.TestCase):
     def test_connect_wrong_username(self):
         cluster = self.cluster_as('wrong_user', 'cassandra')
         try:
-            self.assertRaisesRegexp(NoHostAvailable,
+            six.assertRaisesRegex(self, NoHostAvailable,
                                     '.*AuthenticationFailed.*',
                                     cluster.connect)
             assert_quiescent_pool_state(self, cluster)
@@ -132,7 +133,7 @@ class AuthenticationTests(unittest.TestCase):
     def test_connect_empty_pwd(self):
         cluster = self.cluster_as('Cassandra', '')
         try:
-            self.assertRaisesRegexp(NoHostAvailable,
+            six.assertRaisesRegex(self, NoHostAvailable,
                                     '.*AuthenticationFailed.*',
                                     cluster.connect)
             assert_quiescent_pool_state(self, cluster)
@@ -142,7 +143,7 @@ class AuthenticationTests(unittest.TestCase):
     def test_connect_no_auth_provider(self):
         cluster = TestCluster()
         try:
-            self.assertRaisesRegexp(NoHostAvailable,
+            six.assertRaisesRegex(self, NoHostAvailable,
                                     '.*AuthenticationFailed.*',
                                     cluster.connect)
             assert_quiescent_pool_state(self, cluster)

--- a/tests/integration/standard/test_client_warnings.py
+++ b/tests/integration/standard/test_client_warnings.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+import six
 from cassandra.query import BatchStatement
 
 from tests.integration import use_singledc, PROTOCOL_VERSION, local, TestCluster
@@ -70,7 +71,7 @@ class ClientWarningTests(unittest.TestCase):
         future = self.session.execute_async(self.warn_batch)
         future.result()
         self.assertEqual(len(future.warnings), 1)
-        self.assertRegexpMatches(future.warnings[0], 'Batch.*exceeding.*')
+        six.assertRegex(self, future.warnings[0], 'Batch.*exceeding.*')
 
     def test_warning_with_trace(self):
         """
@@ -86,7 +87,7 @@ class ClientWarningTests(unittest.TestCase):
         future = self.session.execute_async(self.warn_batch, trace=True)
         future.result()
         self.assertEqual(len(future.warnings), 1)
-        self.assertRegexpMatches(future.warnings[0], 'Batch.*exceeding.*')
+        six.assertRegex(self, future.warnings[0], 'Batch.*exceeding.*')
         self.assertIsNotNone(future.get_query_trace())
 
     @local
@@ -105,7 +106,7 @@ class ClientWarningTests(unittest.TestCase):
         future = self.session.execute_async(self.warn_batch, custom_payload=payload)
         future.result()
         self.assertEqual(len(future.warnings), 1)
-        self.assertRegexpMatches(future.warnings[0], 'Batch.*exceeding.*')
+        six.assertRegex(self, future.warnings[0], 'Batch.*exceeding.*')
         self.assertDictEqual(future.custom_payload, payload)
 
     @local
@@ -124,6 +125,6 @@ class ClientWarningTests(unittest.TestCase):
         future = self.session.execute_async(self.warn_batch, trace=True, custom_payload=payload)
         future.result()
         self.assertEqual(len(future.warnings), 1)
-        self.assertRegexpMatches(future.warnings[0], 'Batch.*exceeding.*')
+        six.assertRegex(self, future.warnings[0], 'Batch.*exceeding.*')
         self.assertIsNotNone(future.get_query_trace())
         self.assertDictEqual(future.custom_payload, payload)

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -23,6 +23,7 @@ import logging
 import warnings
 from packaging.version import Version
 
+import six
 import cassandra
 from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT, ControlConnection, Cluster
 from cassandra.concurrent import execute_concurrent
@@ -147,7 +148,7 @@ class ClusterTests(unittest.TestCase):
         get_node(1).pause()
         cluster = TestCluster(contact_points=['127.0.0.1'], connect_timeout=1)
 
-        with self.assertRaisesRegexp(NoHostAvailable, "OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
+        with six.assertRaisesRegex(self, NoHostAvailable, "OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
             cluster.connect()
         cluster.shutdown()
 
@@ -535,7 +536,7 @@ class ClusterTests(unittest.TestCase):
             # cluster agreement wait used for refresh
             original_meta = c.metadata.keyspaces
             start_time = time.time()
-            self.assertRaisesRegexp(Exception, r"Schema metadata was not refreshed.*", c.refresh_schema_metadata)
+            six.assertRaisesRegex(self, Exception, r"Schema metadata was not refreshed.*", c.refresh_schema_metadata)
             end_time = time.time()
             self.assertGreaterEqual(end_time - start_time, agreement_timeout)
             self.assertIs(original_meta, c.metadata.keyspaces)
@@ -572,7 +573,7 @@ class ClusterTests(unittest.TestCase):
             # refresh wait overrides cluster value
             original_meta = c.metadata.keyspaces
             start_time = time.time()
-            self.assertRaisesRegexp(Exception, r"Schema metadata was not refreshed.*", c.refresh_schema_metadata,
+            six.assertRaisesRegex(self, Exception, r"Schema metadata was not refreshed.*", c.refresh_schema_metadata,
                                     max_schema_agreement_wait=agreement_timeout)
             end_time = time.time()
             self.assertGreaterEqual(end_time - start_time, agreement_timeout)

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -1590,7 +1590,7 @@ class FunctionMetadata(FunctionTest):
 
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*%s\(\) .*" % kwargs['name'])
+            six.assertRegex(self, fn_meta.as_cql_query(), "CREATE FUNCTION.*%s\(\) .*" % kwargs['name'])
 
     def test_functions_follow_keyspace_alter(self):
         """
@@ -1638,12 +1638,12 @@ class FunctionMetadata(FunctionTest):
         kwargs['called_on_null_input'] = True
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) CALLED ON NULL INPUT RETURNS .*")
+            six.assertRegex(self, fn_meta.as_cql_query(), "CREATE FUNCTION.*\) CALLED ON NULL INPUT RETURNS .*")
 
         kwargs['called_on_null_input'] = False
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
+            six.assertRegex(self, fn_meta.as_cql_query(), "CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
 
 
 class AggregateMetadata(FunctionTest):

--- a/tests/integration/standard/test_single_interface.py
+++ b/tests/integration/standard/test_single_interface.py
@@ -71,4 +71,4 @@ class SingleInterfaceTest(unittest.TestCase):
                                                  consistency_level=ConsistencyLevel.ALL))
 
         for pool in self.session.get_pools():
-            self.assertEquals(1, pool.get_state()['open_count'])
+            self.assertEqual(1, pool.get_state()['open_count'])

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -69,7 +69,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
                 msg = r'.*Invalid STRING constant \(.*?\) for "b" of type blob.*'
             else:
                 msg = r'.*Invalid STRING constant \(.*?\) for b of type blob.*'
-            self.assertRaisesRegexp(InvalidRequest, msg, s.execute, query, params)
+            six.assertRaisesRegex(self, InvalidRequest, msg, s.execute, query, params)
             return
 
         # In python2, with Cassandra < 2.0, we can manually encode the 'byte str' type as hex for insertion in a blob.
@@ -1060,7 +1060,7 @@ class TestDateRangePrepared(AbstractDateRangeTest, BasicSharedKeyspaceUnitTestCa
             results =  self.session.execute(prep_sel)
 
         dr = results[0].dr
-        # sometimes this is truncated in the assertEquals output on failure;
+        # sometimes this is truncated in the assertEqual output on failure;
         if isinstance(expected, six.string_types):
             self.assertEqual(str(dr), expected)
         else:
@@ -1114,7 +1114,7 @@ class TestDateRangeSimple(AbstractDateRangeTest, BasicSharedKeyspaceUnitTestCase
         results= self.session.execute("SELECT * FROM tab WHERE dr = '{0}' ".format(to_insert))
 
         dr = results[0].dr
-        # sometimes this is truncated in the assertEquals output on failure;
+        # sometimes this is truncated in the assertEqual output on failure;
         if isinstance(expected, six.string_types):
             self.assertEqual(str(dr), expected)
         else:

--- a/tests/unit/advanced/test_graph.py
+++ b/tests/unit/advanced/test_graph.py
@@ -259,7 +259,7 @@ class GraphOptionTests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             GraphOptions(unknown_param=42)
         self.assertEqual(len(w), 1)
-        self.assertRegexpMatches(str(w[0].message), r"^Unknown keyword.*GraphOptions.*")
+        six.assertRegex(self, str(w[0].message), r"^Unknown keyword.*GraphOptions.*")
 
     def test_update(self):
         opts = GraphOptions(**self.api_params)

--- a/tests/unit/cqlengine/test_connection.py
+++ b/tests/unit/cqlengine/test_connection.py
@@ -14,6 +14,8 @@
 
 import unittest
 
+import six
+
 from cassandra.cluster import _ConfigMode
 from cassandra.cqlengine import connection
 from cassandra.query import dict_factory
@@ -50,12 +52,12 @@ class ConnectionTest(unittest.TestCase):
         """
         Users can't get the default session without having a default connection set.
         """
-        with self.assertRaisesRegexp(connection.CQLEngineException, self.no_registered_connection_msg):
+        with six.assertRaisesRegex(self, connection.CQLEngineException, self.no_registered_connection_msg):
             connection.get_session(connection=None)
 
     def test_get_cluster_fails_without_existing_connection(self):
         """
         Users can't get the default cluster without having a default connection set.
         """
-        with self.assertRaisesRegexp(connection.CQLEngineException, self.no_registered_connection_msg):
+        with six.assertRaisesRegex(self, connection.CQLEngineException, self.no_registered_connection_msg):
             connection.get_cluster(connection=None)

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -392,7 +392,7 @@ class ConnectionHeartbeatTest(unittest.TestCase):
         connection.defunct.assert_has_calls([call(ANY)] * get_holders.call_count)
         exc = connection.defunct.call_args_list[0][0][0]
         self.assertIsInstance(exc, ConnectionException)
-        self.assertRegexpMatches(exc.args[0], r'^Received unexpected response to OptionsMessage.*')
+        six.assertRegex(self, exc.args[0], r'^Received unexpected response to OptionsMessage.*')
         holder.return_connection.assert_has_calls(
             [call(connection)] * get_holders.call_count)
 

--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -526,7 +526,7 @@ class ControlConnectionTest(unittest.TestCase):
         self.assertEqual(self.cluster.added_hosts[0].broadcast_rpc_address, "192.168.1.3")
         self.assertEqual(self.cluster.added_hosts[0].broadcast_rpc_port, 555)
         self.assertEqual(self.cluster.added_hosts[0].broadcast_address, "10.0.0.3")
-        self.assertEquals(self.cluster.added_hosts[0].broadcast_port, 666)
+        self.assertEqual(self.cluster.added_hosts[0].broadcast_port, 666)
         self.assertEqual(self.cluster.added_hosts[0].datacenter, "dc1")
         self.assertEqual(self.cluster.added_hosts[0].rack, "rack1")
 
@@ -546,7 +546,7 @@ class ControlConnectionTest(unittest.TestCase):
         self.assertEqual(self.cluster.added_hosts[0].broadcast_rpc_address, "192.168.1.3")
         self.assertEqual(self.cluster.added_hosts[0].broadcast_rpc_port, None)
         self.assertEqual(self.cluster.added_hosts[0].broadcast_address, "10.0.0.3")
-        self.assertEquals(self.cluster.added_hosts[0].broadcast_port, None)
+        self.assertEqual(self.cluster.added_hosts[0].broadcast_port, None)
         self.assertEqual(self.cluster.added_hosts[0].datacenter, "dc1")
         self.assertEqual(self.cluster.added_hosts[0].rack, "rack1")
 

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1298,7 +1298,7 @@ class HostFilterPolicyInitTest(unittest.TestCase):
         expected_message_regex = "can't set attribute"
         hfp = HostFilterPolicy(child_policy=Mock(name='child_policy'),
                                predicate=Mock(name='predicate'))
-        with self.assertRaisesRegexp(AttributeError, expected_message_regex):
+        with six.assertRaisesRegex(self, AttributeError, expected_message_regex):
             hfp.predicate = object()
 
 

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -14,6 +14,7 @@
 
 import unittest
 
+import six
 from mock import Mock
 
 from cassandra import ProtocolVersion, UnsupportedOperation
@@ -172,7 +173,7 @@ class MessageTest(unittest.TestCase):
         keyspace_message = QueryMessage('a', consistency_level=3, keyspace='ks')
         io = Mock(name='io')
 
-        with self.assertRaisesRegexp(UnsupportedOperation, 'Keyspaces.*set'):
+        with six.assertRaisesRegex(self, UnsupportedOperation, 'Keyspaces.*set'):
             keyspace_message.send_body(io, protocol_version=4)
         io.assert_not_called()
 

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -16,6 +16,8 @@ import unittest
 
 from collections import deque
 from threading import RLock
+
+import six
 from mock import Mock, MagicMock, ANY
 
 from cassandra import ConsistencyLevel, Unavailable, SchemaTargetType, SchemaChangeType, OperationTimedOut
@@ -158,7 +160,7 @@ class ResponseFutureTests(unittest.TestCase):
 
         # Simulate ResponseFuture timing out
         rf._on_timeout()
-        self.assertRaisesRegexp(OperationTimedOut, "Connection defunct by heartbeat", rf.result)
+        six.assertRaisesRegex(self, OperationTimedOut, "Connection defunct by heartbeat", rf.result)
 
     def test_read_timeout_error_message(self):
         session = self.make_session()

--- a/tests/unit/test_timestamps.py
+++ b/tests/unit/test_timestamps.py
@@ -15,6 +15,7 @@
 import unittest
 
 import mock
+import six
 
 from cassandra import timestamps
 from threading import Thread, Lock
@@ -105,7 +106,7 @@ class TestTimestampGeneratorLogging(unittest.TestCase):
         last_warn_args, last_warn_kwargs = call
         self.assertEqual(len(last_warn_args), 1)
         self.assertEqual(len(last_warn_kwargs), 0)
-        self.assertRegexpMatches(
+        six.assertRegex(self,
             last_warn_args[0],
             pattern,
         )


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268 .