### PR TITLE
Release 3.30.0: changelog, version and documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,26 @@
+3.30.0
+======
+March 23, 2026
+
+Features
+--------
+* Introduce pyproject.toml to explicitly declare build dependencies (CASSPYTHON-7)
+* Add Python 3.14 to CI, remove Python 3.9 (CASSPYTHON-4)
+* Mark eventlet, gevent and Twisted event loops as deprecated (CASSPYTHON-12)
+
+Bug Fixes
+---------
+* Do not set timeout to None when calling execute_async in execute_concurrent (PYTHON-1354)
+* No C extension .so files in published binary Python whl packages of 3.29.3 (CASSPYTHON-3)
+* Win32 wheels do not include compiled libev modules (CASSPYTHON-5)
+
+Others
+------
+* Remove obsolete __future__ import absolute_import (PR 1263)
+* Remove ez_setup for compatibility with setuptools v82 (PR 1268)
+* Replace usage of with await lock (PR 1270)
+* Update cassandra.util.Version to better support Cassandra version strings (CASSPYTHON-10)
+
 3.29.3
 ======
 October 20, 2025

--- a/README-dev.rst
+++ b/README-dev.rst
@@ -75,7 +75,7 @@ Running Integration Tests
 -------------------------
 In order to run integration tests, you must specify a version to run using the ``CASSANDRA_VERSION`` or ``DSE_VERSION`` environment variable::
 
-    CASSANDRA_VERSION=2.0.9 pytest tests/integration/standard
+    CASSANDRA_VERSION=4.0.1 pytest tests/integration/standard
 
 Or you can specify a cassandra directory (to test unreleased versions)::
 
@@ -85,7 +85,7 @@ Specifying the usage of an already running Cassandra cluster
 ------------------------------------------------------------
 The test will start the appropriate Cassandra clusters when necessary  but if you don't want this to happen because a Cassandra cluster is already running the flag ``USE_CASS_EXTERNAL`` can be used, for example::
 
-    USE_CASS_EXTERNAL=1 CASSANDRA_VERSION=2.0.9 pytest tests/integration/standard
+    USE_CASS_EXTERNAL=1 CASSANDRA_VERSION=4.0.1 pytest tests/integration/standard
 
 Specify a Protocol Version for Tests
 ------------------------------------
@@ -96,7 +96,7 @@ it with the ``PROTOCOL_VERSION`` environment variable::
 
 Testing Multiple Python Versions
 --------------------------------
-Use tox to test all of Python 3.9 through 3.13 and pypy::
+Use tox to test all of Python 3.10 through 3.14 and pypy::
 
     tox
 
@@ -106,7 +106,7 @@ Running the Benchmarks
 ======================
 There needs to be a version of cassandra running locally so before running the benchmarks, if ccm is installed:
 	
-	ccm create benchmark_cluster -v 3.0.1 -n 1 -s
+	ccm create benchmark_cluster -v 4.0.1 -n 1 -s
 
 To run the benchmarks, pick one of the files under the ``benchmarks/`` dir and run it::
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Apache Cassandra Python Driver
 A modern, `feature-rich <https://github.com/datastax/python-driver#features>`_ and highly-tunable Python client library for Apache Cassandra (2.1+) and
 DataStax Enterprise (4.7+) using exclusively Cassandra's binary protocol and Cassandra Query Language v3.
 
-The driver supports Python 3.9 through 3.13.
+The driver supports Python 3.10 through 3.14.
 
 **Note:** DataStax products do not support big-endian systems.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ A Python client driver for `Apache Cassandra® <http://cassandra.apache.org>`_.
 This driver works exclusively with the Cassandra Query Language v3 (CQL3)
 and Cassandra's native protocol.  Cassandra 2.1+ is supported, including DSE 4.7+.
 
-The driver supports Python 3.9 through 3.13.
+The driver supports Python 3.10 through 3.14.
 
 This driver is open source under the
 `Apache v2 License <http://www.apache.org/licenses/LICENSE-2.0.html>`_.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@ Installation
 
 Supported Platforms
 -------------------
-Python 3.9 through 3.13 are supported.  Both CPython (the standard Python
+Python 3.10 through 3.14 are supported.  Both CPython (the standard Python
 implementation) and `PyPy <http://pypy.org>`_ are supported and tested.
 
 Linux, OSX, and Windows are supported.
@@ -26,7 +26,7 @@ To check if the installation was successful, you can run::
 
     python -c 'import cassandra; print(cassandra.__version__)'
 
-It should print something like "3.29.3".
+This command should print something like ``3.30.0``.
 
 .. _installation-datastax-graph:
 
@@ -62,8 +62,8 @@ just run ``apt-get install python-snappy``.)
 (*Optional*) Metrics Support
 ----------------------------
 The driver has built-in support for capturing :attr:`.Cluster.metrics` about
-the queries you run.  However, the ``scales`` library is required to
-support this::
+the queries you run.  Note that the ``scales`` module is required to
+support metrics.  This module is available from Pypi and can be installed with::
 
     pip install scales
 
@@ -91,7 +91,6 @@ details at `PYTHON-1351 <https://datastax-oss.atlassian.net/browse/PYTHON-1351>`
 
 Speeding Up Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^
-
 By default, installing the driver through ``pip`` uses a pre-compiled, platform-specific wheel when available.
 If using a source distribution rather than a wheel, Cython is used to compile certain parts of the driver.
 This makes those hot paths faster at runtime, but the Cython compilation
@@ -99,15 +98,12 @@ process can take a long time -- as long as 10 minutes in some environments.
 
 In environments where performance is less important, it may be worth it to
 :ref:`disable Cython as documented below <cython-extensions>`.
-You can also use ``CASS_DRIVER_BUILD_CONCURRENCY`` to increase the number of
-threads used to build the driver and any C extensions:
 
-.. code-block:: bash
-
-    $ # installing from source
-    $ CASS_DRIVER_BUILD_CONCURRENCY=8 python setup.py install
-    $ # installing from pip
-    $ CASS_DRIVER_BUILD_CONCURRENCY=8 pip install cassandra-driver
+Cython also supports concurrent builds of native extensions.  The ``build-concurrency`` key in the
+``tool.cassandra-driver`` table of pyproject.toml is an integer value which specifies the number of
+concurrent builds Cython may execute.  The value for this key must be a non-negative integer; the default is zero,
+indicating no concurrent builds.  Note that Cython's concurrent builds use the standard ``multiprocessing`` package
+so this library must be availble is concurrent builds are used.
 
 OSX Installation Error
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -147,8 +143,7 @@ installed. You can find the list of dependencies in
 
 Once the dependencies are installed, simply run::
 
-    python setup.py install
-
+    pip install .
 
 (*Optional*) Non-python Dependencies
 ------------------------------------
@@ -161,9 +156,10 @@ for token-aware routing with the ``Murmur3Partitioner``,
 `libev <http://software.schmorp.de/pkg/libev.html>`_ event loop integration,
 and Cython optimized extensions.
 
-When installing manually through setup.py, you can disable both with
-the ``--no-extensions`` option, or selectively disable them with
-with ``--no-murmur3``, ``--no-libev``, or ``--no-cython``.
+Some or all of these native extensions can be disabled by changing the corresponding
+key in the ``tool.cassandra-driver`` table of pyproject.toml to ``false``.  Please consult
+the ``build-murmur3-extension``, ``build-libev-extension`` and ``build-cython-extensions``
+keys (respectively) to disable these extensions.
 
 To compile the extensions, ensure that GCC and the Python headers are available.
 
@@ -184,36 +180,12 @@ See :ref:`windows_build` for notes on configuring the build environment on Windo
 Cython-based Extensions
 ~~~~~~~~~~~~~~~~~~~~~~~
 By default, this package uses `Cython <http://cython.org/>`_ to optimize core modules and build custom extensions.
-This is not a hard requirement, but is engaged by default to build extensions offering better performance than the
+This is not a hard requirement, but is enabled by default to build extensions offering better performance than the
 pure Python implementation.
 
-This is a costly build phase, especially in clean environments where the Cython compiler must be built
-This build phase can be avoided using the build switch, or an environment variable::
-
-    python setup.py install --no-cython
-
-Alternatively, an environment variable can be used to switch this option regardless of
-context::
-
-    CASS_DRIVER_NO_CYTHON=1 <your script here>
-    - or, to disable all extensions:
-    CASS_DRIVER_NO_EXTENSIONS=1 <your script here>
-
-This method is required when using pip, which provides no other way of injecting user options in a single command::
-
-    CASS_DRIVER_NO_CYTHON=1 pip install cassandra-driver
-    CASS_DRIVER_NO_CYTHON=1 sudo -E pip install ~/python-driver
-
-The environment variable is the preferred option because it spans all invocations of setup.py, and will
-prevent Cython from being materialized as a setup requirement.
-
-If your sudo configuration does not allow SETENV, you must push the option flag down via pip. However, pip
-applies these options to all dependencies (which break on the custom flag). Therefore, you must first install
-dependencies, then use install-option::
-
-    sudo pip install futures
-    sudo pip install --install-option="--no-cython"
-
+This process does take some time, however, so if you wish to build without generating these extensions using
+Cython you can do so by changing the ``build-cython-extensions`` key in the ``tool.cassandra-driver`` table of pyproject.toml.
+By default this key is set to ``true``; simply changing it to ``false`` will disable all Cython functionality.
 
 Supported Event Loops
 ^^^^^^^^^^^^^^^^^^^^^
@@ -250,7 +222,7 @@ install libev using any Windows package manager.  For example, to install using 
     $ vcpkg install libev
 
 If successful, you should be able to build and install the extension
-(just using ``setup.py build`` or ``setup.py install``) and then use
+(just using ``pip install`` or ``pip install -e``) and then use
 the libev event loop by doing the following:
 
 .. code-block:: python

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,310,311,312,313},pypy
+envlist = py{310,311,312,313,314},pypy
 
 [base]
 deps = pytest


### PR DESCRIPTION
Changelog entries plus a few changes related to things from this release.  We don't have cassandra.__version__ anymore so I tweaked that to use supported protocol versions instead.

Also yanked all the env var stuff we used to support in setup.py... that's all in pyproject.toml now.