### PR TITLE
Please don't merge this - but I wanted to let you know the bug tracker seems to be broken

### DIFF
--- a/NONSENSENOTICE
+++ b/NONSENSENOTICE
@@ -1,0 +1,3 @@
+I deeply apologize for this not being a reasonable pull request.
+It seems to be the only easy way to reach the developers,
+see pull request description. Please DO NOT MERGE this.


### PR DESCRIPTION
I deeply apologize for this not being a reasonable pull request. It seems to be the only easy way to reach the developers, see pull request description. Please DO NOT MERGE this.

However, it seems like the bug tracker isn't working correctly, and won't let users report any issues:

<img width="1545" height="845" alt="Screenshot_20260226_215113" src="https://github.com/user-attachments/assets/21f2309c-b599-4e43-b03a-732c03cfcd28" />


It also doesn't seem to be possible to reach the team via `info@datastix.com` to point anything out:

<img width="873" height="787" alt="Screenshot_20260226_215547-1" src="https://github.com/user-attachments/assets/f7d0feef-686c-4152-aa63-7d68686dba66" />


My apologies if all of the above is actually intentional.

The reason I wanted to reach the bug tracker is to point out that setuptools versions that break [due to ez_setup](https://github.com/apache/cassandra-python-driver/commit/7d8015e3c1cff543a5f64c70cff3e14216e58037) seem to be out in the wild. Therefore, I simply wanted suggest that [a new release is made on pip](https://pypi.org/project/cassandra-driver/) so that the package can be installed again.