### PR TITLE
Add MD5 usedforsecurity=false

### DIFF
--- a/cassandra/metadata.py
+++ b/cassandra/metadata.py
@@ -1864,7 +1864,7 @@ class MD5Token(HashToken):
     def hash_fn(cls, key):
         if isinstance(key, str):
             key = key.encode('UTF-8')
-        return abs(varint_unpack(md5(key).digest()))
+        return abs(varint_unpack(md5(key,usedforsecurity=False).digest()))
 
 
 class BytesToken(Token):


### PR DESCRIPTION
Adopting usedforsecurity=False is good practice for modern Python. Since this was introduced in Python 3.9, it serves as explicit documentation that our use of MD5 isn't for cryptographic security. This is particularly helpful for users running automated compliance scanners; it allows those tools to recognize the usage as a non-issue rather than flagging it as a vulnerability.

Note: this issue was originally raised in #1288.  Hat tip to @lratc for raising the issue and contributing to the conversation there!
