### PR TITLE
Add PYTEST_DONT_REWRITE to type_codes module

### DIFF
--- a/cassandra/type_codes.py
+++ b/cassandra/type_codes.py
@@ -37,7 +37,8 @@ Type codes are repeated here from the Cassandra binary protocol specification:
             0x0022    Set: the value is an [option], representing the type
                             of the elements of the set
 
-See https://issues.apache.org/jira/browse/CASSANDRA-18369
+# This line is needed to workaround pytest issue https://github.com/pytest-dev/pytest/issues/10844
+# It can be safely removed when the issue is solved
 PYTEST_DONT_REWRITE
 """
 

--- a/cassandra/type_codes.py
+++ b/cassandra/type_codes.py
@@ -36,6 +36,9 @@ Type codes are repeated here from the Cassandra binary protocol specification:
                            keys and values of the map
             0x0022    Set: the value is an [option], representing the type
                             of the elements of the set
+
+See https://issues.apache.org/jira/browse/CASSANDRA-18369
+PYTEST_DONT_REWRITE
 """
 
 CUSTOM_TYPE = 0x0000


### PR DESCRIPTION
Solves the problem that collecting on running test without exclusion on Pytest test name, importing cassandra driver causes a very strangely looking error:

```
from cassandra.cluster import Cluster
cassandra/cluster.py:48: in init cassandra.cluster ???
cassandra/connection.py:40: in init cassandra.connection ???
cassandra/protocol.py:698: in genexpr
???
cassandra/protocol.py:698: in genexpr
???
E KeyError: '@py_builtins'
```

This happened for Apache Airflow when we wanted to enable pytest collection to include all files, rather than only "test_*.py" files, because we found that there were at least few modules in airflow that did not start with "test".

It turned out that the culprit was Assert Rewrite done by pytest that tried to rewrite "type_codes.py" module of Cassandra.

One of the ways to avoid the problem is to disable assert rewrite by "–assert=plain".  However then asserts are not as useful. Better solution (PR is coming) is to add PYTEST_DONT_REWRITE in the docstring:

https://docs.pytest.org/en/latest/how-to/assert.html#disabling-assert-rewriting

Reference: https://issues.apache.org/jira/browse/CASSANDRA-18369