### PR TITLE
Documentation cleanup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@
 .. |travis| image:: https://api.travis-ci.com/datastax/python-driver.svg?branch=master
     :target: https://travis-ci.com/github/datastax/python-driver
 
-|license| |version| |pyversion|
-|travis|
+| |license| |version| |pyversion|
+| |travis|
 
 DataStax Driver for Apache Cassandra
 ====================================

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,7 @@
 .. |travis| image:: https://api.travis-ci.com/datastax/python-driver.svg?branch=master
     :target: https://travis-ci.com/github/datastax/python-driver
 
-| |license| |version| |pyversion|
-| |travis|
+|license| |version| |pyversion| |travis|
 
 DataStax Driver for Apache Cassandra
 ====================================

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
 DataStax Driver for Apache Cassandra
 ====================================
 
-.. image:: https://travis-ci.com/datastax/python-driver.png?branch=master
+.. image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
    :target: https://travis-ci.com/github/datastax/python-driver
 
 A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ and highly-tunable Python client library for Apache Cassandra (2.1+) and
@@ -79,9 +79,8 @@ If you would like to contribute, please feel free to open a pull request.
 
 Getting Help
 ------------
-Your best options for getting help with the driver are the
-`mailing list <https://groups.google.com/a/lists.datastax.com/forum/#!forum/python-driver-user>`_
-and the `DataStax Community <https://community.datastax.com>`_.
+Your best options for getting help with the driver is the
+`mailing list <https://groups.google.com/a/lists.datastax.com/forum/#!forum/python-driver-user>`_.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,13 @@ The driver supports Python 3.9 through 3.13.
 
 Features
 --------
-* `Synchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster/index.html#cassandra.cluster.Session.execute>`_ and `Asynchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Session.execute_async>`_ APIs
+* `Synchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster/index.html#cassandra.cluster.Session.execute>`_ and `Asynchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster/index.html#cassandra.cluster.Session.execute_async>`_ APIs
 * `Simple, Prepared, and Batch statements <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/query/index.html#cassandra.query.Statement>`_
 * Asynchronous IO, parallel execution, request pipelining
 * `Connection pooling <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster/index.html#cassandra.cluster.Cluster.get_core_connections_per_host>`_
 * Automatic node discovery
 * `Automatic reconnection <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies/index.html#reconnecting-to-dead-hosts>`_
-* Configurable `load balancing <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies/index.html#load-balancing>`_ and `retry policies <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies.html#retrying-failed-operations>`_
+* Configurable `load balancing <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies/index.html#load-balancing>`_ and `retry policies <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies/index.html#retrying-failed-operations>`_
 * `Concurrent execution utilities <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/concurrent/index.html>`_
 * `Object mapper <https://docs.datastax.com/en/developer/python-driver/latest/object_mapper/>`_
 * `Connecting to DataStax Astra database (cloud) <https://docs.datastax.com/en/developer/python-driver/latest/cloud/>`_
@@ -43,7 +43,7 @@ Installation through pip is recommended::
     $ pip install cassandra-driver
 
 For more complete installation instructions, see the
-`installation guide <https://docs.datastax.com/en/developer/python-driver/latest/installation.html>`_.
+`installation guide <https://docs.datastax.com/en/developer/python-driver/latest/installation/index.html>`_.
 
 Documentation
 -------------
@@ -51,16 +51,16 @@ The documentation can be found online `here <https://docs.datastax.com/en/develo
 
 A couple of links for getting up to speed:
 
-* `Installation <https://docs.datastax.com/en/developer/python-driver/latest/installation.html>`_
-* `Getting started guide <https://docs.datastax.com/en/developer/python-driver/latest/getting_started.html>`_
+* `Installation <https://docs.datastax.com/en/developer/python-driver/latest/installation/index.html>`_
+* `Getting started guide <https://docs.datastax.com/en/developer/python-driver/latest/getting_started/index.html>`_
 * `API docs <https://docs.datastax.com/en/developer/python-driver/latest/api/index.html>`_
-* `Performance tips <https://docs.datastax.com/en/developer/python-driver/latest/performance.html>`_
+* `Performance tips <https://docs.datastax.com/en/developer/python-driver/latest/performance/index.html>`_
 
 Object Mapper
 -------------
 cqlengine (originally developed by Blake Eggleston and Jon Haddad, with contributions from the
 community) is now maintained as an integral part of this package. Refer to
-`documentation here <https://docs.datastax.com/en/developer/python-driver/latest/object_mapper.html>`_.
+`documentation here <https://docs.datastax.com/en/developer/python-driver/latest/object_mapper/index.html>`_.
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 .. |version| image:: https://badge.fury.io/py/cassandra-driver.svg
     :target: https://badge.fury.io/py/cassandra-driver
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/cassandra-driver.svg
-.. |travis| image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
+.. |travis| image:: https://api.travis-ci.com/datastax/python-driver.svg?branch=master
     :target: https://travis-ci.com/github/datastax/python-driver
 
 |license| |version| |pyversion|

--- a/README.rst
+++ b/README.rst
@@ -22,15 +22,15 @@ The driver supports Python 3.9 through 3.13.
 
 Features
 --------
