### PR TITLE
PYTHON-1267 Add a more useful error message for NaN decimals.

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -450,6 +450,8 @@ class DecimalType(_CassandraType):
             try:
                 sign, digits, exponent = Decimal(dec).as_tuple()
             except Exception:
+                if (Decimal(dec).is_nan()):
+                    raise ValueError("NaN is not a valid Cassandra Decimal value")
                 raise TypeError("Invalid type for Decimal value: %r", dec)
         unscaled = int(''.join([str(digit) for digit in digits]))
         if sign:

--- a/tests/unit/test_marshalling.py
+++ b/tests/unit/test_marshalling.py
@@ -143,3 +143,5 @@ class UnmarshalTest(unittest.TestCase):
             for n in converted_types:
                 expected = Decimal(n)
                 self.assertEqual(DecimalType.from_binary(DecimalType.to_binary(n, proto_ver), proto_ver), expected)
+        with self.assertRaises(ValueError):
+            DecimalType.to_binary(Decimal('NaN'), proto_ver)


### PR DESCRIPTION
Ideally we would be able to have full NaN support in the cassandra driver for python, as python Decimal type supports NaN. This isn't really doable, as Cassandra line protocol currently (v5) doesn't support it.  This gives us a better error message so at least it will be easy for users to understand what is going on when they try to serialize a NaN-valued python Decimal.