### PR TITLE
PYTHON-1304 Fix test_connection integration test to account for recent changes to stream ID handling

### DIFF
--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -568,7 +568,9 @@ class HostConnection(object):
         connection = self._connection
         open_count = 1 if connection and not (connection.is_closed or connection.is_defunct) else 0
         in_flights = [connection.in_flight] if connection else []
-        return {'shutdown': self.is_shutdown, 'open_count': open_count, 'in_flights': in_flights}
+        orphan_requests = [connection.orphaned_request_ids] if connection else []
+        return {'shutdown': self.is_shutdown, 'open_count': open_count, \
+            'in_flights': in_flights, 'orphan_requests': orphan_requests}
 
     @property
     def open_count(self):
@@ -926,4 +928,6 @@ class HostConnectionPool(object):
 
     def get_state(self):
         in_flights = [c.in_flight for c in self._connections]
-        return {'shutdown': self.is_shutdown, 'open_count': self.open_count, 'in_flights': in_flights}
+        orphan_requests = [c.orphaned_request_ids for c in self._connections]
+        return {'shutdown': self.is_shutdown, 'open_count': self.open_count, \
+            'in_flights': in_flights, 'orphan_requests': orphan_requests}


### PR DESCRIPTION
[This commit](https://github.com/datastax/python-driver/commit/387150acc365b6cf1daaee58c62db13e4929099a) introduced some changes around the handling of orphaned stream IDs.  Unfortunately we had a utility class used by at least one of our integration tests which needed to be updated for some of the cases introduced by the improved stream ID handling.