### PR TITLE
Whitelist round robin policy handle nodes with same ip

### DIFF
--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -46,10 +46,10 @@ from cassandra import (ConsistencyLevel, AuthenticationFailed,
                        SchemaTargetType, DriverException, ProtocolVersion,
                        UnresolvableContactPoints, DependencyException)
 from cassandra.auth import _proxy_execute_key, PlainTextAuthProvider
+from cassandra.endpoint import EndPoint, DefaultEndPoint, DefaultEndPointFactory, SniEndPointFactory
 from cassandra.connection import (ConnectionException, ConnectionShutdown,
                                   ConnectionHeartbeat, ProtocolVersionUnsupported,
-                                  EndPoint, DefaultEndPoint, DefaultEndPointFactory,
-                                  ContinuousPagingState, SniEndPointFactory, ConnectionBusy)
+                                  ContinuousPagingState, ConnectionBusy)
 from cassandra.cqltypes import UserType
 from cassandra.encoder import Encoder
 from cassandra.protocol import (QueryMessage, ResultMessage,

--- a/cassandra/connection.py
+++ b/cassandra/connection.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import  # to enable import io from stdlib
 from collections import defaultdict, deque
 import errno
-from functools import wraps, partial, total_ordering
+from functools import wraps, partial
 from heapq import heappush, heappop
 import io
 import logging
@@ -26,7 +26,6 @@ from threading import Thread, Event, RLock, Condition
 import time
 import ssl
 import weakref
-
 
 if 'gevent.monkey' in sys.modules:
     from gevent.queue import Queue, Empty
@@ -44,6 +43,7 @@ from cassandra.protocol import (ReadyMessage, AuthenticateMessage, OptionsMessag
                                 RegisterMessage, ReviseRequestMessage)
 from cassandra.segment import SegmentCodec, CrcException
 from cassandra.util import OrderedDict
+from cassandra.endpoint import EndPoint, DefaultEndPoint
 
 
 log = logging.getLogger(__name__)
@@ -116,257 +116,6 @@ HEADER_DIRECTION_MASK = 0x80
 
 frame_header_v1_v2 = struct.Struct('>BbBi')
 frame_header_v3 = struct.Struct('>BhBi')
-
-
-class EndPoint(object):
-    """
-    Represents the information to connect to a cassandra node.
-    """
-
-    @property
-    def address(self):
-        """
-        The IP address of the node. This is the RPC address the driver uses when connecting to the node
-        """
-        raise NotImplementedError()
-
-    @property
-    def port(self):
-        """
-        The port of the node.
-        """
-        raise NotImplementedError()
-
-    @property
-    def ssl_options(self):
-        """
-        SSL options specific to this endpoint.
-        """
-        return None
-
-    @property
-    def socket_family(self):
-        """
-        The socket family of the endpoint.
-        """
-        return socket.AF_UNSPEC
-
-    def resolve(self):
-        """
-        Resolve the endpoint to an address/port. This is called
-        only on socket connection.
-        """
-        raise NotImplementedError()
-
-
-class EndPointFactory(object):
-
-    cluster = None
-
-    def configure(self, cluster):
-        """
-        This is called by the cluster during its initialization.
-        """
-        self.cluster = cluster
-        return self
-
-    def create(self, row):
-        """
-        Create an EndPoint from a system.peers row.
-        """
-        raise NotImplementedError()
-
-
-@total_ordering
-class DefaultEndPoint(EndPoint):
-    """
-    Default EndPoint implementation, basically just an address and port.
-    """
-
-    def __init__(self, address, port=9042):
-        self._address = address
-        self._port = port
-
-    @property
-    def address(self):
-        return self._address
-
-    @property
-    def port(self):
-        return self._port
-
-    def resolve(self):
-        return self._address, self._port
-
-    def __eq__(self, other):
-        return isinstance(other, DefaultEndPoint) and \
-               self.address == other.address and self.port == other.port
-
-    def __hash__(self):
-        return hash((self.address, self.port))
-
-    def __lt__(self, other):
-        return (self.address, self.port) < (other.address, other.port)
-
-    def __str__(self):
-        return str("%s:%d" % (self.address, self.port))
-
-    def __repr__(self):
-        return "<%s: %s:%d>" % (self.__class__.__name__, self.address, self.port)
-
-
-class DefaultEndPointFactory(EndPointFactory):
-
-    port = None
-    """
-    If no port is discovered in the row, this is the default port
-    used for endpoint creation. 
-    """
-
-    def __init__(self, port=None):
-        self.port = port
-
-    def create(self, row):
-        # TODO next major... move this class so we don't need this kind of hack
-        from cassandra.metadata import _NodeInfo
-        addr = _NodeInfo.get_broadcast_rpc_address(row)
-        port = _NodeInfo.get_broadcast_rpc_port(row)
-        if port is None:
-            port = self.port if self.port else 9042
-
-        # create the endpoint with the translated address
-        # TODO next major, create a TranslatedEndPoint type
-        return DefaultEndPoint(
-            self.cluster.address_translator.translate(addr),
-            port)
-
-
-@total_ordering
-class SniEndPoint(EndPoint):
-    """SNI Proxy EndPoint implementation."""
-
-    def __init__(self, proxy_address, server_name, port=9042, init_index=0):
-        self._proxy_address = proxy_address
-        self._index = init_index
-        self._resolved_address = None  # resolved address
-        self._port = port
-        self._server_name = server_name
-        self._ssl_options = {'server_hostname': server_name}
-
-    @property
-    def address(self):
-        return self._proxy_address
-
-    @property
-    def port(self):
-        return self._port
-
-    @property
-    def ssl_options(self):
-        return self._ssl_options
-
-    def resolve(self):
-        try:
-            resolved_addresses = self._resolve_proxy_addresses()
-        except socket.gaierror:
-            log.debug('Could not resolve sni proxy hostname "%s" '
-                      'with port %d' % (self._proxy_address, self._port))
-            raise
-
-        # round-robin pick
-        self._resolved_address = sorted(addr[4][0] for addr in resolved_addresses)[self._index % len(resolved_addresses)]
-        self._index += 1
-
-        return self._resolved_address, self._port
-
-    def _resolve_proxy_addresses(self):
-        return socket.getaddrinfo(self._proxy_address, self._port,
-                                  socket.AF_UNSPEC, socket.SOCK_STREAM)
-
-    def __eq__(self, other):
-        return (isinstance(other, SniEndPoint) and
-                self.address == other.address and self.port == other.port and
-                self._server_name == other._server_name)
-
-    def __hash__(self):
-        return hash((self.address, self.port, self._server_name))
-
-    def __lt__(self, other):
-        return ((self.address, self.port, self._server_name) <
-                (other.address, other.port, self._server_name))
-
-    def __str__(self):
-        return str("%s:%d:%s" % (self.address, self.port, self._server_name))
-
-    def __repr__(self):
-        return "<%s: %s:%d:%s>" % (self.__class__.__name__,
-                                   self.address, self.port, self._server_name)
-
-
-class SniEndPointFactory(EndPointFactory):
-
-    def __init__(self, proxy_address, port):
-        self._proxy_address = proxy_address
-        self._port = port
-        # Initial lookup index to prevent all SNI endpoints to be resolved
-        # into the same starting IP address (which might not be available currently).
-        # If SNI resolves to 3 IPs, first endpoint will connect to first
-        # IP address, and subsequent resolutions to next IPs in round-robin
-        # fusion.
-        self._init_index = -1
-
-    def create(self, row):
-        host_id = row.get("host_id")
-        if host_id is None:
-            raise ValueError("No host_id to create the SniEndPoint")
-
-        self._init_index += 1
-        return SniEndPoint(self._proxy_address, str(host_id), self._port, self._init_index)
-
-    def create_from_sni(self, sni):
-        self._init_index += 1
-        return SniEndPoint(self._proxy_address, sni, self._port, self._init_index)
-
-
-@total_ordering
-class UnixSocketEndPoint(EndPoint):
-    """
-    Unix Socket EndPoint implementation.
-    """
-
-    def __init__(self, unix_socket_path):
-        self._unix_socket_path = unix_socket_path
-
-    @property
-    def address(self):
-        return self._unix_socket_path
-
-    @property
-    def port(self):
-        return None
-
-    @property
-    def socket_family(self):
-        return socket.AF_UNIX
-
-    def resolve(self):
-        return self.address, None
-
-    def __eq__(self, other):
-        return (isinstance(other, UnixSocketEndPoint) and
-                self._unix_socket_path == other._unix_socket_path)
-
-    def __hash__(self):
-        return hash(self._unix_socket_path)
-
-    def __lt__(self, other):
-        return self._unix_socket_path < other._unix_socket_path
-
-    def __str__(self):
-        return str("%s" % (self._unix_socket_path,))
-
-    def __repr__(self):
-        return "<%s: %s>" % (self.__class__.__name__, self._unix_socket_path)
 
 
 class _Frame(object):

--- a/cassandra/endpoint.py
+++ b/cassandra/endpoint.py
@@ -1,0 +1,271 @@
+# Copyright DataStax, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import  # to enable import io from stdlib
+from functools import total_ordering
+import logging
+import socket
+
+log = logging.getLogger(__name__)
+
+class EndPoint(object):
+    """
+    Represents the information to connect to a cassandra node.
+    """
+
+    @property
+    def address(self):
+        """
+        The IP address of the node. This is the RPC address the driver uses when connecting to the node
+        """
+        raise NotImplementedError()
+
+    @property
+    def port(self):
+        """
+        The port of the node.
+        """
+        raise NotImplementedError()
+
+    @property
+    def ssl_options(self):
+        """
+        SSL options specific to this endpoint.
+        """
+        return None
+
+    @property
+    def socket_family(self):
+        """
+        The socket family of the endpoint.
+        """
+        return socket.AF_UNSPEC
+
+    def resolve(self):
+        """
+        Resolve the endpoint to an address/port. This is called
+        only on socket connection.
+        """
+        raise NotImplementedError()
+
+
+class EndPointFactory(object):
+
+    cluster = None
+
+    def configure(self, cluster):
+        """
+        This is called by the cluster during its initialization.
+        """
+        self.cluster = cluster
+        return self
+
+    def create(self, row):
+        """
+        Create an EndPoint from a system.peers row.
+        """
+        raise NotImplementedError()
+
+
+@total_ordering
+class DefaultEndPoint(EndPoint):
+    """
+    Default EndPoint implementation, basically just an address and port.
+    """
+
+    def __init__(self, address, port=9042):
+        self._address = address
+        self._port = port
+
+    @property
+    def address(self):
+        return self._address
+
+    @property
+    def port(self):
+        return self._port
+
+    def resolve(self):
+        return self._address, self._port
+
+    def __eq__(self, other):
+        return isinstance(other, DefaultEndPoint) and \
+               self.address == other.address and self.port == other.port
+
+    def __hash__(self):
+        return hash((self.address, self.port))
+
+    def __lt__(self, other):
+        return (self.address, self.port) < (other.address, other.port)
+
+    def __str__(self):
+        return str("%s:%d" % (self.address, self.port))
+
+    def __repr__(self):
+        return "<%s: %s:%d>" % (self.__class__.__name__, self.address, self.port)
+
+
+class DefaultEndPointFactory(EndPointFactory):
+
+    port = None
+    """
+    If no port is discovered in the row, this is the default port
+    used for endpoint creation. 
+    """
+
+    def __init__(self, port=None):
+        self.port = port
+
+    def create(self, row):
+        # TODO next major... move this class so we don't need this kind of hack
+        from cassandra.metadata import _NodeInfo
+        addr = _NodeInfo.get_broadcast_rpc_address(row)
+        port = _NodeInfo.get_broadcast_rpc_port(row)
+        if port is None:
+            port = self.port if self.port else 9042
+
+        # create the endpoint with the translated address
+        # TODO next major, create a TranslatedEndPoint type
+        return DefaultEndPoint(
+            self.cluster.address_translator.translate(addr),
+            port)
+
+
+@total_ordering
+class SniEndPoint(EndPoint):
+    """SNI Proxy EndPoint implementation."""
+
+    def __init__(self, proxy_address, server_name, port=9042, init_index=0):
+        self._proxy_address = proxy_address
+        self._index = init_index
+        self._resolved_address = None  # resolved address
+        self._port = port
+        self._server_name = server_name
+        self._ssl_options = {'server_hostname': server_name}
+
+    @property
+    def address(self):
+        return self._proxy_address
+
+    @property
+    def port(self):
+        return self._port
+
+    @property
+    def ssl_options(self):
+        return self._ssl_options
+
+    def resolve(self):
+        try:
+            resolved_addresses = self._resolve_proxy_addresses()
+        except socket.gaierror:
+            log.debug('Could not resolve sni proxy hostname "%s" '
+                      'with port %d' % (self._proxy_address, self._port))
+            raise
+
+        # round-robin pick
+        self._resolved_address = sorted(addr[4][0] for addr in resolved_addresses)[self._index % len(resolved_addresses)]
+        self._index += 1
+
+        return self._resolved_address, self._port
+
+    def _resolve_proxy_addresses(self):
+        return socket.getaddrinfo(self._proxy_address, self._port,
+                                  socket.AF_UNSPEC, socket.SOCK_STREAM)
+
+    def __eq__(self, other):
+        return (isinstance(other, SniEndPoint) and
+                self.address == other.address and self.port == other.port and
+                self._server_name == other._server_name)
+
+    def __hash__(self):
+        return hash((self.address, self.port, self._server_name))
+
+    def __lt__(self, other):
+        return ((self.address, self.port, self._server_name) <
+                (other.address, other.port, self._server_name))
+
+    def __str__(self):
+        return str("%s:%d:%s" % (self.address, self.port, self._server_name))
+
+    def __repr__(self):
+        return "<%s: %s:%d:%s>" % (self.__class__.__name__,
+                                   self.address, self.port, self._server_name)
+
+
+class SniEndPointFactory(EndPointFactory):
+
+    def __init__(self, proxy_address, port):
+        self._proxy_address = proxy_address
+        self._port = port
+        # Initial lookup index to prevent all SNI endpoints to be resolved
+        # into the same starting IP address (which might not be available currently).
+        # If SNI resolves to 3 IPs, first endpoint will connect to first
+        # IP address, and subsequent resolutions to next IPs in round-robin
+        # fusion.
+        self._init_index = -1
+
+    def create(self, row):
+        host_id = row.get("host_id")
+        if host_id is None:
+            raise ValueError("No host_id to create the SniEndPoint")
+
+        self._init_index += 1
+        return SniEndPoint(self._proxy_address, str(host_id), self._port, self._init_index)
+
+    def create_from_sni(self, sni):
+        self._init_index += 1
+        return SniEndPoint(self._proxy_address, sni, self._port, self._init_index)
+
+
+@total_ordering
+class UnixSocketEndPoint(EndPoint):
+    """
+    Unix Socket EndPoint implementation.
+    """
+
+    def __init__(self, unix_socket_path):
+        self._unix_socket_path = unix_socket_path
+
+    @property
+    def address(self):
+        return self._unix_socket_path
+
+    @property
+    def port(self):
+        return None
+
+    @property
+    def socket_family(self):
+        return socket.AF_UNIX
+
+    def resolve(self):
+        return self.address, None
+
+    def __eq__(self, other):
+        return (isinstance(other, UnixSocketEndPoint) and
+                self._unix_socket_path == other._unix_socket_path)
+
+    def __hash__(self):
+        return hash(self._unix_socket_path)
+
+    def __lt__(self, other):
+        return self._unix_socket_path < other._unix_socket_path
+
+    def __str__(self):
+        return str("%s" % (self._unix_socket_path,))
+
+    def __repr__(self):
+        return "<%s: %s>" % (self.__class__.__name__, self._unix_socket_path)
+

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -40,7 +40,7 @@ from cassandra.protocol import QueryMessage
 from cassandra.query import dict_factory, bind_params
 from cassandra.util import OrderedDict, Version
 from cassandra.pool import HostDistance
-from cassandra.connection import EndPoint
+from cassandra.endpoint import EndPoint
 
 log = logging.getLogger(__name__)
 

--- a/cassandra/pool.py
+++ b/cassandra/pool.py
@@ -28,7 +28,8 @@ except ImportError:
     from cassandra.util import WeakSet  # NOQA
 
 from cassandra import AuthenticationFailed
-from cassandra.connection import ConnectionException, EndPoint, DefaultEndPoint
+from cassandra.connection import ConnectionException
+from cassandra.endpoint import EndPoint, DefaultEndPoint
 from cassandra.policies import HostDistance
 
 log = logging.getLogger(__name__)

--- a/tests/integration/advanced/test_unixsocketendpoint.py
+++ b/tests/integration/advanced/test_unixsocketendpoint.py
@@ -18,7 +18,7 @@ import subprocess
 import logging
 
 from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
-from cassandra.connection import UnixSocketEndPoint
+from cassandra.endpoint import UnixSocketEndPoint
 from cassandra.policies import WhiteListRoundRobinPolicy, RoundRobinPolicy
 
 from tests import notwindows

--- a/tests/integration/cloud/test_cloud.py
+++ b/tests/integration/cloud/test_cloud.py
@@ -24,7 +24,7 @@ from ssl import SSLContext, PROTOCOL_TLS
 
 from cassandra import DriverException, ConsistencyLevel, InvalidRequest
 from cassandra.cluster import NoHostAvailable, ExecutionProfile, Cluster, _execution_profile_to_string
-from cassandra.connection import SniEndPoint
+from cassandra.endpoint import SniEndPoint
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.policies import TokenAwarePolicy, DCAwareRoundRobinPolicy, ConstantReconnectionPolicy
 

--- a/tests/integration/long/test_ssl.py
+++ b/tests/integration/long/test_ssl.py
@@ -16,7 +16,7 @@ import unittest
 
 import os, sys, traceback, logging, ssl, time, math, uuid
 from cassandra.cluster import NoHostAvailable
-from cassandra.connection import DefaultEndPoint
+from cassandra.endpoint import DefaultEndPoint
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 

--- a/tests/integration/simulacron/test_endpoint.py
+++ b/tests/integration/simulacron/test_endpoint.py
@@ -16,7 +16,7 @@ import unittest
 from functools import total_ordering
 
 from cassandra.cluster import Cluster
-from cassandra.connection import DefaultEndPoint, EndPoint, DefaultEndPointFactory
+from cassandra.endpoint import DefaultEndPoint, EndPoint, DefaultEndPointFactory
 from cassandra.metadata import _NodeInfo
 from tests.integration import requiressimulacron
 from tests.integration.simulacron import SimulacronCluster, PROTOCOL_VERSION

--- a/tests/integration/standard/test_cluster.py
+++ b/tests/integration/standard/test_cluster.py
@@ -34,7 +34,7 @@ from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement, TraceUnavailable, tuple_factory
 from cassandra.auth import PlainTextAuthProvider, SaslAuthProvider
 from cassandra import connection
-from cassandra.connection import DefaultEndPoint
+from cassandra.endpoint import DefaultEndPoint
 
 from tests import notwindows
 from tests.integration import use_singledc, get_server_versions, CASSANDRA_VERSION, \

--- a/tests/integration/standard/test_policies.py
+++ b/tests/integration/standard/test_policies.py
@@ -18,7 +18,7 @@ from cassandra.cluster import ExecutionProfile, EXEC_PROFILE_DEFAULT
 from cassandra.policies import HostFilterPolicy, RoundRobinPolicy,  SimpleConvictionPolicy, \
     WhiteListRoundRobinPolicy
 from cassandra.pool import Host
-from cassandra.connection import DefaultEndPoint
+from cassandra.endpoint import DefaultEndPoint
 
 from tests.integration import local, use_singledc, TestCluster
 

--- a/tests/integration/standard/test_policies.py
+++ b/tests/integration/standard/test_policies.py
@@ -80,7 +80,22 @@ class WhiteListRoundRobinPolicyTests(unittest.TestCase):
         only_connect_hosts = {"127.0.0.1", "127.0.0.2"}
         white_list = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy(only_connect_hosts))
         cluster = TestCluster(execution_profiles={"white_list": white_list})
