### PR TITLE
fix build from source on macos using homebrew

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ murmur3_ext = Extension('cassandra.cmurmur3',
 
 libev_ext = Extension('cassandra.io.libevwrapper',
                       sources=['cassandra/io/libevwrapper.c'],
-                      include_dirs=['/usr/include/libev', '/usr/local/include', '/opt/local/include'],
+                      include_dirs=['/usr/include/libev', '/usr/local/include', '/opt/local/include', '/opt/homebrew/include', os.path.expanduser('~/homebrew/include')],
                       libraries=['ev'],
                       library_dirs=['/usr/local/lib', '/opt/local/lib'])
 


### PR DESCRIPTION
Documentation [here](https://python-driver.readthedocs.io/en/stable/installation.html#libev-support) mentions to install `libev` from homebrew. 

```sh
 $ brew install libev
 ```
 
The problem I found is that the pre-build package from pip doesn't have the extensions compiled [PYTHON-1376](https://datastax-oss.atlassian.net/jira/software/c/projects/PYTHON/issues/PYTHON-1376). Building from source on macOS doesn't find `libev` include folder for Homebrew as well.
 
 This PR fixes the missing include folder to be aligned with the current documentation.

[PYTHON-1376]: https://datastax-oss.atlassian.net/browse/PYTHON-1376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