### PR TITLE
docs: Fix a few typos

### DIFF
--- a/cassandra/cqlengine/models.py
+++ b/cassandra/cqlengine/models.py
@@ -593,7 +593,7 @@ class BaseModel(object):
 
     def _set_column_value(self, name, value):
         """Function to change a column value without changing the value manager states"""
-        self._values[name].value = value  # internal assignement, skip the main setter
+        self._values[name].value = value  # internal assignment, skip the main setter
 
     def validate(self):
         """

--- a/tests/integration/advanced/__init__.py
+++ b/tests/integration/advanced/__init__.py
@@ -125,7 +125,7 @@ def use_cluster_with_graph(num_nodes):
 
 class BasicGeometricUnitTestCase(BasicKeyspaceUnitTestCase):
     """
-    This base test class is used by all the geomteric tests. It contains class level teardown and setup
+    This base test class is used by all the geometric tests. It contains class level teardown and setup
     methods. It also contains the test fixtures used by those tests
     """
 

--- a/tests/integration/advanced/graph/test_graph_query.py
+++ b/tests/integration/advanced/graph/test_graph_query.py
@@ -56,7 +56,7 @@ class BasicGraphQueryTest(BasicGraphUnitTestCase):
         cl_attrs = ('graph_read_consistency_level', 'graph_write_consistency_level')
 
         # Iterates over the graph options and constructs an array containing
-        # The graph_options that correlate to graoh read and write consistency levels
+        # The graph_options that correlate to graph read and write consistency levels
         graph_params = [a[2] for a in _graph_options if a[0] in cl_attrs]
 
         s = self.session

--- a/tests/integration/advanced/test_spark.py
+++ b/tests/integration/advanced/test_spark.py
@@ -42,7 +42,7 @@ class SparkLBTests(BasicGraphUnitTestCase):
         self.session.execute_graph(ClassicGraphFixtures.classic())
         spark_master = find_spark_master(self.session)
 
-        # Run multipltle times to ensure we don't round robin
+        # Run multiple times to ensure we don't round robin
         for i in range(3):
             to_run = SimpleGraphStatement("g.V().count()")
             rs = self.session.execute_graph(to_run, execution_profile=EXEC_PROFILE_GRAPH_ANALYTICS_DEFAULT)

--- a/tests/integration/cqlengine/connections/test_connection.py
+++ b/tests/integration/cqlengine/connections/test_connection.py
@@ -102,7 +102,7 @@ class SeveralConnectionsTest(BaseCassEngTestCase):
     def test_connection_session_switch(self):
         """
         Test to ensure that when the default keyspace is changed in a session and that session,
-        is set in the connection class, that the new defaul keyspace is honored.
+        is set in the connection class, that the new default keyspace is honored.
 
         @since 3.1
         @jira_ticket PYTHON-486

--- a/tests/integration/cqlengine/test_connections.py
+++ b/tests/integration/cqlengine/test_connections.py
@@ -458,7 +458,7 @@ class UsingDescriptorTests(BaseCassEngTestCase):
 
         @since 3.7
         @jira_ticket PYTHON-613
-        @expected_result Keyspace segration is honored
+        @expected_result Keyspace segregation is honored
 
         @test_category object_mapper
         """

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -670,11 +670,11 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         """
         test for synchronously refreshing table metadata
 
-        test_refresh_table_metatadata tests that table metadata is refreshed when calling test_refresh_table_metatadata().
+        test_refresh_table_metadata tests that table metadata is refreshed when calling test_refresh_table_metadata().
         It creates a second cluster object with schema_event_refresh_window=-1 such that schema refreshes are disabled
         for schema change push events. It then alters the table, adding a new column, using the first cluster
         object, and verifies that the table metadata has not changed in the second cluster object. Finally, it calls
-        test_refresh_table_metatadata() and verifies that the table metadata is updated in the second cluster object.
+        test_refresh_table_metadata() and verifies that the table metadata is updated in the second cluster object.
 
         @since 2.6.0
         @jira_ticket PYTHON-291
@@ -704,10 +704,10 @@ class SchemaMetadataTests(BasicSegregatedKeyspaceUnitTestCase):
         test for synchronously refreshing materialized view metadata
 
         test_refresh_table_metadata_for_materialized_views tests that materialized view metadata is refreshed when calling
-        test_refresh_table_metatadata() with the materialized view name as the table. It creates a second cluster object
+        test_refresh_table_metadata() with the materialized view name as the table. It creates a second cluster object
         with schema_event_refresh_window=-1 such that schema refreshes are disabled for schema change push events.
         It then creates a new materialized view , using the first cluster object, and verifies that the materialized view
-        metadata has not changed in the second cluster object. Finally, it calls test_refresh_table_metatadata() with the
+        metadata has not changed in the second cluster object. Finally, it calls test_refresh_table_metadata() with the
         materialized view name as the table name, and verifies that the materialized view metadata is updated in the
         second cluster object.
 

