### PR TITLE
Introduce Datetime type for ranges outside datetime.[MIN|MAX]YEAR

### DIFF
--- a/cassandra/deserializers.pyx
+++ b/cassandra/deserializers.pyx
@@ -17,7 +17,7 @@ from libc.stdint cimport int32_t, uint16_t
 
 include 'cython_marshal.pyx'
 from cassandra.buffer cimport Buffer, to_bytes, slice_buffer
-from cassandra.cython_utils cimport datetime_from_timestamp
+from cassandra.cython_utils cimport datetime_from_timestamp, DATETIME_EPOC
 
 from cython.view cimport array as cython_array
 from cassandra.tuple cimport tuple_new, tuple_set
@@ -136,7 +136,7 @@ cdef class DesCounterColumnType(DesLongType):
 cdef class DesDateType(Deserializer):
     cdef deserialize(self, Buffer *buf, int protocol_version):
         cdef double timestamp = unpack_num[int64_t](buf) / 1000.0
-        return datetime_from_timestamp(timestamp)
+        return util.Datetime(util.Datetime(DATETIME_EPOC) + datetime.timedelta(seconds=timestamp))
 
 
 cdef class TimestampType(DesDateType):

--- a/cassandra/encoder.py
+++ b/cassandra/encoder.py
@@ -29,7 +29,7 @@ import types
 from uuid import UUID
 import ipaddress
 
