### PR TITLE
PYTHON-1378 Expand search directories for includes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,13 +145,15 @@ murmur3_ext = Extension('cassandra.cmurmur3',
                         sources=['cassandra/cmurmur3.c'])
 
 libev_includes = ['/usr/include/libev', '/usr/local/include', '/opt/local/include', '/usr/include']
+libev_libdirs = ['/usr/local/lib', '/opt/local/lib', '/usr/lib64']
 if is_macos:
     libev_includes.extend(['/opt/homebrew/include', os.path.expanduser('~/homebrew/include')])
+    libev_libdirs.extend(['/opt/homebrew/lib'])
 libev_ext = Extension('cassandra.io.libevwrapper',
                       sources=['cassandra/io/libevwrapper.c'],
                       include_dirs=libev_includes,
                       libraries=['ev'],
-                      library_dirs=['/usr/local/lib', '/opt/local/lib', '/usr/lib64'])
+                      library_dirs=libev_libdirs)
 
 platform_unsupported_msg = \
 """

--- a/setup.py
+++ b/setup.py
@@ -138,15 +138,20 @@ class BuildFailed(Exception):
     def __init__(self, ext):
         self.ext = ext
 
+is_windows = sys.platform.startswith('win32')
+is_macos = sys.platform.startswith('darwin')
 
 murmur3_ext = Extension('cassandra.cmurmur3',
                         sources=['cassandra/cmurmur3.c'])
 
+libev_includes = ['/usr/include/libev', '/usr/local/include', '/opt/local/include', '/usr/include']
+if is_macos:
+    libev_includes.extend(['/opt/homebrew/include', os.path.expanduser('~/homebrew/include')])
 libev_ext = Extension('cassandra.io.libevwrapper',
                       sources=['cassandra/io/libevwrapper.c'],
-                      include_dirs=['/usr/include/libev', '/usr/local/include', '/opt/local/include', '/opt/homebrew/include', os.path.expanduser('~/homebrew/include')],
+                      include_dirs=libev_includes,
                       libraries=['ev'],
-                      library_dirs=['/usr/local/lib', '/opt/local/lib'])
+                      library_dirs=['/usr/local/lib', '/opt/local/lib', '/usr/lib64'])
 
 platform_unsupported_msg = \
 """
@@ -168,8 +173,6 @@ pypy_unsupported_msg = \
 Some optional C extensions are not supported in PyPy. Only murmur3 will be built.
 =================================================================================
 """
-
-is_windows = os.name == 'nt'
 
 is_pypy = "PyPy" in sys.version
 if is_pypy:


### PR DESCRIPTION
Need to make sure we can find include directories for packages installed on the Docker images used by cibuildwheel