### PR TITLE
Add 5.0-beta1 to matrix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ import com.datastax.jenkins.drivers.python.Slack
 
 slack = new Slack()
 
-DEFAULT_CASSANDRA = ['3.0', '3.11', '4.0']
+DEFAULT_CASSANDRA = ['3.0', '3.11', '4.0', '5.0-beta1']
 DEFAULT_DSE = ['dse-5.1.35', 'dse-6.8.30']
 DEFAULT_RUNTIME = ['3.8.16', '3.9.16', '3.10.11', '3.11.3', '3.12.0']
 DEFAULT_CYTHON = ["True", "False"]
@@ -558,6 +558,10 @@ pipeline {
                           <td>Apache CassandraⓇ v4.0.x</td>
                         </tr>
                         <tr>
+                          <td><strong>5.0-beta1</strong></td>
+                          <td>Apache CassandraⓇ v5.0-beta1</td>
+                        </tr>
+                        <tr>
                           <td><strong>dse-5.1.35</strong></td>
                           <td>DataStax Enterprise v5.1.x</td>
                         </tr>
@@ -644,7 +648,7 @@ pipeline {
     parameterizedCron(branchPatternCron().matcher(env.BRANCH_NAME).matches() ? """
       # Every weeknight (Monday - Friday) around 4:00 AM
       # These schedules will run with and without Cython enabled for Python 3.8.16 and 3.12.0
-      H 4 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;EVENT_LOOP=LIBEV;CI_SCHEDULE_PYTHON_VERSION=3.8.16 3.12.0;CI_SCHEDULE_SERVER_VERSION=3.11 4.0 dse-5.1.35 dse-6.8.30
+      H 4 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;EVENT_LOOP=LIBEV;CI_SCHEDULE_PYTHON_VERSION=3.8.16 3.12.0;CI_SCHEDULE_SERVER_VERSION=3.11 4.0 5.0-beta1 dse-5.1.35 dse-6.8.30
     """ : "")
   }
 


### PR DESCRIPTION
Currently tests are failing and I think most (if not all) are related to cassandra.yml setting renaming that happened in C* 4.1. This is happening with other drivers as well. The Java driver already handled this in https://github.com/apache/cassandra-java-driver/pull/1924

C* 4.1 renamed some config settings but C* is still looking at the old names because of backwards compability reasons. However, C* fails to launch if it finds both the NEW name and the OLD name for a specific setting. The driver tests call ccm to add the OLD config setting but because the name is different from the one in cassadra.yml, the setting is added to cassandra.yml instead of replacing it.

Another issue that I found is that Jenkins is not  marking a step as "red"/failed if the tests fail. I don't know if this is related to the recent changes to the test infrastructure that happened on this driver.

I've already updated the AMI so it's already running the updated ccm that supports 5.0.