### PR TITLE
add convenience method for authenticating with astra via db_id and token

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1046,7 +1046,7 @@ class Cluster(object):
         (or)
 
         {
-            # Astra DB cluster UUID. Only if secure_connect_bundle is not provided
+            # Astra DB cluster UUID, used if secure_connect_bundle is not provided
             'db_id': 'db_id',
 
             # required with db_id. Astra DB token
@@ -1188,7 +1188,7 @@ class Cluster(object):
             uses_eventlet = EventletConnection and issubclass(self.connection_class, EventletConnection)
 
             # Check if we need to download the secure connect bundle
-            if all(akey in cloud for akey in ('db_id', 'token')):
+            if all(akey in cloud for akey in ['db_id', 'token']):
                 # download SCB if necessary
                 if 'secure_connect_bundle' not in cloud:
                     bundle_path = f'astradb-scb-{cloud["db_id"]}'
@@ -2233,7 +2233,7 @@ class Cluster(object):
 
         Args:
             db_id (str): The Astra DB cluster UUID.
-            token (str): The Astra token.
+            token (str): The Astra security token.
             db_region (optional str): The Astra DB cluster region.
 
         Returns:

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1198,7 +1198,7 @@ class Cluster(object):
                         bundle_path += '.zip'
                     if not os.path.exists(bundle_path):
                         log.info('Downloading Secure Cloud Bundle...')
-                        url = self._get_astra_bundle_url(cloud['db_id'], cloud['token'], cloud["db_region"])
+                        url = self._get_astra_bundle_url(cloud['db_id'], cloud['token'], cloud.get("db_region"))
                         try:
                             with urllib.request.urlopen(url) as r:
                                 with open(bundle_path, 'wb') as f:


### PR DESCRIPTION
example usage:
```
from cassandra.cluster import Cluster

cloud_config = {
    'db_id': '04ab96df-...',
    'token': 'AstraCS:...'
    }
cluster = Cluster(cloud=cloud_config)
```