-        #cluster = Cluster(load_balancing_policy=WhiteListRoundRobinPolicy(only_connect_hosts))
+        session = cluster.connect(wait_for_all_pools=True)
+        queried_hosts = set()
+        for _ in range(10):
+            response = session.execute('SELECT * from system.local', execution_profile="white_list")
+            queried_hosts.update(response.response_future.attempted_hosts)
+        queried_hosts = set(host.address for host in queried_hosts)
+        self.assertEqual(queried_hosts, only_connect_hosts)
+
+    @local
+    def test_only_connects_to_subset_with_port(self):
+        only_connect_hosts = {
+            ("127.0.0.1", 9042),
+            ("127.0.0.2", 9043)
+        }
+        white_list = ExecutionProfile(load_balancing_policy=WhiteListRoundRobinPolicy(only_connect_hosts))
+        cluster = TestCluster(execution_profiles={"white_list": white_list})
         session = cluster.connect(wait_for_all_pools=True)
         queried_hosts = set()
         for _ in range(10):

--- a/tests/unit/io/test_twistedreactor.py
+++ b/tests/unit/io/test_twistedreactor.py
@@ -15,7 +15,7 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from cassandra.connection import DefaultEndPoint
+from cassandra.endpoint import DefaultEndPoint
 
 try:
     from twisted.test import proto_helpers

--- a/tests/unit/io/utils.py
+++ b/tests/unit/io/utils.py
@@ -19,7 +19,7 @@ from cassandra.marshal import uint8_pack, uint32_pack
 from cassandra.protocol import (
     write_stringmultimap, write_int, write_string, SupportedMessage, ReadyMessage, ServerError
 )
-from cassandra.connection import DefaultEndPoint
+from cassandra.endpoint import DefaultEndPoint
 from tests import is_monkey_patched
 
 import io

--- a/tests/unit/test_cluster.py
+++ b/tests/unit/test_cluster.py
@@ -23,7 +23,7 @@ from cassandra import ConsistencyLevel, DriverException, Timeout, Unavailable, R
     InvalidRequest, Unauthorized, AuthenticationFailed, OperationTimedOut, UnsupportedOperation, RequestValidationException, ConfigurationException, ProtocolVersion
 from cassandra.cluster import _Scheduler, Session, Cluster, default_lbp_factory, \
     ExecutionProfile, _ConfigMode, EXEC_PROFILE_DEFAULT
-from cassandra.connection import SniEndPoint, SniEndPointFactory
+from cassandra.endpoint import SniEndPoint, SniEndPointFactory
 from cassandra.pool import Host
 from cassandra.policies import HostDistance, RetryPolicy, RoundRobinPolicy, DowngradingConsistencyRetryPolicy, SimpleConvictionPolicy
 from cassandra.query import SimpleStatement, named_tuple_factory, tuple_factory

