### PR TITLE
Don't fail when inserting UDTs with prepared queries with some missing fields #224

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -1026,7 +1026,9 @@ class UserType(TupleType):
             try:
                 item = val[i]
             except TypeError:
-                item = getattr(val, fieldname)
+                item = getattr(val, fieldname, None)
+                if item is None and not hasattr(val, fieldname):
+                    log.warning(f"field {fieldname} is part of the UDT {cls.typename} but is not present in the value {val}")
 
             if item is not None:
                 packed_item = subtype.to_binary(item, proto_version)


### PR DESCRIPTION
Let's say you have an object:
```
class Address(object):

    def __init__(self, street, zipcode, **kwargs):
        self.street = street
        self.zipcode = zipcode

cluster.register_user_type('mykeyspace', 'address', Address)
```

And let's say the type actually contains another field, let's call i raw_address

Then inserting data through a prepared statement will actually fail : the driver will complain raw_address is missing.

This change addresses that, as any field should be optional.