### PR TITLE
Upgraded cython to 3.0.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -368,7 +368,7 @@ def run_setup(extensions):
         # 1.) build_ext eats errors at compile time, letting the install complete while producing useful feedback
         # 2.) there could be a case where the python environment has cython installed but the system doesn't have build tools
         if pre_build_check():
-            cython_dep = 'Cython>=0.20,!=0.25,<0.30'
+            cython_dep = 'Cython>=3.0'
             user_specified_cython_version = os.environ.get('CASS_DRIVER_ALLOWED_CYTHON_VERSION')
             if user_specified_cython_version is not None:
                 cython_dep = 'Cython==%s' % (user_specified_cython_version,)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ pure-sasl
 twisted[tls]
 gevent
 eventlet
-cython>=0.20,<0.30
+cython>=3.0
 packaging
 futurist
 asynctest

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py{38,39,310,311,312},pypy
 [base]
 deps = pytest
        packaging
-       cython>=0.20,<0.30
+       cython>=3.0
        eventlet
        gevent
        twisted[tls]


### PR DESCRIPTION
Upgrade cython to 3.x which builds for Python 3.x by default. 