### PR TITLE
PYTHON-1402 Run integration tests with DSE 6.9.0

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -342,6 +342,7 @@ greaterthanorequaldse51 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Ver
 greaterthanorequaldse50 = unittest.skipUnless(DSE_VERSION and DSE_VERSION >= Version('5.0'), "DSE 5.0 or greater required for this test")
 lessthandse51 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('5.1'), "DSE version less than 5.1 required")
 lessthandse60 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('6.0'), "DSE version less than 6.0 required")
+lessthandse69 = unittest.skipUnless(DSE_VERSION and DSE_VERSION < Version('6.9'), "DSE version less than 6.9 required")
 
 pypy = unittest.skipUnless(platform.python_implementation() == "PyPy", "Test is skipped unless it's on PyPy")
 requiresmallclockgranularity = unittest.skipIf("Windows" in platform.system() or "asyncore" in EVENT_LOOP_MANAGER,

--- a/tests/integration/cqlengine/statements/test_base_statement.py
+++ b/tests/integration/cqlengine/statements/test_base_statement.py
@@ -25,7 +25,7 @@ from cassandra.cqlengine.columns import Column
 
 from tests.integration.cqlengine.base import BaseCassEngTestCase, TestQueryUpdateModel
 from tests.integration.cqlengine import DEFAULT_KEYSPACE
-from tests.integration import greaterthanorequalcass3_10, TestCluster
+from tests.integration import greaterthanorequalcass3_10, lessthandse69, TestCluster
 
 from cassandra.cqlengine.connection import execute
 
@@ -101,6 +101,7 @@ class ExecuteStatementTest(BaseCassEngTestCase):
         self.assertEqual(TestQueryUpdateModel.objects.count(), 0)
 
     @greaterthanorequalcass3_10
+    @lessthandse69
     def test_like_operator(self):
         """
         Test to verify the like operator works appropriately


### PR DESCRIPTION
SASI indexes have been removed in DSE 6.9.0.
Error message: `Column 'text' has a SASI index but SASI is not supported anymore. This index should removed and probably replaced by an equivalent Storage Attached Index (SAI)`