### PR TITLE
PYTHON-1290 Convert asyncio reactor away from @asyncio.coroutine

### DIFF
--- a/cassandra/io/asyncioreactor.py
+++ b/cassandra/io/asyncioreactor.py
@@ -10,13 +10,6 @@ from threading import Lock, Thread, get_ident
 
 log = logging.getLogger(__name__)
 
-
-# This module uses ``yield from`` and ``@asyncio.coroutine`` over ``await`` and
-# ``async def`` for pre-Python-3.5 compatibility, so keep in mind that the
-# managed coroutines are generator-based, not native coroutines. See PEP 492:
-# https://www.python.org/dev/peps/pep-0492/#coroutine-objects
-
-
 try:
     asyncio.run_coroutine_threadsafe
 except AttributeError:
@@ -40,9 +33,10 @@ class AsyncioTimer(object):
                                   'does not implement .end()')
 
     def __init__(self, timeout, callback, loop):
-        delayed = self._call_delayed_coro(timeout=timeout,
+        delayed = asyncio.wait_for(self._call_delayed_coro(timeout=timeout,
                                           callback=callback,
-                                          loop=loop)
+                                          loop=loop),
+                                    timeout=None)
         self._handle = asyncio.run_coroutine_threadsafe(delayed, loop=loop)
 
     @staticmethod
@@ -96,10 +90,10 @@ class AsyncioConnection(Connection):
         # see initialize_reactor -- loop is running in a separate thread, so we
         # have to use a threadsafe call
         self._read_watcher = asyncio.run_coroutine_threadsafe(
-            self.handle_read(), loop=self._loop
+            asyncio.wait_for(self.handle_read(), timeout=None), loop=self._loop
         )
         self._write_watcher = asyncio.run_coroutine_threadsafe(
-            self.handle_write(), loop=self._loop
+            asyncio.wait_for(self.handle_write(), timeout=None), loop=self._loop
         )
         self._send_options_message()
 
@@ -132,7 +126,7 @@ class AsyncioConnection(Connection):
         # close from the loop thread to avoid races when removing file
         # descriptors
         asyncio.run_coroutine_threadsafe(
-            self._close(), loop=self._loop
+            asyncio.wait_for(self._close(), timeout=None), loop=self._loop
         )
 
     async def _close(self):
@@ -165,7 +159,7 @@ class AsyncioConnection(Connection):
 
         if self._loop_thread.ident != get_ident():
             asyncio.run_coroutine_threadsafe(
-                self._push_msg(chunks),
+                asyncio.wait_for(self._push_msg(chunks), timeout=None),
                 loop=self._loop
             )
         else:

--- a/cassandra/io/asyncioreactor.py
+++ b/cassandra/io/asyncioreactor.py
@@ -46,9 +46,8 @@ class AsyncioTimer(object):
         self._handle = asyncio.run_coroutine_threadsafe(delayed, loop=loop)
 
     @staticmethod
-    @asyncio.coroutine
-    def _call_delayed_coro(timeout, callback, loop):
-        yield from asyncio.sleep(timeout, loop=loop)
+    async def _call_delayed_coro(timeout, callback, loop):
+        await asyncio.sleep(timeout, loop=loop)
         return callback()
 
     def __lt__(self, other):
@@ -136,8 +135,7 @@ class AsyncioConnection(Connection):
             self._close(), loop=self._loop
         )
 
-    @asyncio.coroutine
-    def _close(self):
+    async def _close(self):
         log.debug("Closing connection (%s) to %s" % (id(self), self.endpoint))
         if self._write_watcher:
             self._write_watcher.cancel()
@@ -174,21 +172,19 @@ class AsyncioConnection(Connection):
             # avoid races/hangs by just scheduling this, not using threadsafe
             self._loop.create_task(self._push_msg(chunks))
 
-    @asyncio.coroutine
-    def _push_msg(self, chunks):
+    async def _push_msg(self, chunks):
         # This lock ensures all chunks of a message are sequential in the Queue
-        with (yield from self._write_queue_lock):
+        with await self._write_queue_lock:
             for chunk in chunks:
                 self._write_queue.put_nowait(chunk)
 
 
-    @asyncio.coroutine
-    def handle_write(self):
+    async def handle_write(self):
         while True:
             try:
-                next_msg = yield from self._write_queue.get()
+                next_msg = await self._write_queue.get()
                 if next_msg:
-                    yield from self._loop.sock_sendall(self._socket, next_msg)
+                    await self._loop.sock_sendall(self._socket, next_msg)
             except socket.error as err:
                 log.debug("Exception in send for %s: %s", self, err)
                 self.defunct(err)
@@ -196,11 +192,10 @@ class AsyncioConnection(Connection):
             except asyncio.CancelledError:
                 return
 
-    @asyncio.coroutine
-    def handle_read(self):
+    async def handle_read(self):
         while True:
             try:
-                buf = yield from self._loop.sock_recv(self._socket, self.in_buffer_size)
+                buf = await self._loop.sock_recv(self._socket, self.in_buffer_size)
                 self._iobuf.write(buf)
             # sock_recv expects EWOULDBLOCK if socket provides no data, but
             # nonblocking ssl sockets raise these instead, so we handle them

--- a/cassandra/io/asyncioreactor.py
+++ b/cassandra/io/asyncioreactor.py
@@ -202,7 +202,9 @@ class AsyncioConnection(Connection):
             # ourselves by yielding to the event loop, where the socket will
             # get the reading/writing it "wants" before retrying
             except (ssl.SSLWantWriteError, ssl.SSLWantReadError):
-                yield
+                # Apparently the preferred way to yield to the event loop from within
+                # a native coroutine based on https://github.com/python/asyncio/issues/284
+                await asyncio.sleep(0)
                 continue
             except socket.error as err:
                 log.debug("Exception during socket recv for %s: %s",


### PR DESCRIPTION
Short-term goal is to address the underlying issue at play in https://github.com/datastax/python-driver/pull/1118.  Longer-term this has the nice benefit of making us more compatible with how asyncio appears to be going generally.