### PR TITLE
Handle "log gone" (PYTHON-1266) at the end of _run_loop

### DIFF
--- a/cassandra/io/asyncorereactor.py
+++ b/cassandra/io/asyncorereactor.py
@@ -259,7 +259,13 @@ class AsyncoreLoop(object):
                     break
             self._started = False
 
-        log.debug("Asyncore event loop ended")
+        try:
+            log.debug("Asyncore event loop ended")
+        except Exception:
+            # TODO: Remove when Python 2 support is removed
+            # PYTHON-1266. If our logger has disappeared, there's nothing we
+            # can do, so just log nothing.
+            pass            
 
     def add_timer(self, timer):
         self._timers.add_timer(timer)


### PR DESCRIPTION
If log is somehow gone and file exception due to the race mention in PYTHON-1266 it will also inevitably fail for the same reason after the loop so we need to catch the exception there as well.

I have hit it in some Cassandra dtest:
```
Exception in thread asyncore_cassandra_driver_event_loop (most likely raised during interpreter shutdown):
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
  File "/usr/lib/python2.7/threading.py", line 754, in run
  File "/dse/dse-db/bin/../lib/cassandra-driver-internal-only-3.25.0.zip/cassandra-driver-3.25.0/cassandra/io/asyncorereactor.py", line 262, in _run_loop
<type 'exceptions.AttributeError'>: 'NoneType' object has no attribute 'debug'
```

[PYTHON-1266]: https://datastax-oss.atlassian.net/browse/PYTHON-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