--- a/tests/integration/standard/test_metrics.py
+++ b/tests/integration/standard/test_metrics.py
@@ -276,7 +276,7 @@ class MetricsNamespaceTest(BasicSharedKeyspaceUnitTestCaseRF3WM):
         session2 = cluster2.connect(self.ks_name, wait_for_all_pools=True)
         session3 = cluster3.connect(self.ks_name, wait_for_all_pools=True)
 
-        # Basic validation that naming metrics doesn't impact their segration or accuracy
+        # Basic validation that naming metrics doesn't impact their segregation or accuracy
         for i in range(10):
             query = SimpleStatement("SELECT * FROM {0}.{0}".format(self.ks_name), consistency_level=ConsistencyLevel.ALL)
             session2.execute(query)

--- a/tests/integration/standard/test_prepared_statements.py
+++ b/tests/integration/standard/test_prepared_statements.py
@@ -546,7 +546,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
     def test_id_is_not_updated_conditional_v4(self):
         """
         Test that verifies that the result_metadata and the
-        result_metadata_id are udpated correctly in conditional statements
+        result_metadata_id are updated correctly in conditional statements
         in protocol V4
 
         @since 3.13
@@ -561,7 +561,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
     def test_id_is_not_updated_conditional_v5(self):
         """
         Test that verifies that the result_metadata and the
-        result_metadata_id are udpated correctly in conditional statements
+        result_metadata_id are updated correctly in conditional statements
         in protocol V5
         @since 3.13
         @jira_ticket PYTHON-847
@@ -575,7 +575,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
     def test_id_is_not_updated_conditional_dsev1(self):
         """
         Test that verifies that the result_metadata and the
-        result_metadata_id are udpated correctly in conditional statements
+        result_metadata_id are updated correctly in conditional statements
         in protocol DSE V1
 
         @since 3.13
@@ -590,7 +590,7 @@ class PreparedStatementInvalidationTest(BasicSharedKeyspaceUnitTestCase):
     def test_id_is_not_updated_conditional_dsev2(self):
         """
         Test that verifies that the result_metadata and the
-        result_metadata_id are udpated correctly in conditional statements
+        result_metadata_id are updated correctly in conditional statements
         in protocol DSE V2
 
         @since 3.13

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1199,7 +1199,7 @@ class DowngradingConsistencyRetryPolicyTest(unittest.TestCase):
                 query=None, consistency=ONE, write_type=write_type,
                 required_responses=1, received_responses=2, retry_num=0)
             self.assertEqual(retry, RetryPolicy.IGNORE)
-            # retrhow if we can't be sure we have a replica
+            # rethrow if we can't be sure we have a replica
             retry, consistency = policy.on_write_timeout(
                 query=None, consistency=ONE, write_type=write_type,
                 required_responses=1, received_responses=0, retry_num=0)

--- a/tests/unit/test_resultset.py
+++ b/tests/unit/test_resultset.py
@@ -121,7 +121,7 @@ class ResultSetTests(unittest.TestCase):
         # index access before iteration causes list to be materialized
         self.assertEqual(rs[0], expected[0])
 
-        # resusable iteration
+        # reusable iteration
         self.assertListEqual(list(rs), expected)
         self.assertListEqual(list(rs), expected)
 
@@ -136,7 +136,7 @@ class ResultSetTests(unittest.TestCase):
         # index access before iteration causes list to be materialized
         self.assertEqual(rs[0], expected[0])
         self.assertEqual(rs[9], expected[9])
-        # resusable iteration
+        # reusable iteration
         self.assertListEqual(list(rs), expected)
         self.assertListEqual(list(rs), expected)
 


### PR DESCRIPTION
There are small typos in:
- cassandra/cqlengine/models.py
- tests/integration/advanced/__init__.py
- tests/integration/advanced/graph/test_graph_query.py
- tests/integration/advanced/test_spark.py
- tests/integration/cqlengine/connections/test_connection.py
- tests/integration/cqlengine/test_connections.py
- tests/integration/standard/test_metadata.py
- tests/integration/standard/test_metrics.py
- tests/integration/standard/test_prepared_statements.py
- tests/unit/test_policies.py
- tests/unit/test_resultset.py

Fixes:
- Should read `updated` rather than `udpated`.
- Should read `segregation` rather than `segration`.
- Should read `reusable` rather than `resusable`.
- Should read `metadata` rather than `metatadata`.
- Should read `rethrow` rather than `retrhow`.
- Should read `multiple` rather than `multipltle`.
- Should read `graph` rather than `graoh`.
- Should read `geometric` rather than `geomteric`.
- Should read `default` rather than `defaul`.
- Should read `assignment` rather than `assignement`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md