-from cassandra.util import (OrderedDict, OrderedMap, OrderedMapSerializedKey,
+from cassandra.util import (Datetime, OrderedDict, OrderedMap, OrderedMapSerializedKey,
                             sortedset, Time, Date, Point, LineString, Polygon)
 
 
@@ -67,6 +67,7 @@ class Encoder(object):
             datetime.date: self.cql_encode_date,
             datetime.time: self.cql_encode_time,
             Date: self.cql_encode_date_ext,
+            Datetime: self.cql_encode_datetime_ext,
             Time: self.cql_encode_time,
             dict: self.cql_encode_map_collection,
             OrderedDict: self.cql_encode_map_collection,
@@ -141,6 +142,13 @@ class Encoder(object):
         """
         timestamp = calendar.timegm(val.utctimetuple())
         return str(int(timestamp * 1e3 + getattr(val, 'microsecond', 0) / 1e3))
+
+    def cql_encode_datetime_ext(self, val):
+        """
+        Encodes a :class:`cassandra.util.Datetime` object as an integer
+        """
+        # using the int form in case the Datetime exceeds datetime.[MIN|MAX]YEAR
+        return str(val.milliseconds_from_epoch)
 
     def cql_encode_date(self, val):
         """

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -1006,6 +1006,131 @@ class Date(object):
             return str(self.days_from_epoch)
 
 
+@total_ordering
+class Datetime(object):
+    '''
+    Idealized datetime: year, month, day, hour, minute, second, microsecond, and tzinfo
+
+    Offers wider year range than datetime.datetime. For Datetimess that cannot be represented
+    as a datetime.datetime (because datetime.MINYEAR, datetime.MAXYEAR), this type falls back
+    to printing milliseconds_from_epoch offset.
+    '''
+    
+    MICRO = 1000
+    MILLI = 1000 * MICRO
+    SECOND = 1000 * MILLI
+    MINUTE = 60
+    HOUR = 60 * MINUTE
+    DAY = 24 * HOUR
+
+    milliseconds_from_epoch = 0
+    tzinfo = None
+
+    def __init__(self, value):
+        """
+        Initializer value can be:
+
+        - number_type: milliseconds from epoch (1970, 1, 1). Can be negative.
+        - datetime.datetime: built-in datetime
+        """
+        if isinstance(value, (int, long, float)):
+            self.milliseconds_from_epoch = value
+        elif isinstance(value, datetime.datetime):
+            self._from_datetime(value)
+        elif isinstance(value, datetime.date):
+            self._from_timetuple(value.timetuple())
+        elif isinstance(value, Datetime):
+            self.milliseconds_from_epoch = value.milliseconds_from_epoch
+            self.tzinfo = value.tzinfo
+        else:
+            raise TypeError('Date arguments must be a whole number or datetime.datetime')
+
+    @property
+    def seconds(self):
+        """
+        Absolute seconds from epoch (can be negative)
+        """
+        return self.milliseconds_from_epoch // 1000
+     
+    @property
+    def days(self):
+        """
+        Absolute days from epoch (can be negative)
+        """
+        return self.seconds // Date.DAY
+
+    def datetime(self):
+        """
+        Return a built-in datetime.datetime for Dates falling in the years [datetime.MINYEAR, datetime.MAXYEAR]
+
+        ValueError is raised for Dates outside this range.
+        """
+        try:
+            dt = datetime.datetime(1970, 1, 1, tzinfo=self.tzinfo) + datetime.timedelta(milliseconds=self.milliseconds_from_epoch)
+            return dt
+        except Exception:
+            raise ValueError("%r exceeds ranges for built-in datetime.datetime" % self)
+        
+    def utctimetuple(self):
+        return self.datetime().utctimetuple()
+    
+    def timetuple(self):
+        return self.datetime().timetuple()
+
+    def isoformat(self, sep='T', timespec='auto'):
+        return self.datetime().isoformat(sep, timespec)
+
+    def _from_timetuple(self, t):
+        self.milliseconds_from_epoch = calendar.timegm(t) * 1000
+
+    def _from_datetime(self, v):
+        self.milliseconds_from_epoch = calendar.timegm(v.timetuple()) * 1000 + v.microsecond // 1000
+        self.tzinfo = v.tzinfo
+
+    def __hash__(self):
+        return self.milliseconds_from_epoch
+
+    def __eq__(self, other):
+        if isinstance(other, Datetime):
+            return self.milliseconds_from_epoch == other.milliseconds_from_epoch
+
+        if isinstance(other, (int, long, float)):
+            return self.milliseconds_from_epoch == other
+
+        try:
+            return self.datetime() == other
+        except Exception:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __lt__(self, other):
+        if not isinstance(other, Datetime):
+            return NotImplemented
+        return self.milliseconds_from_epoch < other.milliseconds_from_epoch
+
+    def __add__(self, other):
+        if isinstance(other, datetime.timedelta):
+            return Datetime(int(self.milliseconds_from_epoch + other.total_seconds() * 1000))
+        return self + other
+    
+    def __sub__(self, other):
+        if isinstance(other, Datetime):
+            return datetime.timedelta(milliseconds=self.milliseconds_from_epoch - other.milliseconds_from_epoch)
+        return self - other
+
+    def __repr__(self):
+        return "Datetime(%s)" % self.milliseconds_from_epoch
+
+    def __str__(self):
+        try:
+            dt = datetime.datetime(1970, 1, 1, tzinfo=self.tzinfo) + datetime.timedelta(milliseconds=self.milliseconds_from_epoch)
+            return "%04d-%02d-%02d %02d:%02d:%02d.%09d" % (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
+        except:
+            return str(self.milliseconds_from_epoch)
+
+
 inet_pton = socket.inet_pton
 inet_ntop = socket.inet_ntop
 

--- a/tests/integration/cqlengine/columns/test_container_columns.py
+++ b/tests/integration/cqlengine/columns/test_container_columns.py
@@ -25,6 +25,7 @@ import cassandra.cqlengine.columns as columns
 from cassandra.cqlengine.functions import get_total_seconds
 from cassandra.cqlengine.models import Model, ValidationError
 from cassandra.cqlengine.management import sync_table, drop_table
+from cassandra.util import Datetime
 
 from tests.integration import CASSANDRA_IP
 from tests.integration.cqlengine import is_prepend_reversed
@@ -389,7 +390,7 @@ class TestMapColumn(BaseCassEngTestCase):
         """ Tests that a basic usage works as expected """
         k1 = uuid4()
         k2 = uuid4()
-        now = datetime.now()
+        now = Datetime(datetime.now())
         then = now + timedelta(days=1)
         m1 = TestMapModel.create(int_map={1: k1, 2: k2},
                                  text_map={'now': now, 'then': then})

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -97,7 +97,7 @@ class TestDatetime(BaseCassEngTestCase):
         dt_value = 1454520554
         self.DatetimeTest.objects.create(test_id=5, created_at=dt_value)
         dt2 = self.DatetimeTest.objects(test_id=5).first()
-        self.assertEqual(dt2.created_at, datetime.utcfromtimestamp(dt_value))
+        self.assertEqual(dt2.created_at, util.Datetime(datetime.utcfromtimestamp(dt_value)))
 
     def test_datetime_large(self):
         dt_value = datetime(2038, 12, 31, 10, 10, 10, 123000)
@@ -318,12 +318,12 @@ class TestDateTime(DataType, BaseCassEngTestCase):
     def setUpClass(cls):
         cls.db_klass, cls.python_klass = (
             DateTime,
-            datetime
+            util.Datetime
         )
         cls.first_value, cls.second_value, cls.third_value = (
-            datetime(2017, 4, 13, 18, 34, 24, 317000),
-            datetime(1, 1, 1),
-            datetime(1, 1, 2)
+            util.Datetime(datetime(2017, 4, 13, 18, 34, 24, 317000)),
+            util.Datetime(datetime(1, 1, 1)),
+            util.Datetime(datetime(1, 1, 2))
         )
         super(TestDateTime, cls).setUpClass()
 

--- a/tests/integration/cqlengine/query/test_datetime_queries.py
+++ b/tests/integration/cqlengine/query/test_datetime_queries.py
@@ -15,6 +15,7 @@
 from datetime import datetime, timedelta
 from uuid import uuid4
 from cassandra.cqlengine.functions import get_total_seconds
+from cassandra.util import Datetime
 
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 
@@ -65,7 +66,7 @@ class TestDateTimeQueries(BaseCassEngTestCase):
     @execute_count(3)
     def test_datetime_precision(self):
         """ Tests that millisecond resolution is preserved when saving datetime objects """
-        now = datetime.now()
+        now = Datetime(datetime.now())
         pk = 1000
         obj = DateTimeQueryTestModel.create(user=pk, day=now, data='energy cheese')
         load = DateTimeQueryTestModel.get(user=pk)

--- a/tests/integration/datatype_utils.py
+++ b/tests/integration/datatype_utils.py
@@ -17,7 +17,7 @@ from datetime import datetime, date, time
 import ipaddress
 from uuid import uuid1, uuid4
 
-from cassandra.util import OrderedMap, Date, Time, sortedset, Duration
+from cassandra.util import Datetime, OrderedMap, Date, Time, sortedset, Duration
 
 from tests.integration import get_server_versions
 
@@ -103,7 +103,7 @@ def get_sample_data():
             sample_data[datatype] = 'text'
 
         elif datatype == 'timestamp':
-            sample_data[datatype] = datetime(2013, 12, 31, 23, 59, 59, 999000)
+            sample_data[datatype] = Datetime(datetime(2013, 12, 31, 23, 59, 59, 999000))
 
         elif datatype == 'timeuuid':
             sample_data[datatype] = uuid1()

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -85,21 +85,17 @@ class QueryTests(BasicSharedKeyspaceUnitTestCase):
         for event in trace.events:
             str(event)
 
-    def test_row_error_message(self):
-        """
-        Test to validate, new column deserialization message
-        @since 3.7.0
-        @jira_ticket PYTHON-361
-        @expected_result Special failed decoding message should be present
+    def test_datetime_outside_range(self):
+        """ Test to validate if driver supports datetime outside datetime.[MIN|MAX]YEAR range """
+        self.session.execute("CREATE TABLE {0}.{1} (k int PRIMARY KEY, v date)".format(self.keyspace_name,self.function_table_name))
 
-        @test_category tracing
-        """
-        self.session.execute("CREATE TABLE {0}.{1} (k int PRIMARY KEY, v timestamp)".format(self.keyspace_name,self.function_table_name))
-        ss = SimpleStatement("INSERT INTO {0}.{1} (k, v) VALUES (1, 1000000000000000)".format(self.keyspace_name, self.function_table_name))
+        ss = SimpleStatement("INSERT INTO {0}.{1} (k, v) VALUES (1, {2})".format(self.keyspace_name, self.function_table_name, 2**30))
         self.session.execute(ss)
-        with self.assertRaises(DriverException) as context:
-            self.session.execute("SELECT * FROM {0}.{1}".format(self.keyspace_name, self.function_table_name))
-        self.assertIn("Failed decoding result column", str(context.exception))
+        self.session.execute("SELECT totimestamp(v) FROM {0}.{1}".format(self.keyspace_name, self.function_table_name))
+
+        ss = SimpleStatement("INSERT INTO {0}.{1} (k, v) VALUES (1, {2})".format(self.keyspace_name, self.function_table_name, 2**31 - 2**29))
+        self.session.execute(ss)
+        self.session.execute("SELECT totimestamp(v) FROM {0}.{1}".format(self.keyspace_name, self.function_table_name))
 
     def test_trace_id_to_resultset(self):
 

--- a/tests/unit/cython/types_testhelper.pyx
+++ b/tests/unit/cython/types_testhelper.pyx
@@ -23,6 +23,7 @@ import io
 from cassandra.cqltypes import DateType
 from cassandra.protocol import write_value
 from cassandra.deserializers import find_deserializer
+from cassandra.util import Datetime
 from cassandra.bytesio cimport BytesIOReader
 from cassandra.buffer cimport Buffer
 from cassandra.deserializers cimport from_binary, Deserializer
@@ -38,7 +39,7 @@ def test_datetype(assert_equal):
         cdef BytesIOReader reader
         cdef Buffer buf
 
-        dt = datetime.datetime.utcfromtimestamp(timestamp)
+        dt = Datetime(datetime.datetime.utcfromtimestamp(timestamp))
 
         bytes = io.BytesIO()
         write_value(bytes, DateType.serialize(dt, 0))
@@ -89,7 +90,7 @@ def test_date_side_by_side(assert_equal):
         bior = BytesIOReader(blob)
         buf.ptr = bior.read()
         buf.size = bior.size
-        cython_deserialized = from_binary(cython_deserializer, &buf, 0)
+        cython_deserialized = Datetime(from_binary(cython_deserializer, &buf, 0))
         python_deserialized = DateType.deserialize(blob, 0)
         assert_equal(cython_deserialized, python_deserialized)
 

--- a/tests/unit/test_marshalling.py
+++ b/tests/unit/test_marshalling.py
@@ -23,7 +23,7 @@ from decimal import Decimal
 from uuid import UUID
 
 from cassandra.cqltypes import lookup_casstype, DecimalType, UTF8Type, DateType
-from cassandra.util import OrderedMapSerializedKey, sortedset, Time, Date
+from cassandra.util import Datetime, OrderedMapSerializedKey, sortedset, Time, Date
 
 marshalled_value_pairs = (
     # binary form, type, python native type
@@ -37,8 +37,8 @@ marshalled_value_pairs = (
     (b'\x7f\xff\xff\xff\xff\xff\xff\xff', 'CounterColumnType', 9223372036854775807),
     (b'\x80\x00\x00\x00\x00\x00\x00\x00', 'CounterColumnType', -9223372036854775808),
     (b'', 'CounterColumnType', None),
-    (b'\x00\x00\x013\x7fb\xeey', 'DateType', datetime(2011, 11, 7, 18, 55, 49, 881000)),
-    (b'\x00\x00\x01P\xc5~L\x00', 'DateType', datetime(2015, 11, 2)),
+    (b'\x00\x00\x013\x7fb\xeey', 'DateType', Datetime(datetime(2011, 11, 7, 18, 55, 49, 881000))),
+    (b'\x00\x00\x01P\xc5~L\x00', 'DateType', Datetime(datetime(2015, 11, 2))),
     (b'', 'DateType', None),
     (b'\x00\x00\x00\r\nJ\x04"^\x91\x04\x8a\xb1\x18\xfe', 'DecimalType', Decimal('1243878957943.1234124191998')),
     (b'\x00\x00\x00\x06\xe5\xde]\x98Y', 'DecimalType', Decimal('-112233.441191')),
@@ -131,7 +131,7 @@ class UnmarshalTest(unittest.TestCase):
                                  % (valtype, marshaller, type(whatwegot), type(serializedval)))
 
     def test_date(self):
-        # separate test because it will deserialize as datetime
+        # separate test because it will deserialize as Datetime
         self.assertEqual(DateType.from_binary(DateType.to_binary(date(2015, 11, 2), 1), 1), datetime(2015, 11, 2))
 
     def test_decimal(self):


### PR DESCRIPTION
In Python `datetime.datetime` type year has to be in range [MINYEAR, MAXYEAR]. This range is not the same as possible timestamps in scylla. Previously if timestamp was outside this range it made driver raise an Exception. It was not correct behavior. There was a work around implemented in cqlsh.

This PR introduces a `Datetime` type to accommodate ranges outside datetime.[MIN|MAX]YEAR. For Datetimes that cannot be represented as a datetime.datetime (because datetime.MINYEAR, datetime.MAXYEAR), this type falls back to printing milliseconds_from_epoch offset.

Something similar was introduced before for datetime.date type - https://github.com/scylladb/python-driver/commit/4f3c77c970e10774243e7ad7baed2d41c06c4790.

This is for sure a breaking change, because of change of the return type. The question is if it is worth to break compatibility for fixing this bug. As far as I know it was not reported by any users, in scylladb we encounter it on two occasions in tests. 

This PR is based on scylladb#310 - in scylladb we are considering different approaches to this problem and it would be helpful to know your opinion on that. 

This is the original issue: https://datastax-oss.atlassian.net/browse/PYTHON-441. I've left a comment there to reopen the discussion.