### PR TITLE
Add Jenkins support for Python 3.12.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ slack = new Slack()
 
 DEFAULT_CASSANDRA = ['3.0', '3.11', '4.0']
 DEFAULT_DSE = ['dse-5.1.35', 'dse-6.8.30']
-DEFAULT_RUNTIME = ['3.8.16', '3.9.16', '3.10.11', '3.11.3']
+DEFAULT_RUNTIME = ['3.8.16', '3.9.16', '3.10.11', '3.11.3', '3.12.0']
 DEFAULT_CYTHON = ["True", "False"]
 matrices = [
   "FULL": [
@@ -605,8 +605,8 @@ pipeline {
   triggers {
     parameterizedCron(branchPatternCron().matcher(env.BRANCH_NAME).matches() ? """
       # Every weeknight (Monday - Friday) around 4:00 AM
-      # These schedules will run with and without Cython enabled for Python 3.8.16 and 3.11.3
-      H 4 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;EVENT_LOOP=LIBEV;CI_SCHEDULE_PYTHON_VERSION=3.8.16 3.11.3;CI_SCHEDULE_SERVER_VERSION=3.11 4.0 dse-5.1.35 dse-6.8.30
+      # These schedules will run with and without Cython enabled for Python 3.8.16 and 3.12.0
+      H 4 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;EVENT_LOOP=LIBEV;CI_SCHEDULE_PYTHON_VERSION=3.8.16 3.12.0;CI_SCHEDULE_SERVER_VERSION=3.11 4.0 dse-5.1.35 dse-6.8.30
     """ : "")
   }
 


### PR DESCRIPTION
Requires Python 3.12.0 to be added to the Jenkins runners; don't merge until that's done.