### PR TITLE
Use raw strings in some docstrings to avoid SyntaxWarning in Python 3.12 .

### DIFF
--- a/cassandra/cqlengine/connection.py
+++ b/cassandra/cqlengine/connection.py
@@ -315,7 +315,7 @@ def setup(
         lazy_connect=False,
         retry_connect=False,
         **kwargs):
-    r"""
+    """
     Setup a the driver connection used by the mapper
 
     :param list hosts: list of hosts, (``contact_points`` for :class:`cassandra.cluster.Cluster`)
@@ -323,7 +323,7 @@ def setup(
     :param int consistency: The global default :class:`~.ConsistencyLevel` - default is the same as :attr:`.Session.default_consistency_level`
     :param bool lazy_connect: True if should not connect until first use
     :param bool retry_connect: True if we should retry to connect even if there was a connection failure initially
-    :param \*\*kwargs: Pass-through keyword arguments for :class:`cassandra.cluster.Cluster`
+    :param kwargs: Pass-through keyword arguments for :class:`cassandra.cluster.Cluster`
     """
 
     from cassandra.cqlengine import models

--- a/cassandra/cqlengine/connection.py
+++ b/cassandra/cqlengine/connection.py
@@ -315,7 +315,7 @@ def setup(
         lazy_connect=False,
         retry_connect=False,
         **kwargs):
-    """
+    r"""
     Setup a the driver connection used by the mapper
 
     :param list hosts: list of hosts, (``contact_points`` for :class:`cassandra.cluster.Cluster`)

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -196,7 +196,7 @@ class BatchQuery(object):
             callback(*args, **kwargs)
 
     def add_callback(self, fn, *args, **kwargs):
-        """Add a function and arguments to be passed to it to be executed after the batch executes.
+        r"""Add a function and arguments to be passed to it to be executed after the batch executes.
 
         A batch can support multiple callbacks.
 
@@ -272,7 +272,7 @@ class BatchQuery(object):
 
 
 class ContextQuery(object):
-    """
+    r"""
     A Context manager to allow a Model to switch context easily. Presently, the context only
     specifies a keyspace for model IO.
 

--- a/cassandra/cqlengine/query.py
+++ b/cassandra/cqlengine/query.py
@@ -196,7 +196,7 @@ class BatchQuery(object):
             callback(*args, **kwargs)
 
     def add_callback(self, fn, *args, **kwargs):
-        r"""Add a function and arguments to be passed to it to be executed after the batch executes.
+        """Add a function and arguments to be passed to it to be executed after the batch executes.
 
         A batch can support multiple callbacks.
 
@@ -205,8 +205,8 @@ class BatchQuery(object):
 
         :param fn: Callable object
         :type fn: callable
-        :param \*args: Positional arguments to be passed to the callback at the time of execution
-        :param \*\*kwargs: Named arguments to be passed to the callback at the time of execution
+        :param args: Positional arguments to be passed to the callback at the time of execution
+        :param kwargs: Named arguments to be passed to the callback at the time of execution
         """
         if not callable(fn):
             raise ValueError("Value for argument 'fn' is {0} and is not a callable object.".format(type(fn)))
@@ -272,12 +272,12 @@ class BatchQuery(object):
 
 
 class ContextQuery(object):
-    r"""
+    """
     A Context manager to allow a Model to switch context easily. Presently, the context only
     specifies a keyspace for model IO.
 
-    :param \*args: One or more models. A model should be a class type, not an instance.
-    :param \*\*kwargs: (optional) Context parameters: can be *keyspace* or *connection*
+    :param args: One or more models. A model should be a class type, not an instance.
+    :param kwargs: (optional) Context parameters: can be *keyspace* or *connection*
 
     For example:
 


### PR DESCRIPTION
Prevent error logs on program startup:

```
/python/path/lib/python3.12/site-packages/cassandra/cqlengine/connection.py:318: SyntaxWarning: invalid escape sequence '\*'
```

These will turn into SyntaxErrors in future python versions. Source: https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences
> Changed in version 3.12: Unrecognized escape sequences produce a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). In a future Python version they will be eventually a [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError).