### PR TITLE
CPython 3.13 Compat and Asyncore Removal

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -148,10 +148,10 @@ def _try_libev_import():
     except DependencyException as e:
         return (None, e)
 
-def _try_asyncore_import():
+def _try_asyncio_import():
     try:
-        from cassandra.io.asyncorereactor import AsyncoreConnection
-        return (AsyncoreConnection,None)
+        from cassandra.io.asyncioreactor import AsyncioConnection
+        return (AsyncioConnection,None)
     except DependencyException as e:
         return (None, e)
 
@@ -167,7 +167,7 @@ def _connection_reduce_fn(val,import_fn):
 
 log = logging.getLogger(__name__)
 
-conn_fns = (_try_gevent_import, _try_eventlet_import, _try_libev_import, _try_asyncore_import)
+conn_fns = (_try_gevent_import, _try_eventlet_import, _try_libev_import, _try_asyncio_import)
 (conn_class, excs) = reduce(_connection_reduce_fn, conn_fns, (None,[]))
 if not conn_class:
     raise DependencyException("Unable to load a default connection class", excs)
@@ -875,15 +875,15 @@ class Cluster(object):
     This determines what event loop system will be used for managing
     I/O with Cassandra.  These are the current options:
 
-    * :class:`cassandra.io.asyncorereactor.AsyncoreConnection`
+    * :class:`cassandra.io.asyncioreactor.AsyncioConnection`
     * :class:`cassandra.io.libevreactor.LibevConnection`
     * :class:`cassandra.io.eventletreactor.EventletConnection` (requires monkey-patching - see doc for details)
     * :class:`cassandra.io.geventreactor.GeventConnection` (requires monkey-patching - see doc for details)
     * :class:`cassandra.io.twistedreactor.TwistedConnection`
     * EXPERIMENTAL: :class:`cassandra.io.asyncioreactor.AsyncioConnection`
 
-    By default, ``AsyncoreConnection`` will be used, which uses
-    the ``asyncore`` module in the Python standard library.
+    By default, ``AsyncioConnection`` will be used, which uses
+    the ``asyncio`` module in the Python standard library.
 
     If ``libev`` is installed, ``LibevConnection`` will be used instead.
 

--- a/cassandra/io/libevwrapper.c
+++ b/cassandra/io/libevwrapper.c
@@ -665,9 +665,14 @@ initlibevwrapper(void)
     if (PyModule_AddObject(module, "Timer", (PyObject *)&libevwrapper_TimerType) == -1)
         INITERROR;
 
+#if PY_MAJOR_VERSION < 3 && PY_MINOR_VERSION < 7
+    // Since CPython 3.7, `Py_Initialize()` routing always initializes GIL.
+    // Routine `PyEval_ThreadsInitialized()` has been deprecated in CPython 3.7
+    // and completely removed in CPython 3.13.
     if (!PyEval_ThreadsInitialized()) {
         PyEval_InitThreads();
     }
+#endif
 
 #if PY_MAJOR_VERSION >= 3
     return module;

--- a/tests/integration/long/test_ipv6.py
+++ b/tests/integration/long/test_ipv6.py
@@ -16,7 +16,7 @@ import os, socket, errno
 from ccmlib import common
 
 from cassandra.cluster import NoHostAvailable
-from cassandra.io.asyncorereactor import AsyncoreConnection
+from cassandra.io.asyncioreactor import AsyncioConnection
 
 from tests import is_monkey_patched
 from tests.integration import use_cluster, remove_cluster, TestCluster

--- a/tests/unit/io/test_asyncioreactor.py
+++ b/tests/unit/io/test_asyncioreactor.py
@@ -1,7 +1,6 @@
 AsyncioConnection, ASYNCIO_AVAILABLE = None, False
 try:
     from cassandra.io.asyncioreactor import AsyncioConnection
-    import asynctest
     ASYNCIO_AVAILABLE = True
 except (ImportError, SyntaxError):
     AsyncioConnection = None
@@ -11,6 +10,7 @@ from tests import is_monkey_patched, connection_class
 from tests.unit.io.utils import TimerCallback, TimerTestMixin
 
 from unittest.mock import patch
+from unittest.mock import AsyncMock
 
 import unittest
 import time
@@ -56,7 +56,7 @@ class AsyncioTimerTests(TimerTestMixin, unittest.TestCase):
         socket_patcher.start()
 
         old_selector = AsyncioConnection._loop._selector
-        AsyncioConnection._loop._selector = asynctest.TestSelector()
+        AsyncioConnection._loop._selector = AsyncMock()
 
         def reset_selector():
             AsyncioConnection._loop._selector = old_selector


### PR DESCRIPTION
Per [Python3.13 Release Notes](https://docs.python.org/3/whatsnew/3.13.html):
> Remove the `PyEval_ThreadsInitialized()` function, deprecated in Python 3.9. Since Python 3.7, `Py_Initialize()` always creates the GIL: calling `PyEval_InitThreads()` does nothing and `PyEval_ThreadsInitialized()` always returns non-zero. (Contributed by Victor Stinner in [gh-105182](https://github.com/python/cpython/issues/105182).)

Removes the use of `PyEval_ThreadsInitialized()` and `PyEval_InitThreads()` if python version is >= 3.7 (written by @daskol in https://github.com/datastax/python-driver/pull/1242/commits/27969fc0c6e5407602c776270bcdcce1ec127b30)

Additionally, removes existing references to `asyncore` in cassandra/cluster.py tests/integration/long/test_ipv6.py tests/unit/io/test_asyncioreactor.py (per @medaminezghal in https://github.com/datastax/python-driver/pull/1242#issuecomment-2760397717