### PR TITLE
remove dependency on old mock external module

### DIFF
--- a/cassandra/cqlengine/functions.py
+++ b/cassandra/cqlengine/functions.py
@@ -17,16 +17,8 @@ from datetime import datetime
 
 from cassandra.cqlengine import UnicodeMixin, ValidationError
 
-import sys
-
-if sys.version_info >= (2, 7):
-    def get_total_seconds(td):
-        return td.total_seconds()
-else:
-    def get_total_seconds(td):
-        # integer division used here to emulate built-in total_seconds
-        return ((86400 * td.days + td.seconds) * 10 ** 6 + td.microseconds) / 10 ** 6
-
+def get_total_seconds(td):
+    return td.total_seconds()
 
 class QueryValue(UnicodeMixin):
     """

--- a/setup.py
+++ b/setup.py
@@ -436,7 +436,7 @@ def run_setup(extensions):
         include_package_data=True,
         install_requires=dependencies,
         extras_require=_EXTRAS_REQUIRE,
-        tests_require=['nose', 'mock>=2.0.0', 'PyYAML', 'pytz', 'sure'],
+        tests_require=['nose', 'PyYAML', 'pytz', 'sure'],
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Intended Audience :: Developers',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
 -r requirements.txt
 scales
 pynose
-mock>1.1
 ccm>=2.1.2
 pytz
 sure

--- a/tests/integration/cloud/test_cloud.py
+++ b/tests/integration/cloud/test_cloud.py
@@ -28,7 +28,7 @@ from cassandra.connection import SniEndPoint
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.policies import TokenAwarePolicy, DCAwareRoundRobinPolicy, ConstantReconnectionPolicy
 
-from mock import patch
+from unittest.mock import patch
 
 from tests.integration import requirescloudproxy
 from tests.util import wait_until_not_raised

--- a/tests/integration/cqlengine/management/test_compaction_settings.py
+++ b/tests/integration/cqlengine/management/test_compaction_settings.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import copy
-from mock import patch
+from unittest.mock import patch
 
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.management import drop_table, sync_table, _get_table_metadata, _update_options

--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 
-import mock
+from unittest import mock
 import logging
 from packaging.version import Version
 from cassandra.cqlengine.connection import get_session, get_cluster

--- a/tests/integration/cqlengine/model/test_model.py
+++ b/tests/integration/cqlengine/model/test_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 
 from cassandra.cqlengine import columns, CQLEngineException
 from cassandra.cqlengine.management import sync_table, drop_table, create_keyspace_simple, drop_keyspace

--- a/tests/integration/cqlengine/model/test_polymorphism.py
+++ b/tests/integration/cqlengine/model/test_polymorphism.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import uuid
-import mock
+from unittest import mock
 
 from cassandra.cqlengine import columns
 from cassandra.cqlengine import models

--- a/tests/integration/cqlengine/model/test_udts.py
+++ b/tests/integration/cqlengine/model/test_udts.py
@@ -15,7 +15,7 @@ import unittest
 
 from datetime import datetime, date, time
 from decimal import Decimal
-from mock import Mock
+from unittest.mock import Mock
 from uuid import UUID, uuid4
 
 from cassandra.cqlengine.models import Model

--- a/tests/integration/cqlengine/model/test_updates.py
+++ b/tests/integration/cqlengine/model/test_updates.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
 from uuid import uuid4
 
-from mock import patch
 from cassandra.cqlengine import ValidationError
 
 from tests.integration import greaterthancass21

--- a/tests/integration/cqlengine/query/test_batch_query.py
+++ b/tests/integration/cqlengine/query/test_batch_query.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 
 from cassandra.cqlengine import columns
 from cassandra.cqlengine.connection import NOT_SET

--- a/tests/integration/cqlengine/query/test_queryset.py
+++ b/tests/integration/cqlengine/query/test_queryset.py
@@ -24,7 +24,7 @@ from cassandra.cluster import Session
 from cassandra import InvalidRequest
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 from cassandra.cqlengine.connection import NOT_SET
-import mock
+from unittest import mock
 from cassandra.cqlengine import functions
 from cassandra.cqlengine.management import sync_table, drop_table
 from cassandra.cqlengine.models import Model

--- a/tests/integration/cqlengine/test_batch_query.py
+++ b/tests/integration/cqlengine/test_batch_query.py
@@ -19,7 +19,7 @@ from cassandra.cqlengine.models import Model
 from cassandra.cqlengine.query import BatchQuery
 from tests.integration.cqlengine.base import BaseCassEngTestCase
 
-from mock import patch
+from unittest.mock import patch
 
 class TestMultiKeyModel(Model):
     partition   = columns.Integer(primary_key=True)

--- a/tests/integration/cqlengine/test_consistency.py
+++ b/tests/integration/cqlengine/test_consistency.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import mock
+from unittest import mock
 from uuid import uuid4
 
 from cassandra import ConsistencyLevel as CL, ConsistencyLevel

--- a/tests/integration/cqlengine/test_ifexists.py
+++ b/tests/integration/cqlengine/test_ifexists.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-
-import mock
+from unittest import mock
 from uuid import uuid4
 
 from cassandra.cqlengine import columns

--- a/tests/integration/cqlengine/test_ifnotexists.py
+++ b/tests/integration/cqlengine/test_ifnotexists.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-
-import mock
+from unittest import mock
 from uuid import uuid4
 
 from cassandra.cqlengine import columns

--- a/tests/integration/cqlengine/test_lwt_conditional.py
+++ b/tests/integration/cqlengine/test_lwt_conditional.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-
-import mock
+from unittest import mock
 from uuid import uuid4
 
 from cassandra.cqlengine import columns

--- a/tests/integration/cqlengine/test_timestamp.py
+++ b/tests/integration/cqlengine/test_timestamp.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from datetime import timedelta, datetime
-import mock
+from unittest import mock
 import sure
 from uuid import uuid4
 

--- a/tests/integration/cqlengine/test_ttl.py
+++ b/tests/integration/cqlengine/test_ttl.py
@@ -23,7 +23,7 @@ from tests.integration.cqlengine.base import BaseCassEngTestCase
 from cassandra.cqlengine.models import Model
 from uuid import uuid4
 from cassandra.cqlengine import columns
-import mock
+from unittest import mock
 from cassandra.cqlengine.connection import get_session
 from tests.integration import CASSANDRA_VERSION, greaterthancass20
 

--- a/tests/integration/long/test_failure_types.py
+++ b/tests/integration/long/test_failure_types.py
@@ -17,8 +17,7 @@ import sys
 import traceback
 import time
 from packaging.version import Version
-
-from mock import Mock
+from unittest.mock import Mock
 
 from cassandra.policies import HostFilterPolicy, RoundRobinPolicy
 from cassandra import (

--- a/tests/integration/simulacron/test_connection.py
+++ b/tests/integration/simulacron/test_connection.py
@@ -15,8 +15,7 @@ import unittest
 
 import logging
 import time
-
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from cassandra import OperationTimedOut
 from cassandra.cluster import (EXEC_PROFILE_DEFAULT, Cluster, ExecutionProfile,

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -16,7 +16,7 @@ import unittest
 
 from collections import deque
 from copy import copy
-from mock import Mock, call, patch, ANY
+from unittest.mock import Mock, call, patch, ANY
 import time
 from uuid import uuid4
 import logging

--- a/tests/integration/standard/test_connection.py
+++ b/tests/integration/standard/test_connection.py
@@ -15,7 +15,7 @@
 import unittest
 
 from functools import partial
-from mock import patch
+from unittest.mock import patch
 import logging
 import sys
 import threading

--- a/tests/integration/standard/test_custom_protocol_handler.py
+++ b/tests/integration/standard/test_custom_protocol_handler.py
@@ -27,7 +27,7 @@ from tests.integration.datatype_utils import update_datatypes, PRIMITIVE_DATATYP
 from tests.integration.standard.utils import create_table_with_all_types, get_all_primitive_params
 
 import uuid
-import mock
+from unittest import mock
 
 
 def setup_module():

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -21,7 +21,7 @@ import sys
 import time
 import os
 from packaging.version import Version
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from cassandra import AlreadyExists, SignatureDescriptor, UserFunctionDescriptor, UserAggregateDescriptor
 

--- a/tests/integration/standard/test_query.py
+++ b/tests/integration/standard/test_query.py
@@ -33,7 +33,7 @@ import time
 import random
 import re
 
-import mock
+from unittest import mock
 
 
 log = logging.getLogger(__name__)

--- a/tests/unit/advanced/cloud/test_cloud.py
+++ b/tests/unit/advanced/cloud/test_cloud.py
@@ -9,13 +9,11 @@
 import tempfile
 import os
 import shutil
-
 import unittest
+from unittest.mock import patch
 
 from cassandra import DriverException
 from cassandra.datastax import cloud
-
-from mock import patch
 
 from tests import notwindows
 

--- a/tests/unit/advanced/test_insights.py
+++ b/tests/unit/advanced/test_insights.py
@@ -16,8 +16,8 @@
 import unittest
 
 import logging
-from mock import sentinel
 import sys
+from unittest.mock import sentinel
 
 from cassandra import ConsistencyLevel
 from cassandra.cluster import (

--- a/tests/unit/advanced/test_policies.py
+++ b/tests/unit/advanced/test_policies.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-
-from mock import Mock
+from unittest.mock import Mock
 
 from cassandra.pool import Host
 from cassandra.policies import RoundRobinPolicy

--- a/tests/unit/cqlengine/test_connection.py
+++ b/tests/unit/cqlengine/test_connection.py
@@ -13,12 +13,11 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import Mock
 
 from cassandra.cluster import _ConfigMode
 from cassandra.cqlengine import connection
 from cassandra.query import dict_factory
-
-from mock import Mock
 
 
 class ConnectionTest(unittest.TestCase):

--- a/tests/unit/io/test_asyncioreactor.py
+++ b/tests/unit/io/test_asyncioreactor.py
@@ -10,7 +10,7 @@ except (ImportError, SyntaxError):
 from tests import is_monkey_patched, connection_class
 from tests.unit.io.utils import TimerCallback, TimerTestMixin
 
-from mock import patch
+from unittest.mock import patch
 
 import unittest
 import time

--- a/tests/unit/io/test_asyncorereactor.py
+++ b/tests/unit/io/test_asyncorereactor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 
-from mock import patch
+from unittest.mock import patch
 import socket
 import cassandra.io.asyncorereactor as asyncorereactor
 from cassandra.io.asyncorereactor import AsyncoreConnection

--- a/tests/unit/io/test_eventletreactor.py
+++ b/tests/unit/io/test_eventletreactor.py
@@ -19,7 +19,7 @@ from tests.unit.io.utils import TimerTestMixin
 from tests import notpypy, EVENT_LOOP_MANAGER
 
 from eventlet import monkey_patch
-from mock import patch
+from unittest.mock import patch
 
 try:
     from cassandra.io.eventletreactor import EventletConnection

--- a/tests/unit/io/test_geventreactor.py
+++ b/tests/unit/io/test_geventreactor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import patch
 
 
 from tests.unit.io.utils import TimerTestMixin
@@ -22,8 +23,6 @@ try:
     import gevent.monkey
 except ImportError:
     GeventConnection = None  # noqa
-
-from mock import patch
 
 
 skip_condition = GeventConnection is None or EVENT_LOOP_MANAGER != "gevent"

--- a/tests/unit/io/test_libevreactor.py
+++ b/tests/unit/io/test_libevreactor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 import weakref
 import socket
 

--- a/tests/unit/io/test_twistedreactor.py
+++ b/tests/unit/io/test_twistedreactor.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from cassandra.connection import DefaultEndPoint
 

--- a/tests/unit/io/utils.py
+++ b/tests/unit/io/utils.py
@@ -27,7 +27,7 @@ import random
 from functools import wraps
 from itertools import cycle
 from io import BytesIO
-from mock import Mock
+from unittest.mock import Mock
 
 import errno
 import logging

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -16,7 +16,7 @@ import unittest
 import logging
 import socket
 
-from mock import patch, Mock
+from unittest.mock import patch, Mock
 
 from cassandra import ConsistencyLevel, DriverException, Timeout, Unavailable, RequestExecutionException, ReadTimeout, WriteTimeout, CoordinationFailure, ReadFailure, WriteFailure, FunctionFailure, AlreadyExists,\
     InvalidRequest, Unauthorized, AuthenticationFailed, OperationTimedOut, UnsupportedOperation, RequestValidationException, ConfigurationException, ProtocolVersion

--- a/tests/unit/test_concurrent.py
+++ b/tests/unit/test_concurrent.py
@@ -16,7 +16,7 @@
 import unittest
 
 from itertools import cycle
-from mock import Mock
+from unittest.mock import Mock
 import time
 import threading
 from queue import PriorityQueue

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
-
-from mock import Mock, ANY, call, patch
 from io import BytesIO
 import time
 from threading import Lock
+from unittest.mock import Mock, ANY, call, patch
 
 from cassandra import OperationTimedOut
 from cassandra.cluster import Cluster

--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -15,7 +15,7 @@
 import unittest
 
 from concurrent.futures import ThreadPoolExecutor
-from mock import Mock, ANY, call
+from unittest.mock import Mock, ANY, call
 
 from cassandra import OperationTimedOut, SchemaTargetType, SchemaChangeType
 from cassandra.protocol import ResultMessage, RESULT_KIND_ROWS

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -12,7 +12,7 @@ import itertools
 
 from cassandra.connection import DefaultEndPoint, SniEndPoint, SniEndPointFactory
 
-from mock import patch
+from unittest.mock import patch
 
 
 def socket_getaddrinfo(*args):

--- a/tests/unit/test_host_connection_pool.py
+++ b/tests/unit/test_host_connection_pool.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 import unittest
-
-from mock import Mock, NonCallableMagicMock
 from threading import Thread, Event, Lock
+from unittest.mock import Mock, NonCallableMagicMock
 
 from cassandra.cluster import Session
 from cassandra.connection import Connection

--- a/tests/unit/test_metadata.py
+++ b/tests/unit/test_metadata.py
@@ -15,7 +15,7 @@ import unittest
 
 from binascii import unhexlify
 import logging
-from mock import Mock
+from unittest.mock import Mock
 import os
 import timeit
 

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -15,7 +15,7 @@
 import unittest
 
 from itertools import islice, cycle
-from mock import Mock, patch, call
+from unittest.mock import Mock, patch, call
 from random import randint
 from _thread import LockType
 import sys

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from mock import Mock
+from unittest.mock import Mock
 
 from cassandra import ProtocolVersion, UnsupportedOperation
 from cassandra.protocol import (

--- a/tests/unit/test_response_future.py
+++ b/tests/unit/test_response_future.py
@@ -16,8 +16,7 @@ import unittest
 
 from collections import deque
 from threading import RLock
-
-from mock import Mock, MagicMock, ANY
+from unittest.mock import Mock, MagicMock, ANY
 
 from cassandra import ConsistencyLevel, Unavailable, SchemaTargetType, SchemaChangeType, OperationTimedOut
 from cassandra.cluster import Session, ResponseFuture, NoHostAvailable, ProtocolVersion

--- a/tests/unit/test_resultset.py
+++ b/tests/unit/test_resultset.py
@@ -11,13 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from cassandra.query import named_tuple_factory, dict_factory, tuple_factory
 
 import unittest
-
-from mock import Mock, PropertyMock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 from cassandra.cluster import ResultSet
+from cassandra.query import named_tuple_factory, dict_factory, tuple_factory
 
 
 class ResultSetTests(unittest.TestCase):

--- a/tests/unit/test_timestamps.py
+++ b/tests/unit/test_timestamps.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 import unittest
-
-import mock
+from unittest import mock
 
 from cassandra import timestamps
 from threading import Thread, Lock

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from concurrent.futures import Future
 from functools import wraps
+from unittest.mock import patch
+
+from concurrent.futures import Future
 from cassandra.cluster import Session
-from mock import patch
 
 
 def mock_session_pools(f):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py{38,39,310,311,312},pypy
 
 [base]
 deps = pynose
-       mock>1.1
        packaging
        cython>=0.20,<0.30
        eventlet


### PR DESCRIPTION
Hi again,

After the `six` removal, here's more Python2-era removal.

https://github.com/testing-cabal/mock 

**mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.**