### PR TITLE
cassandra/query: use timezone specific API to avoid deprecated warning

### DIFF
--- a/cassandra/cqlengine/columns.py
+++ b/cassandra/cqlengine/columns.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from copy import deepcopy, copy
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 import logging
 from uuid import UUID as _UUID
 
@@ -551,7 +551,7 @@ class DateTime(Column):
         elif isinstance(value, date):
             return datetime(*(value.timetuple()[:6]))
 
-        return datetime.utcfromtimestamp(value)
+        return datetime.fromtimestamp(value, tz=timezone.utc).replace(tzinfo=None)
 
     def to_database(self, value):
         value = super(DateTime, self).to_database(value)

--- a/cassandra/query.py
+++ b/cassandra/query.py
@@ -19,7 +19,7 @@ queries.
 """
 
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import re
 import struct
 import time
@@ -1085,7 +1085,7 @@ class TraceEvent(object):
 
     def __init__(self, description, timeuuid, source, source_elapsed, thread_name):
         self.description = description
-        self.datetime = datetime.utcfromtimestamp(unix_time_from_uuid1(timeuuid))
+        self.datetime = datetime.fromtimestamp(unix_time_from_uuid1(timeuuid), tz=timezone.utc)
         self.source = source
         if source_elapsed is not None:
             self.source_elapsed = timedelta(microseconds=source_elapsed)

--- a/cassandra/util.py
+++ b/cassandra/util.py
@@ -38,8 +38,8 @@ except:
 
 from cassandra import DriverException
 
-DATETIME_EPOC = datetime.datetime(1970, 1, 1)
-UTC_DATETIME_EPOC = datetime.datetime.utcfromtimestamp(0)
+DATETIME_EPOC = datetime.datetime(1970, 1, 1).replace(tzinfo=None)
+UTC_DATETIME_EPOC = datetime.datetime.fromtimestamp(0, tz=datetime.timezone.utc).replace(tzinfo=None)
 
 _nan = float('nan')
 

--- a/tests/integration/cqlengine/columns/test_validation.py
+++ b/tests/integration/cqlengine/columns/test_validation.py
@@ -15,7 +15,7 @@
 import unittest
 
 import sys
-from datetime import datetime, timedelta, date, tzinfo, time
+from datetime import datetime, timedelta, date, tzinfo, time, timezone
 from decimal import Decimal as D
 from uuid import uuid4, uuid1
 from packaging.version import Version
@@ -97,7 +97,7 @@ class TestDatetime(BaseCassEngTestCase):
         dt_value = 1454520554
         self.DatetimeTest.objects.create(test_id=5, created_at=dt_value)
         dt2 = self.DatetimeTest.objects(test_id=5).first()
-        self.assertEqual(dt2.created_at, datetime.utcfromtimestamp(dt_value))
+        self.assertEqual(dt2.created_at, datetime.fromtimestamp(dt_value, tz=timezone.utc).replace(tzinfo=None))
 
     def test_datetime_large(self):
         dt_value = datetime(2038, 12, 31, 10, 10, 10, 123000)
@@ -809,7 +809,7 @@ class TestTimeUUIDFromDatetime(BaseCassEngTestCase):
         assert isinstance(uuid, UUID)
 
         ts = (uuid.time - 0x01b21dd213814000) / 1e7 # back to a timestamp
-        new_dt = datetime.utcfromtimestamp(ts)
+        new_dt = datetime.fromtimestamp(ts, tz=timezone.utc).replace(tzinfo=None)
 
         # checks that we created a UUID1 with the proper timestamp
         assert new_dt == dt

--- a/tests/integration/cqlengine/model/test_model_io.py
+++ b/tests/integration/cqlengine/model/test_model_io.py
@@ -15,7 +15,7 @@ import unittest
 
 from uuid import uuid4, UUID
 import random
-from datetime import datetime, date, time
+from datetime import datetime, date, time, timezone
 from decimal import Decimal
 from operator import itemgetter
 
@@ -197,13 +197,13 @@ class TestModelIO(BaseCassEngTestCase):
 
         sync_table(AllDatatypesModel)
 
-        input = ['ascii', 2 ** 63 - 1, bytearray(b'hello world'), True, datetime.utcfromtimestamp(872835240),
+        input = ['ascii', 2 ** 63 - 1, bytearray(b'hello world'), True, datetime.fromtimestamp(872835240, tz=timezone.utc).replace(tzinfo=None),
                  Decimal('12.3E+7'), 2.39, 3.4028234663852886e+38, '123.123.123.123', 2147483647, 'text',
                  UUID('FE2B4360-28C6-11E2-81C1-0800200C9A66'), UUID('067e6162-3b6f-4ae2-a171-2470b63dff00'),
                  int(str(2147483647) + '000')]
 
         AllDatatypesModel.create(id=0, a='ascii', b=2 ** 63 - 1, c=bytearray(b'hello world'), d=True,
-                                 e=datetime.utcfromtimestamp(872835240), f=Decimal('12.3E+7'), g=2.39,
+                                 e=datetime.fromtimestamp(872835240, tz=timezone.utc), f=Decimal('12.3E+7'), g=2.39,
                                  h=3.4028234663852886e+38, i='123.123.123.123', j=2147483647, k='text',
                                  l=UUID('FE2B4360-28C6-11E2-81C1-0800200C9A66'),
                                  m=UUID('067e6162-3b6f-4ae2-a171-2470b63dff00'), n=int(str(2147483647) + '000'),

--- a/tests/integration/cqlengine/model/test_udts.py
+++ b/tests/integration/cqlengine/model/test_udts.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import unittest
 
-from datetime import datetime, date, time
+from datetime import datetime, date, time, timezone
 from decimal import Decimal
 from unittest.mock import Mock
 from uuid import UUID, uuid4
@@ -272,7 +272,7 @@ class UserDefinedTypeTests(BaseCassEngTestCase):
         self.addCleanup(drop_table, AllDatatypesModel)
 
         input = AllDatatypes(a='ascii', b=2 ** 63 - 1, c=bytearray(b'hello world'), d=True,
-                             e=datetime.utcfromtimestamp(872835240), f=Decimal('12.3E+7'), g=2.39,
+                             e=datetime.fromtimestamp(872835240, tz=timezone.utc).replace(tzinfo=None), f=Decimal('12.3E+7'), g=2.39,
                              h=3.4028234663852886e+38, i='123.123.123.123', j=2147483647, k='text',
                              l=UUID('FE2B4360-28C6-11E2-81C1-0800200C9A66'),
                              m=UUID('067e6162-3b6f-4ae2-a171-2470b63dff00'), n=int(str(2147483647) + '000'))

--- a/tests/unit/cython/types_testhelper.pyx
+++ b/tests/unit/cython/types_testhelper.pyx
@@ -38,7 +38,7 @@ def test_datetype(assert_equal):
         cdef BytesIOReader reader
         cdef Buffer buf
 
-        dt = datetime.datetime.utcfromtimestamp(timestamp)
+        dt = datetime.datetime.fromtimestamp(timestamp, tz=datetime.timezone.utc)
 
         bytes = io.BytesIO()
         write_value(bytes, DateType.serialize(dt, 0))
@@ -52,7 +52,7 @@ def test_datetype(assert_equal):
     # deserialize
     # epoc
     expected = 0
-    assert_equal(deserialize(expected), datetime.datetime.utcfromtimestamp(expected))
+    assert_equal(deserialize(expected), datetime.datetime.fromtimestamp(expected, tz=datetime.timezone.utc).replace(tzinfo=None))
 
     # beyond 32b
     expected = 2 ** 33

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -201,7 +201,7 @@ class TypeTests(unittest.TestCase):
 
     def test_datetype(self):
         now_time_seconds = time.time()
-        now_datetime = datetime.datetime.utcfromtimestamp(now_time_seconds)
+        now_datetime = datetime.datetime.fromtimestamp(now_time_seconds, tz=datetime.timezone.utc)
 
         # Cassandra timestamps in millis
         now_timestamp = now_time_seconds * 1e3
@@ -212,23 +212,23 @@ class TypeTests(unittest.TestCase):
         # deserialize
         # epoc
         expected = 0
-        self.assertEqual(DateType.deserialize(int64_pack(1000 * expected), 0), datetime.datetime.utcfromtimestamp(expected))
+        self.assertEqual(DateType.deserialize(int64_pack(1000 * expected), 0), datetime.datetime.fromtimestamp(expected, tz=datetime.timezone.utc).replace(tzinfo=None))
 
         # beyond 32b
         expected = 2 ** 33
-        self.assertEqual(DateType.deserialize(int64_pack(1000 * expected), 0), datetime.datetime(2242, 3, 16, 12, 56, 32))
+        self.assertEqual(DateType.deserialize(int64_pack(1000 * expected), 0), datetime.datetime(2242, 3, 16, 12, 56, 32, tzinfo=datetime.timezone.utc).replace(tzinfo=None))
 
         # less than epoc (PYTHON-119)
         expected = -770172256
-        self.assertEqual(DateType.deserialize(int64_pack(1000 * expected), 0), datetime.datetime(1945, 8, 5, 23, 15, 44))
+        self.assertEqual(DateType.deserialize(int64_pack(1000 * expected), 0), datetime.datetime(1945, 8, 5, 23, 15, 44, tzinfo=datetime.timezone.utc).replace(tzinfo=None))
 
         # work around rounding difference among Python versions (PYTHON-230)
         expected = 1424817268.274
-        self.assertEqual(DateType.deserialize(int64_pack(int(1000 * expected)), 0), datetime.datetime(2015, 2, 24, 22, 34, 28, 274000))
+        self.assertEqual(DateType.deserialize(int64_pack(int(1000 * expected)), 0), datetime.datetime(2015, 2, 24, 22, 34, 28, 274000, tzinfo=datetime.timezone.utc).replace(tzinfo=None))
 
         # Large date overflow (PYTHON-452)
         expected = 2177403010.123
-        self.assertEqual(DateType.deserialize(int64_pack(int(1000 * expected)), 0), datetime.datetime(2038, 12, 31, 10, 10, 10, 123000))
+        self.assertEqual(DateType.deserialize(int64_pack(int(1000 * expected)), 0), datetime.datetime(2038, 12, 31, 10, 10, 10, 123000, tzinfo=datetime.timezone.utc).replace(tzinfo=None))
 
     def test_collection_null_support(self):
         """


### PR DESCRIPTION
before this change, when testing with cqlsh, we have warnings like:

```
  <frozen importlib._bootstrap>:488: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
````

in this change, we replace the deprecated API with timezone-aware API, to avoid this warning.