### PR TITLE
remove unnecessary import __future__

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -16,7 +16,6 @@
 This module houses the main classes you will interact with,
 :class:`.Cluster` and :class:`.Session`.
 """
-from __future__ import absolute_import
 
 import atexit
 from binascii import hexlify

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import  # to enable import io from stdlib
 from collections import defaultdict, deque
 import errno
 from functools import wraps, partial, total_ordering

--- a/cassandra/cqlengine/functions.py
+++ b/cassandra/cqlengine/functions.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
 from datetime import datetime
 
 from cassandra.cqlengine import UnicodeMixin, ValidationError

--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -27,7 +27,6 @@ the corresponding CQL or Cassandra type strings.
 # for example), these classes would be a good place to tack on
 # .from_cql_literal() and .as_cql_literal() classmethods (or whatever).
 
-from __future__ import absolute_import  # to enable import io from stdlib
 import ast
 from binascii import unhexlify
 import calendar

--- a/cassandra/protocol.py
+++ b/cassandra/protocol.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import  # to enable import io from stdlib
 from collections import namedtuple
 import logging
 import socket

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import with_statement
 import calendar
 import datetime
 from functools import total_ordering


### PR DESCRIPTION
unit it tests ran successfully (with pytest) except for those related to PYTHON-1300.
============================================================= short test summary info ==============================================================
FAILED tests/unit/test_host_connection_pool.py::_PoolTests::test_borrow_and_return - TypeError: 'NoneType' object is not callable
FAILED tests/unit/test_host_connection_pool.py::_PoolTests::test_failed_wait_for_connection - TypeError: 'NoneType' object is not callable
FAILED tests/unit/test_host_connection_pool.py::_PoolTests::test_return_closed_connection - TypeError: 'NoneType' object is not callable
FAILED tests/unit/test_host_connection_pool.py::_PoolTests::test_return_defunct_connection - TypeError: 'NoneType' object is not callable
FAILED tests/unit/test_host_connection_pool.py::_PoolTests::test_return_defunct_connection_on_down_host - TypeError: 'NoneType' object is not callable
FAILED tests/unit/test_host_connection_pool.py::_PoolTests::test_spawn_when_at_max - TypeError: 'NoneType' object is not callable
FAILED tests/unit/test_host_connection_pool.py::_PoolTests::test_successful_wait_for_connection - TypeError: 'NoneType' object is not callable
============================================= 7 failed, 559 passed, 68 skipped, 852 warnings in 20.11s =============================================
