### PR TITLE
docs: Fix typo in add_callbacks

### DIFF
--- a/docs/api/cassandra/cluster.rst
+++ b/docs/api/cassandra/cluster.rst
@@ -215,7 +215,7 @@
 
    .. automethod:: add_errback(fn, *args, **kwargs)
 
-   .. automethod:: add_callbacks(callback, errback, callback_args=(), callback_kwargs=None, errback_args=(), errback_args=None)
+   .. automethod:: add_callbacks(callback, errback, callback_args=(), callback_kwargs=None, errback_args=(), errback_kwargs=None)
 
 .. autoclass:: ResultSet ()
    :members:


### PR DESCRIPTION
Fix a typo in the `add_callbacks` method signature.