### PR TITLE
CASSPYTHON-12 Mark eventlet, gevent and Twisted event loops as deprecated

### DIFF
--- a/cassandra/io/eventletreactor.py
+++ b/cassandra/io/eventletreactor.py
@@ -24,6 +24,7 @@ from greenlet import GreenletExit
 import logging
 from threading import Event
 import time
+from deprecated import deprecated
 
 from cassandra.connection import Connection, ConnectionShutdown, Timer, TimerManager
 try:
@@ -45,6 +46,7 @@ def _check_pyopenssl():
         )
 
 
+@deprecated(version="3.30.0", reason="The eventlet event loop is deprecated and will be removed in 3.31.0.  See CASSPYTHON-12.")
 class EventletConnection(Connection):
     """
     An implementation of :class:`.Connection` that utilizes ``eventlet``.

--- a/cassandra/io/geventreactor.py
+++ b/cassandra/io/geventreactor.py
@@ -19,16 +19,15 @@ from gevent.queue import Queue
 from gevent import socket
 import gevent.ssl
 
+from deprecated import deprecated
 import logging
 import time
 
-
 from cassandra.connection import Connection, ConnectionShutdown, Timer, TimerManager
-
 
 log = logging.getLogger(__name__)
 
-
+@deprecated(version="3.30.0", reason="The gevent event loop is deprecated and will be removed in 3.31.0.  See CASSPYTHON-12.")
 class GeventConnection(Connection):
     """
     An implementation of :class:`.Connection` that utilizes ``gevent``.

--- a/cassandra/io/twistedreactor.py
+++ b/cassandra/io/twistedreactor.py
@@ -18,6 +18,7 @@ Module that implements an event loop based on twisted
 ( https://twistedmatrix.com ).
 """
 import atexit
+from deprecated import deprecated
 import logging
 import time
 from functools import partial
@@ -180,7 +181,7 @@ class _SSLCreator(object):
             connection.set_tlsext_host_name(self.ssl_options['server_hostname'].encode('ascii'))
         return connection
 
-
+@deprecated(version="3.30.0", reason="The Twisted event loop is deprecated and will be removed in 3.31.0.  See CASSPYTHON-12.")
 class TwistedConnection(Connection):
     """
     An implementation of :class:`.Connection` that utilizes the

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -217,10 +217,16 @@ dependencies, then use install-option::
 
 Supported Event Loops
 ^^^^^^^^^^^^^^^^^^^^^
-For Python versions before 3.12 the driver uses the ``asyncore`` module for its default
-event loop.  Other event loops such as ``libev``, ``gevent`` and ``eventlet`` are also
-available via Python modules or C extensions.  Python 3.12 has removed ``asyncore`` entirely
-so for this platform one of these other event loops must be used.
+The ``asyncore`` and ``libev`` event loops are proven production-grade event loops.  Python 3.12 removed
+asyncore from the runtime but this event loop can still be used in newer versions of Python via the
+`pyasyncore <https://pypi.org/project/pyasyncore/>`_ package.
+
+The ``asyncio`` event loop is generally functional but still somewhat experimental and not recommended
+for production systems.  We anticipate significant improvements to this event loop (including hopefully
+making this event loop the default going forward) in 3.31.0.
+
+The ``gevent``, ``eventlet`` and ``Twisted`` event loops have been deprecated in 3.30.0 and will be removed
+completely in 3.31.0.
 
 libev support
 ^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["setuptools", "Cython>=3.0", "tomli"]
 name = "cassandra-driver"
 description = "Apache Cassandra Python Driver"
 version = "3.30.0"
-dependencies = ['geomet>=1.1']
+dependencies = ['geomet>=1.1', "Deprecated>=1.3.1"]
 readme = "README.rst"
 authors = [{name = "DataStax"}]
 license = "Apache-2.0"
@@ -19,11 +19,11 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules"


### PR DESCRIPTION
Leverage the [deprecated](https://pypi.org/project/Deprecated/) Python package to handle most of the heavy lifting here.

Local testing confirms that gevent connections still work _and_ that the deprecation warning is printed as expected:

```
2026-03-10 16:28:01,976 [DEBUG] cassandra.cluster: [control connection] Opening new connection to 8c86116c-e592-4e28-886f-e22cb44935d3-us-east-2.db.astra.datastax.com:29042:678e6a1d-e5b1-3cba-b949-7bfaf823957f                             
/home/mersault/work/scratch/python-astra/client.py:33: DeprecationWarning: Call to deprecated class GeventConnection. (The gevent event loop is deprecated and will be removed in 3.31.0.  See CASSPYTHON-12.) -- Deprecated since version 3.3
0.0.                                                                                                                                                                                                                                          
  session = cluster.connect() 
```