--- a/tests/unit/test_control_connection.py
+++ b/tests/unit/test_control_connection.py
@@ -21,7 +21,7 @@ from cassandra import OperationTimedOut, SchemaTargetType, SchemaChangeType
 from cassandra.protocol import ResultMessage, RESULT_KIND_ROWS
 from cassandra.cluster import ControlConnection, _Scheduler, ProfileManager, EXEC_PROFILE_DEFAULT, ExecutionProfile
 from cassandra.pool import Host
-from cassandra.connection import EndPoint, DefaultEndPoint, DefaultEndPointFactory
+from cassandra.endpoint import EndPoint, DefaultEndPoint, DefaultEndPointFactory
 from cassandra.policies import (SimpleConvictionPolicy, RoundRobinPolicy,
                                 ConstantReconnectionPolicy, IdentityTranslator)
 

--- a/tests/unit/test_endpoints.py
+++ b/tests/unit/test_endpoints.py
@@ -10,7 +10,7 @@ import unittest
 
 import itertools
 
-from cassandra.connection import DefaultEndPoint, SniEndPoint, SniEndPointFactory
+from cassandra.endpoint import DefaultEndPoint, SniEndPoint, SniEndPointFactory
 
 from unittest.mock import patch
 

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -24,7 +24,7 @@ from threading import Thread
 
 from cassandra import ConsistencyLevel
 from cassandra.cluster import Cluster