-* `Synchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Session.execute>`_ and `Asynchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Session.execute_async>`_ APIs
-* `Simple, Prepared, and Batch statements <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/query.html#cassandra.query.Statement>`_
+* `Synchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster/index.html#cassandra.cluster.Session.execute>`_ and `Asynchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Session.execute_async>`_ APIs
+* `Simple, Prepared, and Batch statements <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/query/index.html#cassandra.query.Statement>`_
 * Asynchronous IO, parallel execution, request pipelining
-* `Connection pooling <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Cluster.get_core_connections_per_host>`_
+* `Connection pooling <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster/index.html#cassandra.cluster.Cluster.get_core_connections_per_host>`_
 * Automatic node discovery
-* `Automatic reconnection <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies.html#reconnecting-to-dead-hosts>`_
-* Configurable `load balancing <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies.html#load-balancing>`_ and `retry policies <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies.html#retrying-failed-operations>`_
-* `Concurrent execution utilities <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/concurrent.html>`_
-* `Object mapper <https://docs.datastax.com/en/developer/python-driver/latest/object_mapper.html>`_
+* `Automatic reconnection <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies/index.html#reconnecting-to-dead-hosts>`_
+* Configurable `load balancing <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies/index.html#load-balancing>`_ and `retry policies <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies.html#retrying-failed-operations>`_
+* `Concurrent execution utilities <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/concurrent/index.html>`_
+* `Object mapper <https://docs.datastax.com/en/developer/python-driver/latest/object_mapper/>`_
 * `Connecting to DataStax Astra database (cloud) <https://docs.datastax.com/en/developer/python-driver/latest/cloud/>`_
 * DSE Graph execution API
 * DSE Geometric type serialization

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
     :target: https://badge.fury.io/py/cassandra-driver
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/cassandra-driver.svg
 .. |travis| image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
-   :target: https://travis-ci.com/github/datastax/python-driver
+    :target: https://travis-ci.com/github/datastax/python-driver
 
 |license| |version| |pyversion|
 |travis|

--- a/README.rst
+++ b/README.rst
@@ -22,15 +22,15 @@ The driver supports Python 3.9 through 3.13.
 
 Features
 --------
-* `Synchronous <http://datastax.github.io/python-driver/api/cassandra/cluster.html#cassandra.cluster.Session.execute>`_ and `Asynchronous <http://datastax.github.io/python-driver/api/cassandra/cluster.html#cassandra.cluster.Session.execute_async>`_ APIs
-* `Simple, Prepared, and Batch statements <http://datastax.github.io/python-driver/api/cassandra/query.html#cassandra.query.Statement>`_
+* `Synchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Session.execute>`_ and `Asynchronous <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Session.execute_async>`_ APIs
+* `Simple, Prepared, and Batch statements <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/query.html#cassandra.query.Statement>`_
 * Asynchronous IO, parallel execution, request pipelining
-* `Connection pooling <http://datastax.github.io/python-driver/api/cassandra/cluster.html#cassandra.cluster.Cluster.get_core_connections_per_host>`_
+* `Connection pooling <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Cluster.get_core_connections_per_host>`_
 * Automatic node discovery
-* `Automatic reconnection <http://datastax.github.io/python-driver/api/cassandra/policies.html#reconnecting-to-dead-hosts>`_
-* Configurable `load balancing <http://datastax.github.io/python-driver/api/cassandra/policies.html#load-balancing>`_ and `retry policies <http://datastax.github.io/python-driver/api/cassandra/policies.html#retrying-failed-operations>`_
-* `Concurrent execution utilities <http://datastax.github.io/python-driver/api/cassandra/concurrent.html>`_
-* `Object mapper <http://datastax.github.io/python-driver/object_mapper.html>`_
+* `Automatic reconnection <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies.html#reconnecting-to-dead-hosts>`_
+* Configurable `load balancing <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies.html#load-balancing>`_ and `retry policies <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/policies.html#retrying-failed-operations>`_
+* `Concurrent execution utilities <https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/concurrent.html>`_
+* `Object mapper <https://docs.datastax.com/en/developer/python-driver/latest/object_mapper.html>`_
 * `Connecting to DataStax Astra database (cloud) <https://docs.datastax.com/en/developer/python-driver/latest/cloud/>`_
 * DSE Graph execution API
 * DSE Geometric type serialization
@@ -43,24 +43,24 @@ Installation through pip is recommended::
     $ pip install cassandra-driver
 
 For more complete installation instructions, see the
-`installation guide <http://datastax.github.io/python-driver/installation.html>`_.
+`installation guide <https://docs.datastax.com/en/developer/python-driver/latest/installation.html>`_.
 
 Documentation
 -------------
-The documentation can be found online `here <http://datastax.github.io/python-driver/index.html>`_.
+The documentation can be found online `here <https://docs.datastax.com/en/developer/python-driver/latest/index.html>`_.
 
 A couple of links for getting up to speed:
 
