### PR TITLE
fir(test/__init__.py): Ignoring DeprecationWarning from "cassandra.io.asyncioreactor"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
 geomet>=0.1,<0.3
-six >=1.9
-futures <=2.2.0
-# Futures is not required for Python 3, but it works up through 2.2.0 (after which it introduced breaking syntax).
-# This is left here to make sure install -r works with any runtime. When installing via setup.py, futures is omitted
-# for Python 3, in favor of the standard library implementation.
-# see PYTHON-393
+six
+futures; python_version < '3.0'

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -75,7 +75,7 @@ def get_server_versions():
     if cass_version is not None:
         return (cass_version, cql_version)
 
-    c = TestCluster()
+    c = IntegrationTestCluster()
     s = c.connect()
     row = s.execute('SELECT cql_version, release_version FROM system.local')[0]
 
@@ -706,9 +706,9 @@ def setup_keyspace(ipformat=None, wait=True, protocol_version=None):
         _protocol_version = PROTOCOL_VERSION
 
     if not ipformat:
-        cluster = TestCluster(protocol_version=_protocol_version)
+        cluster = IntegrationTestCluster(protocol_version=_protocol_version)
     else:
-        cluster = TestCluster(contact_points=["::1"], protocol_version=_protocol_version)
+        cluster = IntegrationTestCluster(contact_points=["::1"], protocol_version=_protocol_version)
     session = cluster.connect()
 
     try:
@@ -802,7 +802,7 @@ class BasicKeyspaceUnitTestCase(unittest.TestCase):
 
     @classmethod
     def common_setup(cls, rf, keyspace_creation=True, create_class_table=False, **cluster_kwargs):
-        cls.cluster = TestCluster(**cluster_kwargs)
+        cls.cluster = IntegrationTestCluster(**cluster_kwargs)
         cls.session = cls.cluster.connect(wait_for_all_pools=True)
         cls.ks_name = cls.__name__.lower()
         if keyspace_creation:
@@ -990,7 +990,7 @@ def assert_startswith(s, prefix):
         )
 
 
-class TestCluster(object):
+class IntegrationTestCluster(object):
     DEFAULT_PROTOCOL_VERSION = default_protocol_version
     DEFAULT_CASSANDRA_IP = CASSANDRA_IP
     DEFAULT_ALLOW_BETA = ALLOW_BETA_PROTOCOL

--- a/tests/integration/advanced/__init__.py
+++ b/tests/integration/advanced/__init__.py
@@ -26,7 +26,7 @@ from os.path import expanduser
 from ccmlib import common
 
 from tests.integration import get_server_versions, BasicKeyspaceUnitTestCase, \
-    drop_keyspace_shutdown_cluster, get_node, USE_CASS_EXTERNAL, TestCluster
+    drop_keyspace_shutdown_cluster, get_node, USE_CASS_EXTERNAL, IntegrationTestCluster
 from tests.integration import use_singledc, use_single_node, wait_for_node_socket, CASSANDRA_IP
 
 home = expanduser('~')
@@ -106,7 +106,7 @@ def use_cluster_with_graph(num_nodes):
     # Wait for spark master to start up
     spark_master_http = ("localhost", 7080)
     common.check_socket_listening(spark_master_http, timeout=60)
-    tmp_cluster = TestCluster()
+    tmp_cluster = IntegrationTestCluster()
 
     # Start up remaining nodes.
     try:
@@ -134,7 +134,7 @@ class BasicGeometricUnitTestCase(BasicKeyspaceUnitTestCase):
 
     @classmethod
     def common_dse_setup(cls, rf, keyspace_creation=True):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect()
         cls.ks_name = cls.__name__.lower()
         if keyspace_creation:

--- a/tests/integration/advanced/graph/__init__.py
+++ b/tests/integration/advanced/graph/__init__.py
@@ -160,7 +160,7 @@ class BasicGraphUnitTestCase(BasicKeyspaceUnitTestCase):
             )
         )
 
