### PR TITLE
Replace usage of `with await lock` (`asyncio` reactor broken in Python 3.9+)

### DIFF
--- a/cassandra/io/asyncioreactor.py
+++ b/cassandra/io/asyncioreactor.py
@@ -173,7 +173,7 @@ class AsyncioConnection(Connection):
 
     async def _push_msg(self, chunks):
         # This lock ensures all chunks of a message are sequential in the Queue
-        with await self._write_queue_lock:
+        async with self._write_queue_lock:
             for chunk in chunks:
                 self._write_queue.put_nowait(chunk)
 


### PR DESCRIPTION
Trying to connect to Cassandra using the `asyncio` reactor times out in Python 3.9+.
This is because pushing messages to the queue silently fails due to the usage of the `with await asyncio.Lock` syntax, removed in Python 3.9.

I've replaced it with `async with lock` (as suggested by the [docs](https://docs.python.org/3/library/asyncio-sync.html#:~:text=Use%20async%20with%20lock%20instead)), and now it works.