### PR TITLE
Remove Python 3.8 which reached EOL on Oct 2024, update cryptography lib to 42

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,10 +31,10 @@ import com.datastax.jenkins.drivers.python.Slack
 
 slack = new Slack()
 
-DEFAULT_CASSANDRA = ['3.0', '3.11', '4.0', '4.1', '5.0']
+DEFAULT_CASSANDRA = ['3.11', '4.0', '4.1', '5.0']
 DEFAULT_DSE = ['dse-5.1.35', 'dse-6.8.30', 'dse-6.9.0']
 DEFAULT_HCD = ['hcd-1.0.0']
-DEFAULT_RUNTIME = ['3.8.16', '3.9.16', '3.10.11', '3.11.3', '3.12.0']
+DEFAULT_RUNTIME = ['3.9.23', '3.10.18', '3.11.13', '3.12.11', '3.13.5']
 DEFAULT_CYTHON = ["True", "False"]
 matrices = [
   "FULL": [
@@ -674,8 +674,8 @@ pipeline {
   triggers {
     parameterizedCron(branchPatternCron().matcher(env.BRANCH_NAME).matches() ? """
       # Every weeknight (Monday - Friday) around 4:00 AM
-      # These schedules will run with and without Cython enabled for Python 3.8.16 and 3.12.0
-      H 4 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;EVENT_LOOP=LIBEV;CI_SCHEDULE_PYTHON_VERSION=3.8.16 3.12.0;CI_SCHEDULE_SERVER_VERSION=3.11 4.0 5.0 dse-5.1.35 dse-6.8.30 dse-6.9.0 hcd-1.0.0
+      # These schedules will run with and without Cython enabled for Python 3.9.23 and 3.13.5
+      H 4 * * 1-5 %CI_SCHEDULE=WEEKNIGHTS;EVENT_LOOP=LIBEV;CI_SCHEDULE_PYTHON_VERSION=3.9.23 3.13.5;CI_SCHEDULE_SERVER_VERSION=3.11 4.0 5.0 dse-5.1.35 dse-6.8.30 dse-6.9.0 hcd-1.0.0
     """ : "")
   }
 

--- a/README-dev.rst
+++ b/README-dev.rst
@@ -166,7 +166,7 @@ it with the ``PROTOCOL_VERSION`` environment variable::
 
 Testing Multiple Python Versions
 --------------------------------
-Use tox to test all of Python 3.8 through 3.12 and pypy (this is what TravisCI runs)::
+Use tox to test all of Python 3.9 through 3.13 and pypy (this is what TravisCI runs)::
 
     tox
 

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ DataStax Driver for Apache Cassandra
 A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ and highly-tunable Python client library for Apache Cassandra (2.1+) and
 DataStax Enterprise (4.7+) using exclusively Cassandra's binary protocol and Cassandra Query Language v3.
 
-The driver supports Python 3.8 through 3.12.
+The driver supports Python 3.9 through 3.13.
 
 **Note:** DataStax products do not support big-endian systems.
 

--- a/docs.yaml
+++ b/docs.yaml
@@ -2,10 +2,6 @@ title: DataStax Python Driver
 summary: DataStax Python Driver for Apache Cassandra®
 output: docs/_build/
 swiftype_drivers: pythondrivers
-checks:
-  external_links:
-    exclude:
-    - 'http://aka.ms/vcpython27'
 sections:
   - title: N/A
     prefix: /

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ A Python client driver for `Apache Cassandra® <http://cassandra.apache.org>`_.
 This driver works exclusively with the Cassandra Query Language v3 (CQL3)
 and Cassandra's native protocol.  Cassandra 2.1+ is supported, including DSE 4.7+.
 
-The driver supports Python 3.8 through 3.12.
+The driver supports Python 3.9 through 3.13.
 
 This driver is open source under the
 `Apache v2 License <http://www.apache.org/licenses/LICENSE-2.0.html>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Supported Platforms
 -------------------
-Python 3.8 through 3.12 are supported.  Both CPython (the standard Python
+Python 3.9 through 3.13 are supported.  Both CPython (the standard Python
 implementation) and `PyPy <http://pypy.org>`_ are supported and tested.
 
 Linux, OSX, and Windows are supported.

--- a/setup.py
+++ b/setup.py
@@ -390,7 +390,7 @@ def run_setup(extensions):
 
     _EXTRAS_REQUIRE = {
         'graph': ['gremlinpython==3.4.6'],
-        'cle': ['cryptography>=35.0']
+        'cle': ['cryptography>=42.0']
     }
 
     setup(
@@ -424,11 +424,11 @@ def run_setup(extensions):
             'Natural Language :: English',
             'Operating System :: OS Independent',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: 3.12',
+            'Programming Language :: Python :: 3.13',
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
             'Topic :: Software Development :: Libraries :: Python Modules'

--- a/test-datastax-requirements.txt
+++ b/test-datastax-requirements.txt
@@ -1,4 +1,4 @@
 -r test-requirements.txt
 kerberos
 gremlinpython==3.4.6
-cryptography >= 35.0
+cryptography >= 42.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312},pypy
+envlist = py{39,310,311,312,313},pypy
 
 [base]
 deps = pytest
@@ -12,7 +12,7 @@ deps = pytest
        kerberos
        futurist
        lz4
-       cryptography>=35.0
+       cryptography>=42.0
 
 [testenv]
 deps = {[base]deps}


### PR DESCRIPTION
…