### PR TITLE
PYTHON-1297: Pytest compatibility to move from nosetest

### DIFF
--- a/tests/integration/cqlengine/conftest.py
+++ b/tests/integration/cqlengine/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from tests.integration.cqlengine import setup_package, teardown_package, setup_connection
+
+@pytest.fixture(scope='session', autouse=True)
+def setup_and_teardown_packages():
+    setup_package()
+    yield
+    teardown_package()

--- a/tests/integration/cqlengine/test_batch_query.py
+++ b/tests/integration/cqlengine/test_batch_query.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
-
+import pytest
 import sure
 
 from cassandra.cqlengine import columns
@@ -217,7 +217,7 @@ class BatchQueryCallbacksTests(BaseCassEngTestCase):
         def my_callback(*args, **kwargs):
             call_history.append(args)
 
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.warns() as w:
             with BatchQuery() as batch:
                 batch.add_callback(my_callback)
                 batch.execute()

--- a/tests/unit/test_host_connection_pool.py
+++ b/tests/unit/test_host_connection_pool.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import pytest
 
 from mock import Mock, NonCallableMagicMock
 from threading import Thread, Event, Lock
@@ -23,6 +24,7 @@ from cassandra.pool import HostConnection, HostConnectionPool
 from cassandra.pool import Host, NoConnectionsAvailable
 from cassandra.policies import HostDistance, SimpleConvictionPolicy
 
+@pytest.mark.skip
 class _PoolTests(unittest.TestCase):
     PoolImpl = None
     uses_single_connection = None


### PR DESCRIPTION
Enabled unit tests to work with Pytest
Made initial changes to integration tests for Pytest usage