-        self.cluster = TestCluster(execution_profiles={
+        self.cluster = IntegrationTestCluster(execution_profiles={
             EXEC_PROFILE_GRAPH_DEFAULT: ep_graphson1,
             EXEC_PROFILE_GRAPH_ANALYTICS_DEFAULT: ep_analytics,
             "graphson1": ep_graphson1,
@@ -275,7 +275,7 @@ class GraphUnitTestCase(BasicKeyspaceUnitTestCase):
             )
         )
 
-        self.cluster = TestCluster(execution_profiles={
+        self.cluster = IntegrationTestCluster(execution_profiles={
             EXEC_PROFILE_GRAPH_DEFAULT: ep_graphson1,
             EXEC_PROFILE_GRAPH_ANALYTICS_DEFAULT: ep_analytics,
             "graphson1": ep_graphson1,
@@ -360,7 +360,7 @@ class BasicSharedGraphUnitTestCase(BasicKeyspaceUnitTestCase):
 
     @classmethod
     def session_setup(cls):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect()
         cls.ks_name = cls.__name__.lower()
         cls.cass_version, cls.cql_version = get_server_versions()

--- a/tests/integration/advanced/graph/test_graph.py
+++ b/tests/integration/advanced/graph/test_graph.py
@@ -25,7 +25,7 @@ from cassandra.graph import single_object_row_factory, Vertex, graph_object_row_
 from cassandra.util import SortedSet
 
 from tests.integration import DSE_VERSION, greaterthanorequaldse51, greaterthanorequaldse68, \
-    requiredse, TestCluster
+    requiredse, IntegrationTestCluster
 from tests.integration.advanced.graph import BasicGraphUnitTestCase, GraphUnitTestCase, \
     GraphProtocol, ClassicGraphSchema, CoreGraphSchema, use_single_node_with_graph
 
@@ -150,7 +150,7 @@ class GraphProfileTests(BasicGraphUnitTestCase):
         exec_short_timeout.graph_options.graph_name = self.graph_name
 
         # Add a single execution policy on cluster creation
-        local_cluster = TestCluster(execution_profiles={"exec_dif_factory": exec_dif_factory})
+        local_cluster = IntegrationTestCluster(execution_profiles={"exec_dif_factory": exec_dif_factory})
         local_session = local_cluster.connect()
         self.addCleanup(local_cluster.shutdown)
 

--- a/tests/integration/advanced/test_adv_metadata.py
+++ b/tests/integration/advanced/test_adv_metadata.py
@@ -18,7 +18,7 @@ from tests.integration import (BasicExistingKeyspaceUnitTestCase, BasicSharedKey
                                BasicSharedKeyspaceUnitTestCaseRF1,
                                greaterthanorequaldse51, greaterthanorequaldse60,
                                greaterthanorequaldse68, use_single_node,
-                               DSE_VERSION, requiredse, TestCluster)
+                               DSE_VERSION, requiredse, IntegrationTestCluster)
 
 try:
     import unittest2 as unittest
@@ -392,4 +392,4 @@ class GraphMetadataSchemaErrorTests(BasicExistingKeyspaceUnitTestCase):
         """ % (self.ks_name,))
 
         self.session.execute('TRUNCATE system_schema.vertices')
-        TestCluster().connect().shutdown()
+        IntegrationTestCluster().connect().shutdown()

--- a/tests/integration/advanced/test_auth.py
+++ b/tests/integration/advanced/test_auth.py
@@ -30,7 +30,7 @@ from cassandra.cluster import EXEC_PROFILE_GRAPH_DEFAULT, NoHostAvailable
 from cassandra.protocol import Unauthorized
 from cassandra.query import SimpleStatement
 from tests.integration import (get_cluster, greaterthanorequaldse51,
-                               remove_cluster, requiredse, DSE_VERSION, TestCluster)
+                               remove_cluster, requiredse, DSE_VERSION, IntegrationTestCluster)
 from tests.integration.advanced import ADS_HOME, use_single_node_with_graph
 from tests.integration.advanced.graph import reset_graph, ClassicGraphFixtures
 
@@ -158,7 +158,7 @@ class BasicDseAuthTest(unittest.TestCase):
         Runs a simple system query with the auth_provided specified.
         """
         os.environ['KRB5_CONFIG'] = self.krb_conf
-        self.cluster = TestCluster(auth_provider=auth_provider)
+        self.cluster = IntegrationTestCluster(auth_provider=auth_provider)
         self.session = self.cluster.connect()
         query = query if query else "SELECT * FROM system.local"
         statement = SimpleStatement(query)
@@ -321,7 +321,7 @@ class BasicDseAuthTest(unittest.TestCase):
         os.environ['KRB5_CONFIG'] = self.krb_conf
         self.refresh_kerberos_tickets(self.cassandra_keytab, "cassandra@DATASTAX.COM", self.krb_conf)
         auth_provider = DSEGSSAPIAuthProvider(service='dse', qops=["auth"], principal='cassandra@DATASTAX.COM')
-        cluster = TestCluster(auth_provider=auth_provider)
+        cluster = IntegrationTestCluster(auth_provider=auth_provider)
         session = cluster.connect()
 
         session.execute("REVOKE PROXY.LOGIN ON ROLE '{0}' FROM '{1}'".format('charlie@DATASTAX.COM', 'bob@DATASTAX.COM'))
@@ -339,7 +339,7 @@ class BasicDseAuthTest(unittest.TestCase):
         os.environ['KRB5_CONFIG'] = self.krb_conf
         self.refresh_kerberos_tickets(self.cassandra_keytab, "cassandra@DATASTAX.COM", self.krb_conf)
         auth_provider = DSEGSSAPIAuthProvider(service='dse', qops=["auth"], principal='cassandra@DATASTAX.COM')
-        cluster = TestCluster(auth_provider=auth_provider)
+        cluster = IntegrationTestCluster(auth_provider=auth_provider)
         session = cluster.connect()
 
         stmts = [
@@ -404,7 +404,7 @@ class BaseDseProxyAuthTest(unittest.TestCase):
         # Create users and test keyspace
         self.user_role = 'user1'
         self.server_role = 'server'
-        self.root_cluster = TestCluster(auth_provider=DSEPlainTextAuthProvider('cassandra', 'cassandra'))
+        self.root_cluster = IntegrationTestCluster(auth_provider=DSEPlainTextAuthProvider('cassandra', 'cassandra'))
         self.root_session = self.root_cluster.connect()
 
         stmts = [
@@ -470,7 +470,7 @@ class DseProxyAuthTest(BaseDseProxyAuthTest):
         return sasl_options
 
     def connect_and_query(self, auth_provider, execute_as=None, query="SELECT * FROM testproxy.testproxy"):
-        self.cluster = TestCluster(auth_provider=auth_provider)
+        self.cluster = IntegrationTestCluster(auth_provider=auth_provider)
         self.session = self.cluster.connect()
         rs = self.session.execute(query, execute_as=execute_as)
         return rs

--- a/tests/integration/advanced/test_cont_paging.py
+++ b/tests/integration/advanced/test_cont_paging.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from tests.integration import use_singledc, greaterthanorequaldse51, BasicSharedKeyspaceUnitTestCaseRF3WM, \
-    DSE_VERSION, ProtocolVersion, greaterthanorequaldse60, requiredse, TestCluster
+    DSE_VERSION, ProtocolVersion, greaterthanorequaldse60, requiredse, IntegrationTestCluster
 
 import logging
 log = logging.getLogger(__name__)
@@ -64,7 +64,7 @@ class BaseContPagingTests():
     @classmethod
     def create_cluster(cls):
 
-        cls.cluster_with_profiles = TestCluster(protocol_version=cls.protocol_version, execution_profiles=cls.execution_profiles)
+        cls.cluster_with_profiles = IntegrationTestCluster(protocol_version=cls.protocol_version, execution_profiles=cls.execution_profiles)
 
         cls.session_with_profiles = cls.cluster_with_profiles.connect(wait_for_all_pools=True)
         statements_and_params = zip(

--- a/tests/integration/advanced/test_cqlengine_where_operators.py
+++ b/tests/integration/advanced/test_cqlengine_where_operators.py
@@ -25,7 +25,7 @@ from cassandra.cqlengine.management import (CQLENG_ALLOW_SCHEMA_MANAGEMENT,
                                       create_keyspace_simple, drop_table,
                                       sync_table)
 from cassandra.cqlengine.statements import IsNotNull
-from tests.integration import DSE_VERSION, requiredse, CASSANDRA_IP, greaterthanorequaldse60, TestCluster
+from tests.integration import DSE_VERSION, requiredse, CASSANDRA_IP, greaterthanorequaldse60, IntegrationTestCluster
 from tests.integration.advanced import use_single_node_with_graph_and_solr
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
 
@@ -64,7 +64,7 @@ class IsNotNullTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if DSE_VERSION:
-            cls.cluster = TestCluster()
+            cls.cluster = IntegrationTestCluster()
 
     @greaterthanorequaldse60
     def test_is_not_null_execution(self):
@@ -80,7 +80,7 @@ class IsNotNullTests(unittest.TestCase):
 
         @test_category cqlengine
         """
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         self.addCleanup(cluster.shutdown)
         session = cluster.connect()
 

--- a/tests/integration/advanced/test_unixsocketendpoint.py
+++ b/tests/integration/advanced/test_unixsocketendpoint.py
@@ -25,7 +25,7 @@ from cassandra.connection import UnixSocketEndPoint
 from cassandra.policies import WhiteListRoundRobinPolicy, RoundRobinPolicy
 
 from tests import notwindows
-from tests.integration import use_single_node, TestCluster
+from tests.integration import use_single_node, IntegrationTestCluster
 
 log = logging.getLogger()
 log.setLevel('DEBUG')
@@ -65,7 +65,7 @@ class UnixSocketTest(unittest.TestCase):
         lbp = UnixSocketWhiteListRoundRobinPolicy([UNIX_SOCKET_PATH])
         ep = ExecutionProfile(load_balancing_policy=lbp)
         endpoint = UnixSocketEndPoint(UNIX_SOCKET_PATH)
-        cls.cluster = TestCluster(contact_points=[endpoint], execution_profiles={EXEC_PROFILE_DEFAULT: ep})
+        cls.cluster = IntegrationTestCluster(contact_points=[endpoint], execution_profiles={EXEC_PROFILE_DEFAULT: ep})
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/integration/cqlengine/advanced/test_cont_paging.py
+++ b/tests/integration/cqlengine/advanced/test_cont_paging.py
@@ -27,7 +27,7 @@ from cassandra.cluster import (EXEC_PROFILE_DEFAULT,
 from cassandra.cqlengine import columns, connection, models
 from cassandra.cqlengine.management import drop_table, sync_table
 from tests.integration import (DSE_VERSION, greaterthanorequaldse51,
-                               greaterthanorequaldse60, requiredse, TestCluster)
+                               greaterthanorequaldse60, requiredse, IntegrationTestCluster)
 
 
 class TestMultiKeyModel(models.Model):
@@ -76,8 +76,8 @@ class BasicConcurrentTests():
     def _create_cluster_with_cp_options(cls, name, cp_options):
         execution_profiles = {EXEC_PROFILE_DEFAULT:
                                   ExecutionProfile(continuous_paging_options=cp_options)}
-        cls.cluster_default = TestCluster(protocol_version=cls.protocol_version,
-                                          execution_profiles=execution_profiles)
+        cls.cluster_default = IntegrationTestCluster(protocol_version=cls.protocol_version,
+                                                     execution_profiles=execution_profiles)
         cls.session_default = cls.cluster_default.connect(wait_for_all_pools=True)
         connection.register_connection(name, default=True, session=cls.session_default)
         cls.connections.add(name)

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -26,7 +26,7 @@ from cassandra.cluster import ExecutionProfile, _clusters_for_shutdown, _ConfigM
 from cassandra.policies import RoundRobinPolicy
 from cassandra.query import dict_factory
 
-from tests.integration import CASSANDRA_IP, PROTOCOL_VERSION, execute_with_long_wait_retry, local, TestCluster
+from tests.integration import CASSANDRA_IP, PROTOCOL_VERSION, execute_with_long_wait_retry, local, IntegrationTestCluster
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine import DEFAULT_KEYSPACE, setup_connection
 
@@ -76,7 +76,7 @@ class SeveralConnectionsTest(BaseCassEngTestCase):
         cls.keyspace1 = 'ctest1'
         cls.keyspace2 = 'ctest2'
         super(SeveralConnectionsTest, cls).setUpClass()
-        cls.setup_cluster = TestCluster()
+        cls.setup_cluster = IntegrationTestCluster()
         cls.setup_session = cls.setup_cluster.connect()
         ddl = "CREATE KEYSPACE {0} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '{1}'}}".format(cls.keyspace1, 1)
         execute_with_long_wait_retry(cls.setup_session, ddl)
@@ -93,7 +93,7 @@ class SeveralConnectionsTest(BaseCassEngTestCase):
         models.DEFAULT_KEYSPACE
 
     def setUp(self):
-        self.c = TestCluster()
+        self.c = IntegrationTestCluster()
         self.session1 = self.c.connect(keyspace=self.keyspace1)
         self.session1.row_factory = dict_factory
         self.session2 = self.c.connect(keyspace=self.keyspace2)
@@ -149,7 +149,7 @@ class ConnectionInitTest(unittest.TestCase):
         self.assertEqual(conn.cluster._config_mode, _ConfigMode.LEGACY)
 
     def test_connection_from_session_with_execution_profile(self):
-        cluster = TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
+        cluster = IntegrationTestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
         session = cluster.connect()
         connection.default()
         connection.set_session(session)
@@ -157,7 +157,7 @@ class ConnectionInitTest(unittest.TestCase):
         self.assertEqual(conn.cluster._config_mode, _ConfigMode.PROFILES)
 
     def test_connection_from_session_with_legacy_settings(self):
-        cluster = TestCluster(load_balancing_policy=RoundRobinPolicy())
+        cluster = IntegrationTestCluster(load_balancing_policy=RoundRobinPolicy())
         session = cluster.connect()
         session.row_factory = dict_factory
         connection.set_session(session)
@@ -165,7 +165,7 @@ class ConnectionInitTest(unittest.TestCase):
         self.assertEqual(conn.cluster._config_mode, _ConfigMode.LEGACY)
 
     def test_uncommitted_session_uses_legacy(self):
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect()
         session.row_factory = dict_factory
         connection.set_session(session)
@@ -186,7 +186,7 @@ class ConnectionInitTest(unittest.TestCase):
         self.assertEqual(ConnectionModel.objects(key=0)[0].some_data, 'text0')
 
     def test_execution_profile_insert_query(self):
-        cluster = TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
+        cluster = IntegrationTestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)})
         session = cluster.connect()
         connection.default()
         connection.set_session(session)

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -42,7 +42,7 @@ from cassandra.cqlengine import operators
 from cassandra.util import uuid_from_time
 from cassandra.cqlengine.connection import get_session
 from tests.integration import PROTOCOL_VERSION, CASSANDRA_VERSION, greaterthancass20, greaterthancass21, \
-    greaterthanorequalcass30, TestCluster
+    greaterthanorequalcass30, IntegrationTestCluster
 from tests.integration.cqlengine import execute_count, DEFAULT_KEYSPACE
 
 
@@ -775,7 +775,7 @@ class TestQuerySetValidation(BaseQuerySetUsage):
         with self.assertRaises(InvalidRequest):
             list(CustomIndexedTestModel.objects.filter(description__gte='test'))
 
-        with TestCluster().connect() as session:
+        with IntegrationTestCluster().connect() as session:
             session.execute("CREATE INDEX custom_index_cqlengine ON {}.{} (description)".
                             format(DEFAULT_KEYSPACE, CustomIndexedTestModel._table_name))
 

--- a/tests/integration/cqlengine/statements/test_base_statement.py
+++ b/tests/integration/cqlengine/statements/test_base_statement.py
@@ -29,7 +29,7 @@ from cassandra.cqlengine.columns import Column
 
 from tests.integration.cqlengine.base import BaseCassEngTestCase, TestQueryUpdateModel
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
-from tests.integration import greaterthanorequalcass3_10, TestCluster
+from tests.integration import greaterthanorequalcass3_10, IntegrationTestCluster
 
 from cassandra.cqlengine.connection import execute
 
@@ -115,7 +115,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
 
         @test_category data_types:object_mapper
         """
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
 

--- a/tests/integration/cqlengine/test_connections.py
+++ b/tests/integration/cqlengine/test_connections.py
@@ -22,7 +22,7 @@ from cassandra.cqlengine.query import ContextQuery, BatchQuery, ModelQuerySet
 from tests.integration.cqlengine import setup_connection, DEFAULT_KEYSPACE
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from tests.integration.cqlengine.query import test_queryset
-from tests.integration import local, CASSANDRA_IP, TestCluster
+from tests.integration import local, CASSANDRA_IP, IntegrationTestCluster
 
 
 class TestModel(Model):
@@ -226,7 +226,7 @@ class ManagementConnectionTests(BaseCassEngTestCase):
 
         @test_category object_mapper
         """
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect()
         connection_name = 'from_session'
         conn.register_connection(connection_name, session=session)
@@ -257,7 +257,7 @@ class ManagementConnectionTests(BaseCassEngTestCase):
 
         @test_category object_mapper
         """
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect()
         with self.assertRaises(CQLEngineException):
             conn.register_connection("bad_coonection1", session=session, consistency="not_null")

--- a/tests/integration/long/test_failure_types.py
+++ b/tests/integration/long/test_failure_types.py
@@ -31,7 +31,7 @@ from cassandra.query import SimpleStatement
 from tests.integration import (
     use_singledc, PROTOCOL_VERSION, get_cluster, setup_keyspace, remove_cluster,
     get_node, start_cluster_wait_for_up, requiresmallclockgranularity,
-    local, CASSANDRA_VERSION, TestCluster)
+    local, CASSANDRA_VERSION, IntegrationTestCluster)
 
 
 try:
@@ -83,7 +83,7 @@ class ClientExceptionTests(unittest.TestCase):
             raise unittest.SkipTest(
                 "Native protocol 4,0+ is required for custom payloads, currently using %r"
                 % (PROTOCOL_VERSION,))
-        self.cluster = TestCluster()
+        self.cluster = IntegrationTestCluster()
         self.session = self.cluster.connect()
         self.nodes_currently_failing = []
         self.node1, self.node2, self.node3 = get_cluster().nodes.values()
@@ -332,7 +332,7 @@ class TimeoutTimerTest(unittest.TestCase):
         """
         Setup sessions and pause node1
         """
-        self.cluster = TestCluster(
+        self.cluster = IntegrationTestCluster(
             execution_profiles={
                 EXEC_PROFILE_DEFAULT: ExecutionProfile(
                     load_balancing_policy=HostFilterPolicy(

--- a/tests/integration/long/test_ipv6.py
+++ b/tests/integration/long/test_ipv6.py
@@ -19,7 +19,7 @@ from cassandra.cluster import NoHostAvailable
 from cassandra.io.asyncorereactor import AsyncoreConnection
 
 from tests import is_monkey_patched
-from tests.integration import use_cluster, remove_cluster, TestCluster
+from tests.integration import use_cluster, remove_cluster, IntegrationTestCluster
 
 if is_monkey_patched():
     LibevConnection = -1
@@ -75,7 +75,7 @@ class IPV6ConnectionTest(object):
     connection_class = None
 
     def test_connect(self):
-        cluster = TestCluster(connection_class=self.connection_class, contact_points=['::1'], connect_timeout=10)
+        cluster = IntegrationTestCluster(connection_class=self.connection_class, contact_points=['::1'], connect_timeout=10)
         session = cluster.connect()
         future = session.execute_async("SELECT * FROM system.local")
         future.result()
@@ -83,16 +83,16 @@ class IPV6ConnectionTest(object):
         cluster.shutdown()
 
     def test_error(self):
-        cluster = TestCluster(connection_class=self.connection_class, contact_points=['::1'], port=9043,
-                              connect_timeout=10)
+        cluster = IntegrationTestCluster(connection_class=self.connection_class, contact_points=['::1'], port=9043,
+                                         connect_timeout=10)
         self.assertRaisesRegexp(NoHostAvailable, '\(\'Unable to connect.*%s.*::1\', 9043.*Connection refused.*'
                                 % errno.ECONNREFUSED, cluster.connect)
 
     def test_error_multiple(self):
         if len(socket.getaddrinfo('localhost', 9043, socket.AF_UNSPEC, socket.SOCK_STREAM)) < 2:
             raise unittest.SkipTest('localhost only resolves one address')
-        cluster = TestCluster(connection_class=self.connection_class, contact_points=['localhost'], port=9043,
-                              connect_timeout=10)
+        cluster = IntegrationTestCluster(connection_class=self.connection_class, contact_points=['localhost'], port=9043,
+                                         connect_timeout=10)
         self.assertRaisesRegexp(NoHostAvailable, '\(\'Unable to connect.*Tried connecting to \[\(.*\(.*\].*Last error',
                                 cluster.connect)
 

--- a/tests/integration/long/test_large_data.py
+++ b/tests/integration/long/test_large_data.py
@@ -24,7 +24,7 @@ from cassandra import ConsistencyLevel, OperationTimedOut, WriteTimeout
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.query import dict_factory
 from cassandra.query import SimpleStatement
-from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
+from tests.integration import use_singledc, PROTOCOL_VERSION, IntegrationTestCluster
 from tests.integration.long.utils import create_schema
 
 try:
@@ -61,7 +61,7 @@ class LargeDataTests(unittest.TestCase):
         self.keyspace = 'large_data'
 
     def make_session_and_keyspace(self):
-        cluster = TestCluster(execution_profiles={
+        cluster = IntegrationTestCluster(execution_profiles={
             EXEC_PROFILE_DEFAULT: ExecutionProfile(request_timeout=20, row_factory=dict_factory)
         })
         session = cluster.connect()

--- a/tests/integration/long/test_loadbalancingpolicies.py
+++ b/tests/integration/long/test_loadbalancingpolicies.py
@@ -30,7 +30,7 @@ from cassandra.policies import (
 )
 from cassandra.query import SimpleStatement
 
-from tests.integration import use_singledc, use_multidc, remove_cluster, TestCluster, greaterthanorequalcass40, notdse
+from tests.integration import use_singledc, use_multidc, remove_cluster, IntegrationTestCluster, greaterthanorequalcass40, notdse
 from tests.integration.long.utils import (wait_for_up, create_schema,
                                           CoordinatorStats, force_stop,
                                           wait_for_down, decommission, start,
@@ -63,7 +63,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
     def _connect_probe_cluster(self):
         if not self.probe_cluster:
             # distinct cluster so we can see the status of nodes ignored by the LBP being tested
-            self.probe_cluster = TestCluster(
+            self.probe_cluster = IntegrationTestCluster(
                 schema_metadata_enabled=False,
                 token_metadata_enabled=False,
                 execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=RoundRobinPolicy())}
@@ -94,8 +94,8 @@ class LoadBalancingPolicyTests(unittest.TestCase):
     def _cluster_session_with_lbp(self, lbp):
         # create a cluster with no delay on events
 
-        cluster = TestCluster(topology_event_refresh_window=0, status_event_refresh_window=0,
-                              execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=lbp)})
+        cluster = IntegrationTestCluster(topology_event_refresh_window=0, status_event_refresh_window=0,
+                                         execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(load_balancing_policy=lbp)})
         session = cluster.connect()
         return cluster, session
 
@@ -184,7 +184,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         @test_category load_balancing:token_aware
         """
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         self.addCleanup(cluster.shutdown)
 
         if murmur3 is not None:
@@ -694,7 +694,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
         use_singledc()
         keyspace = 'test_white_list'
 
-        cluster = TestCluster(
+        cluster = IntegrationTestCluster(
             contact_points=('127.0.0.2',), topology_event_refresh_window=0, status_event_refresh_window=0,
             execution_profiles={
                 EXEC_PROFILE_DEFAULT: ExecutionProfile(
@@ -746,7 +746,7 @@ class LoadBalancingPolicyTests(unittest.TestCase):
             child_policy=RoundRobinPolicy(),
             predicate=lambda host: host.address != ignored_address
         )
-        cluster = TestCluster(
+        cluster = IntegrationTestCluster(
             contact_points=(IP_FORMAT % 1,),
             topology_event_refresh_window=0,
             status_event_refresh_window=0,

--- a/tests/integration/long/test_policies.py
+++ b/tests/integration/long/test_policies.py
@@ -20,7 +20,7 @@ except ImportError:
 from cassandra import ConsistencyLevel, Unavailable
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 
-from tests.integration import use_cluster, get_cluster, get_node, TestCluster
+from tests.integration import use_cluster, get_cluster, get_node, IntegrationTestCluster
 
 
 def setup_module():
@@ -47,7 +47,7 @@ class RetryPolicyTests(unittest.TestCase):
         ep = ExecutionProfile(consistency_level=ConsistencyLevel.ALL,
                               serial_consistency_level=ConsistencyLevel.SERIAL)
 
-        cluster = TestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ep})
+        cluster = IntegrationTestCluster(execution_profiles={EXEC_PROFILE_DEFAULT: ep})
         session = cluster.connect()
 
         session.execute("CREATE KEYSPACE test_retry_policy_cas WITH replication = {'class':'SimpleStrategy','replication_factor': 3};")

--- a/tests/integration/long/test_schema.py
+++ b/tests/integration/long/test_schema.py
@@ -17,7 +17,7 @@ import logging
 from cassandra import ConsistencyLevel, AlreadyExists
 from cassandra.query import SimpleStatement
 
-from tests.integration import use_singledc, execute_until_pass, TestCluster
+from tests.integration import use_singledc, execute_until_pass, IntegrationTestCluster
 
 import time
 
@@ -37,7 +37,7 @@ class SchemaTests(unittest.TestCase):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect(wait_for_all_pools=True)
 
     @classmethod
@@ -98,7 +98,7 @@ class SchemaTests(unittest.TestCase):
         Tests for any schema disagreements using the same keyspace multiple times
         """
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect(wait_for_all_pools=True)
 
         for i in range(30):
@@ -132,7 +132,7 @@ class SchemaTests(unittest.TestCase):
         @test_category schema
         """
         # This should yield a schema disagreement
-        cluster = TestCluster(max_schema_agreement_wait=0.001)
+        cluster = IntegrationTestCluster(max_schema_agreement_wait=0.001)
         session = cluster.connect(wait_for_all_pools=True)
 
         rs = session.execute("CREATE KEYSPACE test_schema_disagreement WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")
@@ -145,7 +145,7 @@ class SchemaTests(unittest.TestCase):
         cluster.shutdown()
         
         # These should have schema agreement
-        cluster = TestCluster(max_schema_agreement_wait=100)
+        cluster = IntegrationTestCluster(max_schema_agreement_wait=100)
         session = cluster.connect()
         rs = session.execute("CREATE KEYSPACE test_schema_disagreement WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 3}")
         self.check_and_wait_for_agreement(session, rs, True)

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -26,7 +26,7 @@ from cassandra.query import SimpleStatement
 from OpenSSL import SSL, crypto
 
 from tests.integration import (
-    get_cluster, remove_cluster, use_single_node, start_cluster_wait_for_up, EVENT_LOOP_MANAGER, TestCluster
+    get_cluster, remove_cluster, use_single_node, start_cluster_wait_for_up, EVENT_LOOP_MANAGER, IntegrationTestCluster
 )
 
 if not hasattr(ssl, 'match_hostname'):
@@ -103,7 +103,7 @@ def validate_ssl_options(**kwargs):
             if tries > 5:
                 raise RuntimeError("Failed to connect to SSL cluster after 5 attempts")
             try:
-                cluster = TestCluster(
+                cluster = IntegrationTestCluster(
                     contact_points=[DefaultEndPoint(hostname)],
                     ssl_options=ssl_options,
                     ssl_context=ssl_context
@@ -184,7 +184,7 @@ class SSLConnectionTests(unittest.TestCase):
             if tries > 5:
                 raise RuntimeError("Failed to connect to SSL cluster after 5 attempts")
             try:
-                cluster = TestCluster(ssl_options=ssl_options)
+                cluster = IntegrationTestCluster(ssl_options=ssl_options)
                 session = cluster.connect(wait_for_all_pools=True)
                 break
             except Exception:
@@ -290,7 +290,7 @@ class SSLConnectionAuthTests(unittest.TestCase):
         @test_category connection:ssl
         """
 
-        cluster = TestCluster(ssl_options={'ca_certs': CLIENT_CA_CERTS,
+        cluster = IntegrationTestCluster(ssl_options={'ca_certs': CLIENT_CA_CERTS,
                                            'ssl_version': ssl_version})
 
         with self.assertRaises(NoHostAvailable) as _:
@@ -319,7 +319,7 @@ class SSLConnectionAuthTests(unittest.TestCase):
             # I don't set the bad certfile for pyopenssl because it hangs
             ssl_options['certfile'] = DRIVER_CERTFILE_BAD
 
-        cluster = TestCluster(
+        cluster = IntegrationTestCluster(
             ssl_options={'ca_certs': CLIENT_CA_CERTS,
                          'ssl_version': ssl_version,
                          'keyfile': DRIVER_KEYFILE}
@@ -364,7 +364,7 @@ class SSLSocketErrorTests(unittest.TestCase):
         """
         ssl_options = {'ca_certs': CLIENT_CA_CERTS,
                        'ssl_version': ssl_version}
-        cluster = TestCluster(ssl_options=ssl_options)
+        cluster = IntegrationTestCluster(ssl_options=ssl_options)
         session = cluster.connect(wait_for_all_pools=True)
         try:
             session.execute('drop keyspace ssl_error_test')

--- a/tests/integration/long/test_topology_change.py
+++ b/tests/integration/long/test_topology_change.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from cassandra.policies import HostStateListener
-from tests.integration import get_node, use_cluster, local, TestCluster
+from tests.integration import get_node, use_cluster, local, IntegrationTestCluster
 from tests.integration.long.utils import decommission
 from tests.util import wait_until
 
@@ -31,7 +31,7 @@ class TopologyChangeTests(TestCase):
         use_cluster("test_down_then_removed", [3], start=True)
 
         state_listener = StateListener()
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         self.addCleanup(cluster.shutdown)
         cluster.register_listener(state_listener)
         session = cluster.connect(wait_for_all_pools=True)

--- a/tests/integration/standard/test_authentication.py
+++ b/tests/integration/standard/test_authentication.py
@@ -19,7 +19,7 @@ from cassandra.cluster import NoHostAvailable
 from cassandra.auth import PlainTextAuthProvider, SASLClient, SaslAuthProvider
 
 from tests.integration import use_singledc, get_cluster, remove_cluster, PROTOCOL_VERSION, CASSANDRA_IP, \
-    USE_CASS_EXTERNAL, start_cluster_wait_for_up, TestCluster
+    USE_CASS_EXTERNAL, start_cluster_wait_for_up, IntegrationTestCluster
 from tests.integration.util import assert_quiescent_pool_state
 
 try:
@@ -75,12 +75,12 @@ class AuthenticationTests(unittest.TestCase):
         # to ensure the role manager is setup
         for _ in range(5):
             try:
-                cluster = TestCluster(
+                cluster = IntegrationTestCluster(
                     idle_heartbeat_interval=0,
                     auth_provider=self.get_authentication_provider(username='cassandra', password='cassandra'))
                 cluster.connect(wait_for_all_pools=True)
 
-                return TestCluster(
+                return IntegrationTestCluster(
                     idle_heartbeat_interval=0,
                     auth_provider=self.get_authentication_provider(username=usr, password=pwd))
             except Exception as e:
@@ -143,7 +143,7 @@ class AuthenticationTests(unittest.TestCase):
             cluster.shutdown()
 
     def test_connect_no_auth_provider(self):
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         try:
             self.assertRaisesRegexp(NoHostAvailable,
                                     '.*AuthenticationFailed.*',

--- a/tests/integration/standard/test_authentication_misconfiguration.py
+++ b/tests/integration/standard/test_authentication_misconfiguration.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from tests.integration import USE_CASS_EXTERNAL, use_cluster, TestCluster
+from tests.integration import USE_CASS_EXTERNAL, use_cluster, IntegrationTestCluster
 
 
 class MisconfiguredAuthenticationTests(unittest.TestCase):
@@ -33,7 +33,7 @@ class MisconfiguredAuthenticationTests(unittest.TestCase):
             cls.ccm_cluster = ccm_cluster
 
     def test_connect_no_auth_provider(self):
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         cluster.connect()
         cluster.refresh_nodes()
         down_hosts = [host for host in cluster.metadata.all_hosts() if not host.is_up]

--- a/tests/integration/standard/test_client_warnings.py
+++ b/tests/integration/standard/test_client_warnings.py
@@ -20,7 +20,7 @@ except ImportError:
 
 from cassandra.query import BatchStatement
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, local, TestCluster
+from tests.integration import use_singledc, PROTOCOL_VERSION, local, IntegrationTestCluster
 
 
 def setup_module():
@@ -34,7 +34,7 @@ class ClientWarningTests(unittest.TestCase):
         if PROTOCOL_VERSION < 4:
             return
 
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect()
 
         cls.session.execute("CREATE TABLE IF NOT EXISTS test1rf.client_warning (k int, v0 int, v1 int, PRIMARY KEY (k, v0))")

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -150,7 +150,8 @@ class ClusterTests(unittest.TestCase):
         get_node(1).pause()
         cluster = TestCluster(contact_points=['127.0.0.1'], connect_timeout=1)
 
-        with self.assertRaisesRegexp(NoHostAvailable, "OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
+        with self.assertRaisesRegexp(NoHostAvailable,
+                                     r"OperationTimedOut\('errors=Timed out creating connection \(1 seconds\)"):
             cluster.connect()
         cluster.shutdown()
 

--- a/tests/integration/standard/test_concurrent.py
+++ b/tests/integration/standard/test_concurrent.py
@@ -22,7 +22,7 @@ from cassandra.concurrent import execute_concurrent, execute_concurrent_with_arg
 from cassandra.policies import HostDistance
 from cassandra.query import tuple_factory, SimpleStatement
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
+from tests.integration import use_singledc, PROTOCOL_VERSION, IntegrationTestCluster
 
 from six import next
 
@@ -42,7 +42,7 @@ class ClusterTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.cluster = TestCluster(
+        cls.cluster = IntegrationTestCluster(
             execution_profiles = {
                 EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)
             }

--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -38,7 +38,7 @@ from cassandra.pool import HostConnectionPool
 
 from tests import is_monkey_patched
 from tests.integration import use_singledc, get_node, CASSANDRA_IP, local, \
-    requiresmallclockgranularity, greaterthancass20, TestCluster
+    requiresmallclockgranularity, greaterthancass20, IntegrationTestCluster
 
 try:
     from cassandra.io.libevreactor import LibevConnection
@@ -57,7 +57,7 @@ def setup_module():
 class ConnectionTimeoutTest(unittest.TestCase):
 
     def setUp(self):
-        self.cluster = TestCluster(execution_profiles={
+        self.cluster = IntegrationTestCluster(execution_profiles={
             EXEC_PROFILE_DEFAULT: ExecutionProfile(
                 load_balancing_policy=HostFilterPolicy(
                     RoundRobinPolicy(), predicate=lambda host: host.address == CASSANDRA_IP
@@ -117,7 +117,7 @@ class HeartbeatTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.cluster = TestCluster(idle_heartbeat_interval=1)
+        self.cluster = IntegrationTestCluster(idle_heartbeat_interval=1)
         self.session = self.cluster.connect(wait_for_all_pools=True)
 
     def tearDown(self):
@@ -219,8 +219,8 @@ class ConnectionTests(object):
                 conn = self.klass.factory(
                     endpoint=contact_point,
                     timeout=timeout,
-                    protocol_version=TestCluster.DEFAULT_PROTOCOL_VERSION,
-                    allow_beta_protocol_version=TestCluster.DEFAULT_ALLOW_BETA
+                    protocol_version=IntegrationTestCluster.DEFAULT_PROTOCOL_VERSION,
+                    allow_beta_protocol_version=IntegrationTestCluster.DEFAULT_ALLOW_BETA
                 )
                 break
             except (OperationTimedOut, NoHostAvailable, ConnectionShutdown) as e:
@@ -416,10 +416,10 @@ class ConnectionTests(object):
         class C2(self.klass):
             pass
 
-        clusterC1 = TestCluster(connection_class=C1)
+        clusterC1 = IntegrationTestCluster(connection_class=C1)
         clusterC1.connect(wait_for_all_pools=True)
 
-        clusterC2 = TestCluster(connection_class=C2)
+        clusterC2 = IntegrationTestCluster(connection_class=C2)
         clusterC2.connect(wait_for_all_pools=True)
         self.addCleanup(clusterC1.shutdown)
         self.addCleanup(clusterC2.shutdown)

--- a/tests/integration/standard/test_control_connection.py
+++ b/tests/integration/standard/test_control_connection.py
@@ -23,7 +23,7 @@ except ImportError:
 
 
 from cassandra.protocol import ConfigurationException
-from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster, greaterthanorequalcass40, notdse
+from tests.integration import use_singledc, PROTOCOL_VERSION, IntegrationTestCluster, greaterthanorequalcass40, notdse
 from tests.integration.datatype_utils import update_datatypes
 
 
@@ -38,7 +38,7 @@ class ControlConnectionTests(unittest.TestCase):
             raise unittest.SkipTest(
                 "Native protocol 3,0+ is required for UDTs using %r"
                 % (PROTOCOL_VERSION,))
-        self.cluster = TestCluster()
+        self.cluster = IntegrationTestCluster()
 
     def tearDown(self):
         try:
@@ -112,7 +112,7 @@ class ControlConnectionTests(unittest.TestCase):
         Unit tests already validate that the port can be picked up (or not) from the query. This validates
         it picks up the correct port from a real server and is able to connect.
         """
-        self.cluster = TestCluster()
+        self.cluster = IntegrationTestCluster()
 
         host = self.cluster.get_control_connection_host()
         self.assertEqual(host, None)

--- a/tests/integration/standard/test_custom_cluster.py
+++ b/tests/integration/standard/test_custom_cluster.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from cassandra.cluster import NoHostAvailable
-from tests.integration import use_singledc, get_cluster, remove_cluster, local, TestCluster
+from tests.integration import use_singledc, get_cluster, remove_cluster, local, IntegrationTestCluster
 from tests.util import wait_until, wait_until_not_raised
 
 try:
@@ -31,9 +31,9 @@ def setup_module():
     # can't use wait_for_binary_proto cause ccm tries on port 9042
     ccm_cluster.start(wait_for_binary_proto=False)
     # wait until all nodes are up
-    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
-    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
-    wait_until_not_raised(lambda: TestCluster(contact_points=['127.0.0.3'], port=9046).connect().shutdown(), 1, 20)
+    wait_until_not_raised(lambda: IntegrationTestCluster(contact_points=['127.0.0.1'], port=9046).connect().shutdown(), 1, 20)
+    wait_until_not_raised(lambda: IntegrationTestCluster(contact_points=['127.0.0.2'], port=9046).connect().shutdown(), 1, 20)
+    wait_until_not_raised(lambda: IntegrationTestCluster(contact_points=['127.0.0.3'], port=9046).connect().shutdown(), 1, 20)
 
 
 def teardown_module():
@@ -50,11 +50,11 @@ class CustomClusterTests(unittest.TestCase):
 
         All hosts should be marked as up and we should be able to execute queries on it.
         """
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         with self.assertRaises(NoHostAvailable):
             cluster.connect()  # should fail on port 9042
 
-        cluster = TestCluster(port=9046)
+        cluster = IntegrationTestCluster(port=9046)
         session = cluster.connect(wait_for_all_pools=True)
 
         wait_until(lambda: len(cluster.metadata.all_hosts()) == 3, 1, 5)

--- a/tests/integration/standard/test_custom_payload.py
+++ b/tests/integration/standard/test_custom_payload.py
@@ -22,7 +22,7 @@ import six
 
 from cassandra.query import (SimpleStatement, BatchStatement, BatchType)
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, local, TestCluster
+from tests.integration import use_singledc, PROTOCOL_VERSION, local, IntegrationTestCluster
 
 
 def setup_module():
@@ -38,7 +38,7 @@ class CustomPayloadTests(unittest.TestCase):
             raise unittest.SkipTest(
                 "Native protocol 4,0+ is required for custom payloads, currently using %r"
                 % (PROTOCOL_VERSION,))
-        self.cluster = TestCluster()
+        self.cluster = IntegrationTestCluster()
         self.session = self.cluster.connect()
 
     def tearDown(self):

--- a/tests/integration/standard/test_custom_protocol_handler.py
+++ b/tests/integration/standard/test_custom_protocol_handler.py
@@ -25,7 +25,7 @@ from cassandra import ProtocolVersion, ConsistencyLevel
 
 from tests.integration import use_singledc, drop_keyspace_shutdown_cluster, \
     greaterthanorequalcass30, execute_with_long_wait_retry, greaterthanorequaldse51, greaterthanorequalcass3_10, \
-    TestCluster, greaterthanorequalcass40, requirecassandra
+    IntegrationTestCluster, greaterthanorequalcass40, requirecassandra
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES
 from tests.integration.standard.utils import create_table_with_all_types, get_all_primitive_params
 from six import binary_type
@@ -43,7 +43,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE custserdes WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
         cls.session.set_keyspace("custserdes")
@@ -68,7 +68,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         """
 
         # Ensure that we get normal uuid back first
-        cluster = TestCluster(
+        cluster = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
         )
         session = cluster.connect(keyspace="custserdes")
@@ -106,7 +106,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         @test_category data_types:serialization
         """
         # Connect using a custom protocol handler that tracks the various types the result message is used with.
-        cluster = TestCluster(
+        cluster = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
         )
         session = cluster.connect(keyspace="custserdes")
@@ -136,7 +136,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
 
         @test_category connection
         """
-        cluster = TestCluster(protocol_version=ProtocolVersion.V5, allow_beta_protocol_version=True)
+        cluster = IntegrationTestCluster(protocol_version=ProtocolVersion.V5, allow_beta_protocol_version=True)
         session = cluster.connect()
 
         max_pages = 4
@@ -233,7 +233,7 @@ class CustomProtocolHandlerTest(unittest.TestCase):
         return future
 
     def _protocol_divergence_fail_by_flag_uses_int(self, version, uses_int_query_flag, int_flag = True, beta=False):
-        cluster = TestCluster(protocol_version=version, allow_beta_protocol_version=beta)
+        cluster = IntegrationTestCluster(protocol_version=version, allow_beta_protocol_version=beta)
         session = cluster.connect()
 
         query_one = SimpleStatement("INSERT INTO test3rf.test (k, v) VALUES (1, 1)")

--- a/tests/integration/standard/test_cython_protocol_handlers.py
+++ b/tests/integration/standard/test_cython_protocol_handlers.py
@@ -16,7 +16,7 @@ from cassandra.protocol import ProtocolHandler, LazyProtocolHandler, NumpyProtoc
 from cassandra.query import tuple_factory
 from tests import VERIFY_CYTHON
 from tests.integration import use_singledc, notprotocolv1, \
-    drop_keyspace_shutdown_cluster, BasicSharedKeyspaceUnitTestCase, greaterthancass21, TestCluster
+    drop_keyspace_shutdown_cluster, BasicSharedKeyspaceUnitTestCase, greaterthancass21, IntegrationTestCluster
 from tests.integration.datatype_utils import update_datatypes
 from tests.integration.standard.utils import (
     create_table_with_all_types, get_all_primitive_params, get_primitive_datatypes)
@@ -34,7 +34,7 @@ class CythonProtocolHandlerTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE testspace WITH replication = "
                             "{ 'class' : 'SimpleStrategy', 'replication_factor': '1'}")
@@ -65,7 +65,7 @@ class CythonProtocolHandlerTest(unittest.TestCase):
         Test Cython-based parser that returns an iterator, over multiple pages
         """
         # arrays = { 'a': arr1, 'b': arr2, ... }
-        cluster = TestCluster(
+        cluster = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
         )
         session = cluster.connect(keyspace="testspace")
@@ -99,7 +99,7 @@ class CythonProtocolHandlerTest(unittest.TestCase):
         Test Numpy-based parser that returns a NumPy array
         """
         # arrays = { 'a': arr1, 'b': arr2, ... }
-        cluster = TestCluster(
+        cluster = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
         )
         session = cluster.connect(keyspace="testspace")
@@ -182,7 +182,7 @@ def get_data(protocol_handler):
     """
     Get data from the test table.
     """
-    cluster = TestCluster(
+    cluster = IntegrationTestCluster(
         execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=tuple_factory)}
     )
     session = cluster.connect(keyspace="testspace")

--- a/tests/integration/standard/test_dse.py
+++ b/tests/integration/standard/test_dse.py
@@ -19,7 +19,7 @@ from packaging.version import Version
 from tests import notwindows
 from tests.unit.cython.utils import notcython
 from tests.integration import (execute_until_pass,
-                               execute_with_long_wait_retry, use_cluster, TestCluster)
+                               execute_with_long_wait_retry, use_cluster, IntegrationTestCluster)
 
 try:
     import unittest2 as unittest
@@ -59,7 +59,7 @@ class DseCCMClusterTest(unittest.TestCase):
         )
         use_cluster(cluster_name=cluster_name, nodes=[3], dse_options={})
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect()
         result = execute_until_pass(
             session,

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -42,7 +42,7 @@ from tests.integration import (get_cluster, use_singledc, PROTOCOL_VERSION, exec
                                get_supported_protocol_versions, greaterthancass20,
                                greaterthancass21, assert_startswith, greaterthanorequalcass40,
                                greaterthanorequaldse67, lessthancass40,
-                               TestCluster, DSE_VERSION)
+                               IntegrationTestCluster, DSE_VERSION)
 
 
 log = logging.getLogger(__name__)
@@ -109,7 +109,7 @@ class HostMetaDataTests(BasicExistingKeyspaceUnitTestCase):
 class MetaDataRemovalTest(unittest.TestCase):
 
     def setUp(self):
-        self.cluster = TestCluster(contact_points=['127.0.0.1', '127.0.0.2', '127.0.0.3', '126.0.0.186'])
+        self.cluster = IntegrationTestCluster(contact_points=['127.0.0.1', '127.0.0.2', '127.0.0.3', '126.0.0.186'])
         self.cluster.connect()
 
     def tearDown(self):
@@ -143,11 +143,11 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         @test_category metadata
         """
         # Validate metadata is missing where appropriate
-        no_schema = TestCluster(schema_metadata_enabled=False)
+        no_schema = IntegrationTestCluster(schema_metadata_enabled=False)
         no_schema_session = no_schema.connect()
         self.assertEqual(len(no_schema.metadata.keyspaces), 0)
         self.assertEqual(no_schema.metadata.export_schema_as_string(), '')
-        no_token = TestCluster(token_metadata_enabled=False)
+        no_token = IntegrationTestCluster(token_metadata_enabled=False)
         no_token_session = no_token.connect()
         self.assertEqual(len(no_token.metadata.token_map.token_to_host_owner), 0)
 
@@ -575,7 +575,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         @test_category metadata
         """
-        cluster2 = TestCluster(schema_event_refresh_window=-1)
+        cluster2 = IntegrationTestCluster(schema_event_refresh_window=-1)
         cluster2.connect()
 
         self.assertNotIn("new_keyspace", cluster2.metadata.keyspaces)
@@ -658,7 +658,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         @test_category metadata
         """
 
-        cluster2 = TestCluster(schema_event_refresh_window=-1)
+        cluster2 = IntegrationTestCluster(schema_event_refresh_window=-1)
         cluster2.connect()
 
         self.assertTrue(cluster2.metadata.keyspaces[self.keyspace_name].durable_writes)
@@ -689,7 +689,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         table_name = "test"
         self.session.execute("CREATE TABLE {0}.{1} (a int PRIMARY KEY, b text)".format(self.keyspace_name, table_name))
 
-        cluster2 = TestCluster(schema_event_refresh_window=-1)
+        cluster2 = IntegrationTestCluster(schema_event_refresh_window=-1)
         cluster2.connect()
 
         self.assertNotIn("c", cluster2.metadata.keyspaces[self.keyspace_name].tables[table_name].columns)
@@ -723,7 +723,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
 
         self.session.execute("CREATE TABLE {0}.{1} (a int PRIMARY KEY, b text)".format(self.keyspace_name, self.function_table_name))
 
-        cluster2 = TestCluster(schema_event_refresh_window=-1)
+        cluster2 = IntegrationTestCluster(schema_event_refresh_window=-1)
         cluster2.connect()
 
         try:
@@ -747,7 +747,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         self.assertIsNot(original_meta, self.session.cluster.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views['mv1'])
         self.assertEqual(original_meta.as_cql_query(), current_meta.as_cql_query())
 
-        cluster3 = TestCluster(schema_event_refresh_window=-1)
+        cluster3 = IntegrationTestCluster(schema_event_refresh_window=-1)
         cluster3.connect()
         try:
             self.assertNotIn("mv2", cluster3.metadata.keyspaces[self.keyspace_name].tables[self.function_table_name].views)
@@ -782,7 +782,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         if PROTOCOL_VERSION < 3:
             raise unittest.SkipTest("Protocol 3+ is required for UDTs, currently testing against {0}".format(PROTOCOL_VERSION))
 
-        cluster2 = TestCluster(schema_event_refresh_window=-1)
+        cluster2 = IntegrationTestCluster(schema_event_refresh_window=-1)
         cluster2.connect()
 
         self.assertEqual(cluster2.metadata.keyspaces[self.keyspace_name].user_types, {})
@@ -810,7 +810,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
                 raise unittest.SkipTest("Protocol versions 1 and 2 are not supported in Cassandra version ".format(CASSANDRA_VERSION))
 
         for protocol_version in (1, 2):
-            cluster = TestCluster()
+            cluster = IntegrationTestCluster()
             session = cluster.connect()
             self.assertEqual(cluster.metadata.keyspaces[self.keyspace_name].user_types, {})
 
@@ -850,7 +850,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         if PROTOCOL_VERSION < 4:
             raise unittest.SkipTest("Protocol 4+ is required for UDFs, currently testing against {0}".format(PROTOCOL_VERSION))
 
-        cluster2 = TestCluster(schema_event_refresh_window=-1)
+        cluster2 = IntegrationTestCluster(schema_event_refresh_window=-1)
         cluster2.connect()
 
         self.assertEqual(cluster2.metadata.keyspaces[self.keyspace_name].functions, {})
@@ -886,7 +886,7 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         if PROTOCOL_VERSION < 4:
             raise unittest.SkipTest("Protocol 4+ is required for UDAs, currently testing against {0}".format(PROTOCOL_VERSION))
 
-        cluster2 = TestCluster(schema_event_refresh_window=-1)
+        cluster2 = IntegrationTestCluster(schema_event_refresh_window=-1)
         cluster2.connect()
 
         self.assertEqual(cluster2.metadata.keyspaces[self.keyspace_name].aggregates, {})
@@ -1046,7 +1046,7 @@ class TestCodeCoverage(unittest.TestCase):
         Test export schema functionality
         """
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         cluster.connect()
 
         self.assertIsInstance(cluster.metadata.export_schema_as_string(), six.string_types)
@@ -1057,7 +1057,7 @@ class TestCodeCoverage(unittest.TestCase):
         Test export keyspace schema functionality
         """
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         cluster.connect()
 
         for keyspace in cluster.metadata.keyspaces:
@@ -1097,7 +1097,7 @@ class TestCodeCoverage(unittest.TestCase):
         if sys.version_info[0:2] != (2, 7):
             raise unittest.SkipTest('This test compares static strings generated from dict items, which may change orders. Test with 2.7.')
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect()
 
         session.execute("""
@@ -1165,7 +1165,7 @@ CREATE TABLE export_udts.users (
         Test that names that need to be escaped in CREATE statements are
         """
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect()
 
         ksname = 'AnInterestingKeyspace'
@@ -1210,7 +1210,7 @@ CREATE TABLE export_udts.users (
         Ensure AlreadyExists exception is thrown when hit
         """
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         session = cluster.connect()
 
         ksname = 'test3rf'
@@ -1236,7 +1236,7 @@ CREATE TABLE export_udts.users (
         if murmur3 is None:
             raise unittest.SkipTest('the murmur3 extension is not available')
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         self.assertEqual(cluster.metadata.get_replicas('test3rf', 'key'), [])
 
         cluster.connect('test3rf')
@@ -1252,7 +1252,7 @@ CREATE TABLE export_udts.users (
         Test token mappings
         """
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         cluster.connect('test3rf')
         ring = cluster.metadata.token_map.ring
         owners = list(cluster.metadata.token_map.token_to_host_owner[token] for token in ring)
@@ -1276,7 +1276,7 @@ class TokenMetadataTest(unittest.TestCase):
     def test_token(self):
         expected_node_count = len(get_cluster().nodes)
 
-        cluster = TestCluster()
+        cluster = IntegrationTestCluster()
         cluster.connect()
         tmap = cluster.metadata.token_map
         self.assertTrue(issubclass(tmap.token_class, Token))
@@ -1289,7 +1289,7 @@ class KeyspaceAlterMetadata(unittest.TestCase):
     Test verifies that table metadata is preserved on keyspace alter
     """
     def setUp(self):
-        self.cluster = TestCluster()
+        self.cluster = IntegrationTestCluster()
         self.session = self.cluster.connect()
         name = self._testMethodName.lower()
         crt_ks = '''
@@ -1334,7 +1334,7 @@ class IndexMapTests(unittest.TestCase):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect()
         try:
             if cls.keyspace_name in cls.cluster.metadata.keyspaces:
@@ -1443,7 +1443,7 @@ class FunctionTest(unittest.TestCase):
     @classmethod
     def setup_class(cls):
         if PROTOCOL_VERSION >= 4:
-            cls.cluster = TestCluster()
+            cls.cluster = IntegrationTestCluster()
             cls.keyspace_name = cls.__name__.lower()
             cls.session = cls.cluster.connect()
             cls.session.execute("CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}" % cls.keyspace_name)
@@ -1726,7 +1726,7 @@ class AggregateMetadata(FunctionTest):
         """
 
         # This is required until the java driver bundled with C* is updated to support v4
-        c = TestCluster(protocol_version=3)
+        c = IntegrationTestCluster(protocol_version=3)
         s = c.connect(self.keyspace_name)
 
         encoder = Encoder()
@@ -1910,7 +1910,7 @@ class BadMetaTest(unittest.TestCase):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.keyspace_name = cls.__name__.lower()
         cls.session = cls.cluster.connect()
         cls.session.execute("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}" % cls.keyspace_name)

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -1593,7 +1593,7 @@ class FunctionMetadata(FunctionTest):
 
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*%s\(\) .*" % kwargs['name'])
+            self.assertRegexpMatches(fn_meta.as_cql_query(), r"CREATE FUNCTION.*%s\(\) .*" % kwargs['name'])
 
     def test_functions_follow_keyspace_alter(self):
         """
@@ -1641,12 +1641,13 @@ class FunctionMetadata(FunctionTest):
         kwargs['called_on_null_input'] = True
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) CALLED ON NULL INPUT RETURNS .*")
+            self.assertRegexpMatches(fn_meta.as_cql_query(), r"CREATE FUNCTION.*\) CALLED ON NULL INPUT RETURNS .*")
 
         kwargs['called_on_null_input'] = False
         with self.VerifiedFunction(self, **kwargs) as vf:
             fn_meta = self.keyspace_function_meta[vf.signature]
-            self.assertRegexpMatches(fn_meta.as_cql_query(), "CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
+            self.assertRegexpMatches(fn_meta.as_cql_query(),
+                                     r"CREATE FUNCTION.*\) RETURNS NULL ON NULL INPUT RETURNS .*")
 
 
 class AggregateMetadata(FunctionTest):

--- a/tests/integration/standard/test_metrics.py
+++ b/tests/integration/standard/test_metrics.py
@@ -27,7 +27,7 @@ from cassandra import ConsistencyLevel, WriteTimeout, Unavailable, ReadTimeout
 from cassandra.protocol import SyntaxException
 
 from cassandra.cluster import NoHostAvailable, ExecutionProfile, EXEC_PROFILE_DEFAULT
-from tests.integration import get_cluster, get_node, use_singledc, execute_until_pass, TestCluster
+from tests.integration import get_cluster, get_node, use_singledc, execute_until_pass, IntegrationTestCluster
 from greplin import scales
 from tests.integration import BasicSharedKeyspaceUnitTestCaseRF3WM, BasicExistingKeyspaceUnitTestCase, local
 
@@ -42,8 +42,8 @@ class MetricsTests(unittest.TestCase):
 
     def setUp(self):
         contact_point = ['127.0.0.2']
-        self.cluster = TestCluster(contact_points=contact_point, metrics_enabled=True,
-                                   execution_profiles=
+        self.cluster = IntegrationTestCluster(contact_points=contact_point, metrics_enabled=True,
+                                              execution_profiles=
                                    {EXEC_PROFILE_DEFAULT:
                                        ExecutionProfile(
                                            load_balancing_policy=HostFilterPolicy(
@@ -51,7 +51,7 @@ class MetricsTests(unittest.TestCase):
                                            retry_policy=FallthroughRetryPolicy()
                                        )
                                    }
-                                   )
+                                              )
         self.session = self.cluster.connect("test3rf", wait_for_all_pools=True)
 
     def tearDown(self):
@@ -203,7 +203,7 @@ class MetricsNamespaceTest(BasicSharedKeyspaceUnitTestCaseRF3WM):
         @test_category metrics
         """
 
-        cluster2 = TestCluster(
+        cluster2 = IntegrationTestCluster(
             metrics_enabled=True,
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())}
         )
@@ -257,13 +257,13 @@ class MetricsNamespaceTest(BasicSharedKeyspaceUnitTestCaseRF3WM):
 
         @test_category metrics
         """
-        cluster2 = TestCluster(
+        cluster2 = IntegrationTestCluster(
             metrics_enabled=True,
             monitor_reporting_enabled=False,
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())}
         )
 
-        cluster3 = TestCluster(
+        cluster3 = IntegrationTestCluster(
             metrics_enabled=True,
             monitor_reporting_enabled=False,
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(retry_policy=FallthroughRetryPolicy())}

--- a/tests/integration/standard/test_policies.py
+++ b/tests/integration/standard/test_policies.py
@@ -23,7 +23,7 @@ from cassandra.policies import HostFilterPolicy, RoundRobinPolicy,  SimpleConvic
 from cassandra.pool import Host
 from cassandra.connection import DefaultEndPoint
 
-from tests.integration import local, use_singledc, TestCluster
+from tests.integration import local, use_singledc, IntegrationTestCluster
 
 from concurrent.futures import wait as wait_futures
 
@@ -55,9 +55,9 @@ class HostFilterPolicyTests(unittest.TestCase):
         hfp = ExecutionProfile(
             load_balancing_policy=HostFilterPolicy(RoundRobinPolicy(), predicate=predicate)
         )
-        cluster = TestCluster(contact_points=(contact_point,), execution_profiles={EXEC_PROFILE_DEFAULT: hfp},
-                              topology_event_refresh_window=0,
-                              status_event_refresh_window=0)
+        cluster = IntegrationTestCluster(contact_points=(contact_point,), execution_profiles={EXEC_PROFILE_DEFAULT: hfp},
+                                         topology_event_refresh_window=0,
+                                         status_event_refresh_window=0)
         session = cluster.connect(wait_for_all_pools=True)
 
         queried_hosts = set()
@@ -84,7 +84,7 @@ class WhiteListRoundRobinPolicyTests(unittest.TestCase):
     def test_only_connects_to_subset(self):
         only_connect_hosts = {"127.0.0.1", "127.0.0.2"}
         white_list = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy(only_connect_hosts))
-        cluster = TestCluster(execution_profiles={"white_list": white_list})
+        cluster = IntegrationTestCluster(execution_profiles={"white_list": white_list})
         #cluster = Cluster(load_balancing_policy=WhiteListRoundRobinPolicy(only_connect_hosts))
         session = cluster.connect(wait_for_all_pools=True)
         queried_hosts = set()

--- a/tests/integration/standard/test_prepared_statements.py
+++ b/tests/integration/standard/test_prepared_statements.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
+from tests.integration import use_singledc, PROTOCOL_VERSION, IntegrationTestCluster
 
 try:
     import unittest2 as unittest
@@ -43,7 +43,7 @@ class PreparedStatementTests(unittest.TestCase):
         cls.cass_version = get_server_versions()
 
     def setUp(self):
-        self.cluster = TestCluster(metrics_enabled=True, allow_beta_protocol_version=True)
+        self.cluster = IntegrationTestCluster(metrics_enabled=True, allow_beta_protocol_version=True)
         self.session = self.cluster.connect()
 
     def tearDown(self):
@@ -515,7 +515,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.12
         @jira_ticket PYTHON-808
         """
-        one_cluster = TestCluster(metrics_enabled=True)
+        one_cluster = IntegrationTestCluster(metrics_enabled=True)
         one_session = one_cluster.connect()
         self.addCleanup(one_cluster.shutdown)
 
@@ -555,7 +555,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.13
         @jira_ticket PYTHON-847
         """
-        cluster = TestCluster(protocol_version=ProtocolVersion.V4)
+        cluster = IntegrationTestCluster(protocol_version=ProtocolVersion.V4)
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 9)
@@ -569,7 +569,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.13
         @jira_ticket PYTHON-847
         """
-        cluster = TestCluster(protocol_version=ProtocolVersion.V5)
+        cluster = IntegrationTestCluster(protocol_version=ProtocolVersion.V5)
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 10)
@@ -584,7 +584,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.13
         @jira_ticket PYTHON-847
         """
-        cluster = TestCluster(protocol_version=ProtocolVersion.DSE_V1)
+        cluster = IntegrationTestCluster(protocol_version=ProtocolVersion.DSE_V1)
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 10)
@@ -599,7 +599,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
         @since 3.13
         @jira_ticket PYTHON-847
         """
-        cluster = TestCluster(protocol_version=ProtocolVersion.DSE_V2)
+        cluster = IntegrationTestCluster(protocol_version=ProtocolVersion.DSE_V2)
         session = cluster.connect()
         self.addCleanup(cluster.shutdown)
         self._test_updated_conditional(session, 10)

--- a/tests/integration/standard/test_query_paging.py
+++ b/tests/integration/standard/test_query_paging.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from tests.integration import use_singledc, PROTOCOL_VERSION, TestCluster
+from tests.integration import use_singledc, PROTOCOL_VERSION, IntegrationTestCluster
 
 import logging
 log = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ class QueryPagingTests(unittest.TestCase):
                 "Protocol 2.0+ is required for Paging state, currently testing against %r"
                 % (PROTOCOL_VERSION,))
 
-        self.cluster = TestCluster(
+        self.cluster = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(consistency_level=ConsistencyLevel.LOCAL_QUORUM)}
         )
         if PROTOCOL_VERSION < 3:

--- a/tests/integration/standard/test_routing.py
+++ b/tests/integration/standard/test_routing.py
@@ -21,7 +21,7 @@ from uuid import uuid1
 import logging
 log = logging.getLogger(__name__)
 
-from tests.integration import use_singledc, TestCluster
+from tests.integration import use_singledc, IntegrationTestCluster
 
 
 def setup_module():
@@ -36,7 +36,7 @@ class RoutingTests(unittest.TestCase):
 
     @classmethod
     def setup_class(cls):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect('test1rf')
 
     @classmethod

--- a/tests/integration/standard/test_row_factories.py
+++ b/tests/integration/standard/test_row_factories.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from tests.integration import get_server_versions, use_singledc, \
-    BasicSharedKeyspaceUnitTestCaseWFunctionTable, BasicSharedKeyspaceUnitTestCase, execute_until_pass, TestCluster
+    BasicSharedKeyspaceUnitTestCaseWFunctionTable, BasicSharedKeyspaceUnitTestCase, execute_until_pass, IntegrationTestCluster
 
 try:
     import unittest2 as unittest
@@ -87,7 +87,7 @@ class RowFactoryTests(BasicSharedKeyspaceUnitTestCaseWFunctionTable):
         cls.select = "SELECT * FROM {0}.{1}".format(cls.ks_name, cls.ks_name)
 
     def _results_from_row_factory(self, row_factory):
-        cluster = TestCluster(
+        cluster = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=row_factory)}
         )
         with cluster:
@@ -176,7 +176,7 @@ class NamedTupleFactoryAndNumericColNamesTests(unittest.TestCase):
     """
     @classmethod
     def setup_class(cls):
-        cls.cluster = TestCluster()
+        cls.cluster = IntegrationTestCluster()
         cls.session = cls.cluster.connect()
         cls._cass_version, cls._cql_version = get_server_versions()
         ddl = '''
@@ -213,7 +213,7 @@ class NamedTupleFactoryAndNumericColNamesTests(unittest.TestCase):
         """
         can SELECT numeric column  using  dict_factory
         """
-        with TestCluster(
+        with IntegrationTestCluster(
                 execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
         ) as cluster:
             try:

--- a/tests/integration/standard/test_single_interface.py
+++ b/tests/integration/standard/test_single_interface.py
@@ -25,7 +25,7 @@ from cassandra.query import SimpleStatement
 from packaging.version import Version
 from tests.integration import use_singledc, PROTOCOL_VERSION, \
     remove_cluster, greaterthanorequalcass40, notdse, \
-    CASSANDRA_VERSION, DSE_VERSION, TestCluster
+    CASSANDRA_VERSION, DSE_VERSION, IntegrationTestCluster
 
 
 def setup_module():
@@ -42,7 +42,7 @@ def teardown_module():
 class SingleInterfaceTest(unittest.TestCase):
 
     def setUp(self):
-        self.cluster = TestCluster()
+        self.cluster = IntegrationTestCluster()
         self.session = self.cluster.connect()
 
     def tearDown(self):

--- a/tests/integration/standard/test_types.py
+++ b/tests/integration/standard/test_types.py
@@ -34,7 +34,7 @@ from tests.unit.cython.utils import cythontest
 
 from tests.integration import use_singledc, execute_until_pass, notprotocolv1, \
     BasicSharedKeyspaceUnitTestCase, greaterthancass21, lessthancass30, greaterthanorequaldse51, \
-    DSE_VERSION, greaterthanorequalcass3_10, requiredse, TestCluster
+    DSE_VERSION, greaterthanorequalcass3_10, requiredse, IntegrationTestCluster
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES, COLLECTION_TYPES, PRIMITIVE_DATATYPES_KEYS, \
     get_sample, get_all_samples, get_collection_sample
 
@@ -136,7 +136,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         """
         Test insertion of all datatype primitives
         """
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name)
 
         # create table
@@ -217,7 +217,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         Test insertion of all collection types
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name)
         # use tuple encoding, to convert native python tuple into raw CQL
         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
@@ -449,7 +449,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name)
 
         # use this encoder in order to insert tuples
@@ -501,7 +501,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = TestCluster(
+        c = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
         )
         s = c.connect(self.keyspace_name)
@@ -540,7 +540,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name)
         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
 
@@ -568,7 +568,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = TestCluster(
+        c = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
         )
         s = c.connect(self.keyspace_name)
@@ -667,7 +667,7 @@ class TypeTests(BasicSharedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 0):
             raise unittest.SkipTest("The tuple type was introduced in Cassandra 2.1")
 
-        c = TestCluster(
+        c = IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
         )
         s = c.connect(self.keyspace_name)
@@ -1279,7 +1279,7 @@ class TypeTestsProtocol(BasicSharedKeyspaceUnitTestCase):
                 self.read_inserts_at_level(pvr)
 
     def read_inserts_at_level(self, proto_ver):
-        session = TestCluster(protocol_version=proto_ver).connect(self.keyspace_name)
+        session = IntegrationTestCluster(protocol_version=proto_ver).connect(self.keyspace_name)
         try:
             results = session.execute('select * from t')[0]
             self.assertEqual("[SortedSet([1, 2]), SortedSet([3, 5])]", str(results.v))
@@ -1297,7 +1297,7 @@ class TypeTestsProtocol(BasicSharedKeyspaceUnitTestCase):
             session.cluster.shutdown()
 
     def run_inserts_at_version(self, proto_ver):
-        session = TestCluster(protocol_version=proto_ver).connect(self.keyspace_name)
+        session = IntegrationTestCluster(protocol_version=proto_ver).connect(self.keyspace_name)
         try:
             p = session.prepare('insert into t (k, v) values (?, ?)')
             session.execute(p, (0, [{1, 2}, {3, 5}]))

--- a/tests/integration/standard/test_udts.py
+++ b/tests/integration/standard/test_udts.py
@@ -27,7 +27,7 @@ from cassandra.query import dict_factory
 from cassandra.util import OrderedMap
 
 from tests.integration import use_singledc, execute_until_pass, \
-    BasicSegregatedKeyspaceUnitTestCase, greaterthancass20, lessthancass30, greaterthanorequalcass36, TestCluster
+    BasicSegregatedKeyspaceUnitTestCase, greaterthancass20, lessthancass30, greaterthanorequalcass36, IntegrationTestCluster
 from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYPES, PRIMITIVE_DATATYPES_KEYS, \
     COLLECTION_TYPES, get_sample, get_collection_sample
 
@@ -79,7 +79,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the insertion of unprepared, registered UDTs
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         s.execute("CREATE TYPE user (age int, name text)")
@@ -123,7 +123,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the registration of UDTs before session creation
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(wait_for_all_pools=True)
 
         s.execute("""
@@ -144,7 +144,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
 
         # now that types are defined, shutdown and re-create Cluster
         c.shutdown()
-        c = TestCluster()
+        c = IntegrationTestCluster()
 
         User1 = namedtuple('user', ('age', 'name'))
         User2 = namedtuple('user', ('state', 'is_cool'))
@@ -181,7 +181,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the insertion of prepared, unregistered UDTs
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         s.execute("CREATE TYPE user (age int, name text)")
@@ -225,7 +225,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the insertion of prepared, registered UDTs
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         s.execute("CREATE TYPE user (age int, name text)")
@@ -275,7 +275,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test the insertion of UDTs with null and empty string fields
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         s.execute("CREATE TYPE user (a text, b int, c uuid, d blob)")
@@ -305,7 +305,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test for ensuring extra-lengthy udts are properly inserted
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         max_test_length = 254
@@ -385,7 +385,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
             self.assertEqual(udt, result["v_{0}".format(i)])
 
     def _cluster_default_dict_factory(self):
-        return TestCluster(
+        return IntegrationTestCluster(
             execution_profiles={EXEC_PROFILE_DEFAULT: ExecutionProfile(row_factory=dict_factory)}
         )
 
@@ -486,7 +486,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test for ensuring that an error is raised for operating on a nonexisting udt or an invalid keyspace
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
         User = namedtuple('user', ('age', 'name'))
 
@@ -506,7 +506,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test for inserting various types of PRIMITIVE_DATATYPES into UDT's
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         # create UDT
@@ -551,7 +551,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         Test for inserting various types of COLLECTION_TYPES into UDT's
         """
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
 
         # create UDT
@@ -618,7 +618,7 @@ class UDTTests(BasicSegregatedKeyspaceUnitTestCase):
         if self.cass_version < (2, 1, 3):
             raise unittest.SkipTest("Support for nested collections was introduced in Cassandra 2.1.3")
 
-        c = TestCluster()
+        c = IntegrationTestCluster()
         s = c.connect(self.keyspace_name, wait_for_all_pools=True)
         s.encoder.mapping[tuple] = s.encoder.cql_encode_tuple
 


### PR DESCRIPTION
* Replace all places that use old async node (`@asyncio.coroutine` and `yield from`) and use a new Python syntax (Only for Python v3.5+)
* Save the old code to allow users with Python v2+ to run our tests.
* requirements.txt:
  * Install `futures` package only for Python v2
  * Use the latest `sex` package version