### PR TITLE
Remove duplicated condition in primary key check

### DIFF
--- a/cassandra/cqlengine/management.py
+++ b/cassandra/cqlengine/management.py
@@ -256,7 +256,7 @@ def _sync_table(model, connection=None):
 
                 continue
 
-            if col.primary_key or col.primary_key:
+            if col.primary_key:
                 msg = format_log_context("Cannot add primary key '{0}' (with db_field '{1}') to existing table {2}", keyspace=ks_name, connection=connection)
                 raise CQLEngineException(msg.format(model_name, db_name, cf_name))
 


### PR DESCRIPTION
Motivation:
We had a redundant check (`col.primary_key or col.primary_key`) that caused confusion and had no logical effect.

Modifications:
Removed the duplicated check, leaving only a single condition for `col.primary_key`.

Result:
The code is now clearer and avoids unnecessary duplication.