### PR TITLE
Explicitly select Java8 via Jabba before running integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -272,6 +272,9 @@ def executeStandardTests() {
     . ${HOME}/environment.txt
     set +o allexport
 
+    . ${JABBA_SHELL}
+    jabba use 1.8
+
     SIMULACRON_JAR="${HOME}/simulacron.jar"
     SIMULACRON_JAR=${SIMULACRON_JAR} EVENT_LOOP=${EVENT_LOOP} CASSANDRA_DIR=${CCM_INSTALL_DIR} CCM_ARGS="${CCM_ARGS}" DSE_VERSION=${DSE_VERSION} CASSANDRA_VERSION=${CCM_CASSANDRA_VERSION} MAPPED_CASSANDRA_VERSION=${MAPPED_CASSANDRA_VERSION} VERIFY_CYTHON=${CYTHON_ENABLED} pynose -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --exclude test_backpressure.py --xunit-file=simulacron_results.xml tests/integration/simulacron/ || true
 
@@ -288,6 +291,9 @@ def executeStandardTests() {
     . ${HOME}/environment.txt
     set +o allexport
 
+    . ${JABBA_SHELL}
+    jabba use 1.8
+
     EVENT_LOOP=${EVENT_LOOP} CCM_ARGS="${CCM_ARGS}" DSE_VERSION=${DSE_VERSION} CASSANDRA_VERSION=${CCM_CASSANDRA_VERSION} MAPPED_CASSANDRA_VERSION=${MAPPED_CASSANDRA_VERSION} VERIFY_CYTHON=${CYTHON_ENABLED} pynose -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=cqle_results.xml tests/integration/cqlengine/ || true
   '''
 
@@ -296,6 +302,9 @@ def executeStandardTests() {
     set -o allexport
     . ${HOME}/environment.txt
     set +o allexport
+
+    . ${JABBA_SHELL}
+    jabba use 1.8
 
     EVENT_LOOP=${EVENT_LOOP} CCM_ARGS="${CCM_ARGS}" DSE_VERSION=${DSE_VERSION} CASSANDRA_VERSION=${CCM_CASSANDRA_VERSION} MAPPED_CASSANDRA_VERSION=${MAPPED_CASSANDRA_VERSION} VERIFY_CYTHON=${CYTHON_ENABLED} pynose -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=standard_results.xml tests/integration/standard/ || true
   '''
@@ -311,6 +320,9 @@ def executeStandardTests() {
         . ${HOME}/environment.txt
         set +o allexport
 
+        . ${JABBA_SHELL}
+        jabba use 1.8
+
         EVENT_LOOP=${EVENT_LOOP} CASSANDRA_DIR=${CCM_INSTALL_DIR} DSE_VERSION=${DSE_VERSION} ADS_HOME="${HOME}/" VERIFY_CYTHON=${CYTHON_ENABLED} pynose -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=dse_results.xml tests/integration/advanced/ || true
       '''
     }
@@ -322,6 +334,9 @@ def executeStandardTests() {
     . ${HOME}/environment.txt
     set +o allexport
 
+    . ${JABBA_SHELL}
+    jabba use 1.8
+
     EVENT_LOOP=${EVENT_LOOP} CLOUD_PROXY_PATH="${HOME}/proxy/" CASSANDRA_VERSION=${CCM_CASSANDRA_VERSION} MAPPED_CASSANDRA_VERSION=${MAPPED_CASSANDRA_VERSION} VERIFY_CYTHON=${CYTHON_ENABLED} pynose -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=advanced_results.xml tests/integration/cloud/ || true
   '''
 
@@ -331,6 +346,9 @@ def executeStandardTests() {
       set -o allexport
       . ${HOME}/environment.txt
       set +o allexport
+
+      . ${JABBA_SHELL}
+      jabba use 1.8
 
       EVENT_LOOP=${EVENT_LOOP} CCM_ARGS="${CCM_ARGS}" DSE_VERSION=${DSE_VERSION} CASSANDRA_VERSION=${CCM_CASSANDRA_VERSION} MAPPED_CASSANDRA_VERSION=${MAPPED_CASSANDRA_VERSION} VERIFY_CYTHON=${CYTHON_ENABLED} pynose -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --exclude-dir=tests/integration/long/upgrade --with-ignore-docstrings --with-xunit --xunit-file=long_results.xml tests/integration/long/ || true
     '''
@@ -344,6 +362,9 @@ def executeDseSmokeTests() {
     . ${HOME}/environment.txt
     set +o allexport
 
+    . ${JABBA_SHELL}
+    jabba use 1.8
+
     EVENT_LOOP=${EVENT_LOOP} CCM_ARGS="${CCM_ARGS}" CASSANDRA_VERSION=${CCM_CASSANDRA_VERSION} DSE_VERSION=${DSE_VERSION} MAPPED_CASSANDRA_VERSION=${MAPPED_CASSANDRA_VERSION} VERIFY_CYTHON=${CYTHON_ENABLED} pynose -s -v --logging-format="[%(levelname)s] %(asctime)s %(thread)d: %(message)s" --with-ignore-docstrings --with-xunit --xunit-file=standard_results.xml tests/integration/standard/test_dse.py || true
   '''
 }
@@ -354,6 +375,9 @@ def executeEventLoopTests() {
     set -o allexport
     . ${HOME}/environment.txt
     set +o allexport
+
+    . ${JABBA_SHELL}
+    jabba use 1.8
 
     EVENT_LOOP_TESTS=(
       "tests/integration/standard/test_cluster.py"
@@ -628,6 +652,7 @@ pipeline {
     OS_VERSION = 'ubuntu/bionic64/python-driver'
     CCM_ENVIRONMENT_SHELL = '/usr/local/bin/ccm_environment.sh'
     CCM_MAX_HEAP_SIZE = '1536M'
+    JABBA_SHELL = '/usr/lib/jabba/jabba.sh'
   }
 
   stages {


### PR DESCRIPTION
Fix for unexpected test issues after recent Jenkins upgrade forced us to move to Java11 as the default for all runners