### PR TITLE
Removed future print_function, division, and with_statement and some pre 3.7 handling

### DIFF
--- a/cassandra/cqlengine/functions.py
+++ b/cassandra/cqlengine/functions.py
@@ -12,21 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import division
 from datetime import datetime
 
 from cassandra.cqlengine import UnicodeMixin, ValidationError
 
-import sys
-
-if sys.version_info >= (2, 7):
-    def get_total_seconds(td):
-        return td.total_seconds()
-else:
-    def get_total_seconds(td):
-        # integer division used here to emulate built-in total_seconds
-        return ((86400 * td.days + td.seconds) * 10 ** 6 + td.microseconds) / 10 ** 6
-
+def get_total_seconds(td):
+    return td.total_seconds()
 
 class QueryValue(UnicodeMixin):
     """

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import with_statement
 from _weakref import ref
 import calendar
 from collections import OrderedDict

--- a/examples/request_init_listener.py
+++ b/examples/request_init_listener.py
@@ -18,7 +18,6 @@
 # about the encoded request size. Note that the counts would be available using the internal 'metrics' tracking --
 # this is just demonstrating a way to track a few custom attributes.
 
-from __future__ import print_function
 from cassandra.cluster import Cluster
 from greplin import scales
 

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -197,13 +197,7 @@ def _extractall(self, path=".", members=None):
         self.extract(tarinfo, path)
 
     # Reverse sort directories.
-    if sys.version_info < (2, 4):
-        def sorter(dir1, dir2):
-            return cmp(dir1.name, dir2.name)
-        directories.sort(sorter)
-        directories.reverse()
-    else:
-        directories.sort(key=operator.attrgetter('name'), reverse=True)
+    directories.sort(key=operator.attrgetter('name'), reverse=True)
 
     # Set correct owner, mtime and filemode on directories.
     for tarinfo in directories:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import sys
 import warnings

--- a/tests/integration/advanced/graph/__init__.py
+++ b/tests/integration/advanced/graph/__init__.py
@@ -50,11 +50,6 @@ MAX_LONG = 9223372036854775807
 MIN_LONG = -9223372036854775808
 ZERO_LONG = 0
 
-if sys.version_info < (3, 0):
-    MAX_LONG = long(MAX_LONG)
-    MIN_LONG = long(MIN_LONG)
-    ZERO_LONG = long(ZERO_LONG)
-
 MAKE_STRICT = "schema.config().option('graph.schema_mode').set('production')"
 MAKE_NON_STRICT = "schema.config().option('graph.schema_mode').set('development')"
 ALLOW_SCANS = "schema.config().option('graph.allow_scan').set('true')"

--- a/tests/integration/long/utils.py
+++ b/tests/integration/long/utils.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import logging
 import time
 


### PR DESCRIPTION
Removed unnecessary future print_function, division, and with and some pre 3.0 handling

Does not touch __future__imports!