### PR TITLE
Limit md5 import to allow for compatibility with fips environments

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -19,7 +19,6 @@ from bisect import bisect_left
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import total_ordering
-import hashlib
 import json
 import logging
 import re
@@ -27,6 +26,12 @@ import sys
 from threading import RLock
 import struct
 import random
+
+md5 = None
+try:
+    from hashlib import md5
+except ImportError as e:
+    pass
 
 murmur3 = None
 try:
@@ -1827,6 +1832,8 @@ MAX_LONG = (2 ** 63) - 1
 class NoMurmur3(Exception):
     pass
 
+class NoMD5(Exception):
+    pass
 
 class HashToken(Token):
 
@@ -1862,9 +1869,11 @@ class MD5Token(HashToken):
 
     @classmethod
     def hash_fn(cls, key):
+        if md5 is None:
+            raise NoMD5()
         if isinstance(key, str):
             key = key.encode('UTF-8')
-        return abs(varint_unpack(hashlib.md5(key, usedforsecurity=False).digest()))
+        return abs(varint_unpack(md5(key).digest()))
 
 
 class BytesToken(Token):

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -19,7 +19,7 @@ from bisect import bisect_left
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import total_ordering
-from hashlib import md5
+import hashlib
 import json
 import logging
 import re
@@ -1864,7 +1864,7 @@ class MD5Token(HashToken):
     def hash_fn(cls, key):
         if isinstance(key, str):
             key = key.encode('UTF-8')
-        return abs(varint_unpack(md5(key).digest()))
+        return abs(varint_unpack(hashlib.md5(key,usedforsecurity=False).digest()))
 
 
 class BytesToken(Token):

--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1864,7 +1864,7 @@ class MD5Token(HashToken):
     def hash_fn(cls, key):
         if isinstance(key, str):
             key = key.encode('UTF-8')
-        return abs(varint_unpack(hashlib.md5(key,usedforsecurity=False).digest()))
+        return abs(varint_unpack(hashlib.md5(key, usedforsecurity=False).digest()))
 
 
 class BytesToken(Token):


### PR DESCRIPTION
In a FIPS-140 environment, the cassandra-python-driver may error as md5 is not compiled into the hashlib module.

```ModuleNotFoundError: No module named 'md5'```

As md5 is not available, the MD5Token class may not be used but the overall module is still usable.