### PR TITLE
PYTHON-1384: Remove usages of unittest.assertDictContainsSubset

### DIFF
--- a/tests/integration/cqlengine/management/test_management.py
+++ b/tests/integration/cqlengine/management/test_management.py
@@ -254,7 +254,7 @@ class TablePropertiesTests(BaseCassEngTestCase):
 
         table_options = management._get_table_metadata(ModelWithTableProperties).options
 
-        self.assertDictContainsSubset(ModelWithTableProperties.__options__, table_options)
+        self.assertLessEqual(ModelWithTableProperties.__options__.items(), table_options.items())
 
     def test_bogus_option_update(self):
         sync_table(ModelWithTableProperties)

--- a/tests/integration/standard/test_metadata.py
+++ b/tests/integration/standard/test_metadata.py
@@ -1751,9 +1751,9 @@ class AggregateMetadata(FunctionTest):
             cql_init = encoder.cql_encode_all_types(init_cond)
             with self.VerifiedAggregate(self, **self.make_aggregate_kwargs('update_map', 'map<int, int>', init_cond=cql_init)) as va:
                 map_res = s.execute("SELECT %s(v) AS map_res FROM t" % va.function_kwargs['name'])[0].map_res
-                self.assertDictContainsSubset(expected_map_values, map_res)
+                self.assertLessEqual(expected_map_values.items(), map_res.items())
                 init_not_updated = dict((k, init_cond[k]) for k in set(init_cond) - expected_key_set)
-                self.assertDictContainsSubset(init_not_updated, map_res)
+                self.assertLessEqual(init_not_updated.items(), map_res.items())
         c.shutdown()
 
     def test_aggregates_after_functions(self):


### PR DESCRIPTION
I've confirmed via local testing that both integration tests fail with Python 3.12 before any changes (something we've already observed in Jenkins).  Also confirmed that both integration tests also pass using Python 3.8 after this change.