### PR TITLE
Replace deprecated method assertRaisesRegexp for assertRaisesRegex

### DIFF
--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -626,7 +626,7 @@ class ResponseFutureTests(unittest.TestCase):
 
         rf._on_timeout()
         pool.return_connection.assert_called_once_with(connection, stream_was_orphaned=True)
-        self.assertRaisesRegexp(OperationTimedOut, "Client request timeout", rf.result)
+        self.assertRaisesRegex(OperationTimedOut, "Client request timeout", rf.result)
 
         assert len(connection.request_ids) == 0, \
             "Request IDs should be empty but it's not: {}".format(connection.request_ids)


### PR DESCRIPTION
The legacy unittest class method assertRaisesRegexp was deprecated in favour of assertRaisesRegex