-from cassandra.connection import DefaultEndPoint
+from cassandra.endpoint import DefaultEndPoint
 from cassandra.metadata import Metadata
 from cassandra.policies import (RoundRobinPolicy, WhiteListRoundRobinPolicy, DCAwareRoundRobinPolicy,
                                 TokenAwarePolicy, SimpleConvictionPolicy,

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -1252,6 +1252,17 @@ class WhiteListRoundRobinPolicyTest(unittest.TestCase):
 
         self.assertEqual(policy.distance(host), HostDistance.LOCAL)
 
+    def test_hosts_with_hostname_and_port(self):
+        hosts = ['localhost']
+        policy = WhiteListRoundRobinPolicy(hosts)
+        host = Host(DefaultEndPoint("127.0.0.1", 1000), SimpleConvictionPolicy)
+        policy.populate(None, [host])
+
+        qplan = list(policy.make_query_plan())
+        self.assertEqual(sorted(qplan), [host])
+
+        self.assertEqual(policy.distance(host), HostDistance.LOCAL)
+
 
 class AddressTranslatorTest(unittest.TestCase):
 


### PR DESCRIPTION
## Motivation

When using cqlsh on a cassandra cluster where each node has the same IP but different ports, running `SELECT * FROM system.peers_v2;` will result in one of the peers being swapped for one of the local nodes.
I tracked this issue down to the `python-driver`s `WhiteListRoundRobinPolicyTest` which is used by cqlsh.

## Reproduction

I can reproduce the issue with this `docker-compose.yaml`, which creates a cluster of nodes accessible on 127.0.0.1 on ports 9042, 9043 and 9044:

```yaml
services:
  cassandra-one:
    image: &image shotover/cassandra-test:5.0-rc1-r3
    environment: &environment
      CASSANDRA_SEEDS: "cassandra-one,cassandra-two,cassandra-three"
      CASSANDRA_CLUSTER_NAME: TestCluster
      CASSANDRA_DC: datacenter1
      CASSANDRA_RACK: rack1
      CASSANDRA_ENDPOINT_SNITCH: GossipingPropertyFileSnitch
      CASSANDRA_INITIAL_TOKENS: -1838347210670429836,-2934389110905368125,-4713023411728955254,-5691168864245069329,-7310192159942112627,-747050099978217576,-8900196712456011265,1537594777415527418,2609095393755560231,3626946798497987246,4444618731110338041,5520374612335917580,6256290305046811221,7335663112494412879,8579183118175004851,97326547512944180
      CASSANDRA_NATIVE_TRANSPORT_PORT: 9042
      CASSANDRA_BROADCAST_RPC_ADDRESS: "127.0.0.1"
      MAX_HEAP_SIZE: "400M"
      MIN_HEAP_SIZE: "400M"
      HEAP_NEWSIZE: "48M"
    ports:
      - "9042:9042"
    volumes:
      &volumes
      - type: tmpfs
        target: /var/lib/cassandra
  cassandra-two:
    image: *image
    ports:
      - "9043:9043"
    environment:
      <<: *environment
      CASSANDRA_NATIVE_TRANSPORT_PORT: 9043
      CASSANDRA_INITIAL_TOKENS: -2006460884048279486,-3596465436562178124,-387437588351236189,-4563829679640713622,-5807349685321305596,-6886722492768907253,-7622638185479800894,-8698394066705380434,2369342164988465014,3465384065223403303,4556681175915615562,5401057823406777320,590707864164877886,6841326053309360558,7912826669649393371,8930678074391820386
    volumes: *volumes
  cassandra-three:
    image: *image
    ports:
      - "9044:9044"
    environment:
      <<: *environment
      CASSANDRA_NATIVE_TRANSPORT_PORT: 9044
      CASSANDRA_INITIAL_TOKENS: -2141366384311565814,-3731370936825464452,-4698735179903999950,-522343088614522517,-5942255185584591924,-7021627993032193581,-7757543685743087222,-8833299566968666762,2234436664725178686,3330478564960116975,4421775675652329234,455802363901591558,5266152323143490992,6706420553046074230,7777921169386107043,8795772574128534058
    volumes: *volumes
```

And this python-driver sample:
```python
import cassandra
from cassandra.cluster import Cluster
from cassandra.policies import WhiteListRoundRobinPolicy

def main():
    hostname = "127.0.0.1"
    port = 9042
    conn = Cluster(contact_points=[hostname], port=port, cql_version=None,
                        auth_provider=None,
                        ssl_options=None,
                        load_balancing_policy=WhiteListRoundRobinPolicy([hostname]))
    
    session = conn.connect()
    session.row_factory = cassandra.query.dict_factory
    for i in range(10):
        print("Attempt #" + str(i))
        for row in session.execute("select * from system.peers_v2"):
            print("peer:", row["native_address"] + ":" + str(row["native_port"]))
        print("")
    
main()
```

You will observe that each attempt prints a different list of peers, which should not be possible.

The problem is that the `WhiteListRoundRobinPolicy` checks only the hostname/address, so if all nodes have the same address but different ports they will all pass the whitelist.

## The fix

The first commit moves the endpoints into their own file, this was needed to avoid a cyclic dependency issue.

Then I altered the `WhiteListRoundRobinPolicy` constructor to allow the user to optionally specify a port along with the hostname.
The change is completely backwards compatible with the existing interface, I had to make the implementation a little complicated to handle the new functionality in a backwards compatible way.

I didnt really understand what the deal is with the `self._allowed_hosts = tuple(hosts)` line, it seems to be used for some sort of serialization thing, so I just left it as is. Let me know if it requires any changes.

## Process

It seems like a jira ticket isnt strictly needed for small changes, let me know if you need a ticket for this PR to be merged. And if so let me know how I should go about getting access, I tried and couldn't figure it out.