### PR TITLE
PYTHON-1358 Add a TimeUUID class

### DIFF
--- a/cassandra/cqltypes.py
+++ b/cassandra/cqltypes.py
@@ -677,7 +677,7 @@ class TimeUUIDType(DateType):
 
     @staticmethod
     def deserialize(byts, protocol_version):
-        return UUID(bytes=byts)
+        return util.TimeUUID(bytes=byts)
 
     @staticmethod
     def serialize(timeuuid, protocol_version):

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -129,13 +129,13 @@ class TimeUUID(uuid.UUID):
             return self.time == other.time and self.bytes[8:16] == other.bytes[8:16] 
         return NotImplemented
     
-    # def __lt__(self, other):
-    #     if isinstance(other, TimeUUID):
-    #         if self.time != other.time:
-    #             return self.time < other.time
-    #         else:
-    #             return self.lsb < other.lsb
-    #     return NotImplemented
+    def __lt__(self, other):
+        if isinstance(other, TimeUUID):
+            if self.time != other.time:
+                return self.time < other.time
+            else:
+                return self.lsb < other.lsb
+        return NotImplemented
 
     def __gt__(self, other):
         return not self <= other

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -946,3 +946,38 @@ class TestOrdering(unittest.TestCase):
         tokens_equal = [Token(1), Token(1)]
         check_sequence_consistency(self, tokens)
         check_sequence_consistency(self, tokens_equal, equal=True)
+
+    def test_timeuuid_comparison(self):
+        """
+        Test TimeUUID is compared just as Cassandra does
+        If first compares the timestamps,
+        then the last 64 bits interpreted as a signed int
+
+        @jira_ticket PYTHON-1358
+        @expected_result The TimeUUID from 2023-06-19 23:49:56.990000+0000
+        should be smaller than the one from 2023-06-19 23:49:59.961000+0000
+
+        @test_category data_types
+        """
+        time1 = datetime.datetime(2023, 6, 19, 23, 49, 56, 990000)
+        time2 = datetime.datetime(2023, 6, 19, 23, 49, 59, 961000)
+        timeuuid1 = util.uuid_from_time(time1)
+        timeuuid2 = util.uuid_from_time(time2)
+        # self.assertTrue(timeuuid1 < timeuuid2)
+        
+    def test_timeuuid_with_same_time(self):
+        """
+        Test TimeUUID is compared just as Cassandra does
+        If first compares the timestamps,
+        then the last 64 bits interpreted as a signed int
+
+        @jira_ticket PYTHON-1358
+        @expected_result The min TimeUUID should be smaller than 
+        the max TimeUUID with the same timestamp
+
+        @test_category data_types
+        """
+        timestamp = 1693776594
+        min_timeuuid = util.min_uuid_from_time(timestamp)
+        max_timeuuid = util.max_uuid_from_time(timestamp)
+        self.assertTrue(min_timeuuid < max_timeuuid)

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -963,7 +963,7 @@ class TestOrdering(unittest.TestCase):
         time2 = datetime.datetime(2023, 6, 19, 23, 49, 59, 961000)
         timeuuid1 = util.uuid_from_time(time1)
         timeuuid2 = util.uuid_from_time(time2)
-        # self.assertTrue(timeuuid1 < timeuuid2)
+        self.assertTrue(timeuuid1 < timeuuid2)
         
     def test_timeuuid_with_same_time(self):
         """


### PR DESCRIPTION
Closes [PYTHON-1358](https://datastax-oss.atlassian.net/browse/PYTHON-1358). Based on [Cassandra's implementation](https://github.com/apache/cassandra/blob/ae537abc6494564d7254a2126465522d86b44c1e/src/java/org/apache/cassandra/utils/TimeUUID.java) and the issue reporter's [code](https://gist.github.com/cvybhu/ed5b64d8b62eff51dc46258157a92e41).

I am considering where to put the class `TimeUUID` and the relevant tests. I currently put them in `util.py` and `test_types.py`, which is weird. Any suggestions?

Any requests for changes are welcomed.