### PR TITLE
PYTHON-1359 Fix for numpy>=1.24.0

### DIFF
--- a/cassandra/numpy_parser.pyx
+++ b/cassandra/numpy_parser.pyx
@@ -134,7 +134,7 @@ def make_array(coltype, array_size):
     """
     try:
         a = np.ma.empty((array_size,), dtype=_cqltype_to_numpy[coltype])
-        a.mask = np.zeros((array_size,), dtype=np.bool)
+        a.mask = np.zeros((array_size,), dtype=bool)
     except KeyError:
         a = np.empty((array_size,), dtype=obj_dtype)
     return a


### PR DESCRIPTION
Reported also in https://datastax-oss.atlassian.net/browse/PYTHON-1359, minimal `example.py`:

```python
from cassandra.cluster import Cluster
from cassandra.query import tuple_factory
from cassandra.protocol import NumpyProtocolHandler
import pandas as pd
cluster = Cluster()
session = cluster.connect()
session.row_factory = tuple_factory
session.client_protocol_handler = NumpyProtocolHandler
print(pd.DataFrame(session.execute("SELECT broadcast_port FROM system.local").one()))
```

Result with numpy<1.24.0:
```
$ python3 example.py
   broadcast_port
0            7000
```

Result with numpy>=1.24.0:
```
$ python3 example.py
/usr/lib/python3/dist-packages/cassandra/io/libevreactor.py:370: FutureWarning: In the future `np.bool` will be defined as the corresponding NumPy scalar.  (This may have returned Python scalars in past versions.
  self.process_io_buffer()
Empty DataFrame
Columns: []
Index: []
```