-* `Installation <http://datastax.github.io/python-driver/installation.html>`_
-* `Getting started guide <http://datastax.github.io/python-driver/getting_started.html>`_
-* `API docs <http://datastax.github.io/python-driver/api/index.html>`_
-* `Performance tips <http://datastax.github.io/python-driver/performance.html>`_
+* `Installation <https://docs.datastax.com/en/developer/python-driver/latest/installation.html>`_
+* `Getting started guide <https://docs.datastax.com/en/developer/python-driver/latest/getting_started.html>`_
+* `API docs <https://docs.datastax.com/en/developer/python-driver/latest/api/index.html>`_
+* `Performance tips <https://docs.datastax.com/en/developer/python-driver/latest/performance.html>`_
 
 Object Mapper
 -------------
 cqlengine (originally developed by Blake Eggleston and Jon Haddad, with contributions from the
 community) is now maintained as an integral part of this package. Refer to
-`documentation here <http://datastax.github.io/python-driver/object_mapper.html>`_.
+`documentation here <https://docs.datastax.com/en/developer/python-driver/latest/object_mapper.html>`_.
 
 Contributing
 ------------

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
 DataStax Driver for Apache Cassandra
 ====================================
 
-.. |travis-ci| image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
+.. |travis| image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
    :target: https://travis-ci.com/github/datastax/python-driver
 
 A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ and highly-tunable Python client library for Apache Cassandra (2.1+) and

--- a/README.rst
+++ b/README.rst
@@ -4,14 +4,14 @@
 .. |version| image:: https://badge.fury.io/py/cassandra-driver.svg
     :target: https://badge.fury.io/py/cassandra-driver
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/cassandra-driver.svg
+.. |travis| image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
+   :target: https://travis-ci.com/github/datastax/python-driver
 
 |license| |version| |pyversion|
+|travis|
 
 DataStax Driver for Apache Cassandra
 ====================================
-
-.. |travis| image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
-   :target: https://travis-ci.com/github/datastax/python-driver
 
 A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ and highly-tunable Python client library for Apache Cassandra (2.1+) and
 DataStax Enterprise (4.7+) using exclusively Cassandra's binary protocol and Cassandra Query Language v3.

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@
 DataStax Driver for Apache Cassandra
 ====================================
 
-.. image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
+.. |travis-ci| image:: https://travis-ci.com/datastax/python-driver.svg?branch=master
    :target: https://travis-ci.com/github/datastax/python-driver
 
 A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ and highly-tunable Python client library for Apache Cassandra (2.1+) and

--- a/cassandra/cluster.py
+++ b/cassandra/cluster.py
@@ -1700,7 +1700,7 @@ class Cluster(object):
 
         log.warning("Downgrading core protocol version from %d to %d for %s. "
                     "To avoid this, it is best practice to explicitly set Cluster(protocol_version) to the version supported by your cluster. "
-                    "http://datastax.github.io/python-driver/api/cassandra/cluster.html#cassandra.cluster.Cluster.protocol_version", self.protocol_version, new_version, host_endpoint)
+                    "https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html#cassandra.cluster.Cluster.protocol_version", self.protocol_version, new_version, host_endpoint)
         self.protocol_version = new_version
 
     def connect(self, keyspace=None, wait_for_all_pools=False):

--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -29,7 +29,7 @@ except ImportError:
         "The C extension needed to use libev was not found.  This "
         "probably means that you didn't have the required build dependencies "
         "when installing the driver.  See "
-        "http://datastax.github.io/python-driver/installation.html#c-extensions "
+        "https://docs.datastax.com/en/developer/python-driver/latest/installation.html#c-extensions "
         "for instructions on installing build dependencies and building "
         "the C extension.")
 

--- a/cassandra/io/libevreactor.py
+++ b/cassandra/io/libevreactor.py
@@ -29,7 +29,7 @@ except ImportError:
         "The C extension needed to use libev was not found.  This "
         "probably means that you didn't have the required build dependencies "
         "when installing the driver.  See "
-        "https://docs.datastax.com/en/developer/python-driver/latest/installation.html#c-extensions "
+        "https://docs.datastax.com/en/developer/python-driver/latest/installation/index.html#c-extensions "
         "for instructions on installing build dependencies and building "
         "the C extension.")
 

--- a/docs/object_mapper.rst
+++ b/docs/object_mapper.rst
@@ -63,7 +63,7 @@ Getting Started
         description     = columns.Text(required=False)
 
     #next, setup the connection to your cassandra server(s)...
-    # see http://datastax.github.io/python-driver/api/cassandra/cluster.html for options
+    # see https://docs.datastax.com/en/developer/python-driver/latest/api/cassandra/cluster.html for options
     # the list of hosts will be passed to create a Cluster() instance
     connection.setup(['127.0.0.1'], "cqlengine", protocol_version=3)
 


### PR DESCRIPTION
The recent pruning of extraneous branches wound up preventing many of the links in our docs from working due to the removal of datastax.github.io/python-driver.  The goal here is to replace all those URLs with direct references into the DataStax documentation, at least for now.

Also cleaned up a few other things while I was here:

* Removed references to long-gone DataStax Community
* Fixed the Travis badges on the front-end README.rst